### PR TITLE
Add labels to enable pooling of resources

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -8,8 +8,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources;
 
-import java.util.List;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -8,6 +8,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources;
 
+import java.util.List;
+
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -16,6 +18,7 @@ import hudson.model.Descriptor;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
+import java.util.Arrays;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -26,6 +29,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 
 	private final String name;
 	private final String description;
+	private final String labels;
 	private String reservedBy;
 
 	private transient int queueItemId = NOT_QUEUED;
@@ -34,9 +38,11 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	private transient long queuingStarted = 0;
 
 	@DataBoundConstructor
-	public LockableResource(String name, String description, String reservedBy) {
+	public LockableResource(
+			String name, String description, String labels, String reservedBy) {
 		this.name = name;
 		this.description = description;
+		this.labels = labels;
 		this.reservedBy = Util.fixEmptyAndTrim(reservedBy);
 	}
 
@@ -48,6 +54,10 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 		return description;
 	}
 
+	public String getLabels() {
+		return labels;
+	}
+	
 	public String getReservedBy() {
 		return reservedBy;
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -57,6 +57,10 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	public String getLabels() {
 		return labels;
 	}
+
+	public Boolean isValidLabel(String candidate) {
+		return Arrays.asList(labels.split("\\s+")).contains(candidate);
+	}
 	
 	public String getReservedBy() {
 		return reservedBy;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -11,7 +11,10 @@ package org.jenkins.plugins.lockableresources;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import jenkins.model.GlobalConfiguration;
@@ -59,6 +62,20 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			}
 		}
 		return matching;
+	}
+	
+	public Boolean isValidLabel(String label)
+	{
+		return this.getAllLabels().contains(label);
+	}
+
+	public Set<String> getAllLabels()
+	{
+		Set<String> labels = new HashSet<String>();
+		for (LockableResource r : this.resources) {
+			labels.addAll(Arrays.asList(r.getLabels().split("\\s+")));
+		}
+		return labels;
 	}
 
 	public int getDefaultPriority() {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -163,12 +163,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		// if did not get wanted amount or did not get all
-		if ((selected.size() != number) || 
-			(number == 0 && selected.size() != candidates.size())) {
-			
+		int required_amount = (number == 0) ? candidates.size() : number;
+
+		if (selected.size() != required_amount) {
 			log.log(Level.FINEST, "{0} found {1} resource(s) to queue." +
-			    "Waiting for correct amount.",
-			    new Object[]{queueItemProject, selected.size()});
+			    "Waiting for correct amount: {2}.",
+			    new Object[]{queueItemProject, selected.size(), required_amount});
 			// just to be sure, clean up
 			for (LockableResource x : resources) {
 				if (x.getQueueItemProject() != null

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -61,7 +61,6 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 		return labelName;
 	}
 
-
 	public String getResourceNamesVar() {
 		return resourceNamesVar;
 	}
@@ -159,8 +158,13 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 		}
 
 		public FormValidation doCheckResourceNumber(@QueryParameter String value,
-			@QueryParameter String resourceNames) {
+			@QueryParameter String resourceNames,
+			@QueryParameter String labelName) {
+			
 			String number = Util.fixEmptyAndTrim(value);
+			String names = Util.fixEmptyAndTrim(resourceNames);
+			String label = Util.fixEmptyAndTrim(labelName);
+			
 			if (number == null || number.equals("") || number.trim().equals("0")) {
 				return FormValidation.ok();
 			}
@@ -172,11 +176,17 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 				return FormValidation.error(
 					"Could not parse the given value as integer.");
 			}
-			int numResources = resourceNames.split("\\s+").length;
+			int numResources = 0;
+			if (names != null) {
+				numResources = names.split("\\s+").length;
+			} else if (label != null) {
+				numResources = LockableResourcesManager.get().
+					getResourcesWithLabel(label).size();
+			}
 
 			if (numResources < numAsInt) {
 				return FormValidation.error(String.format(
-					"Given amount %d in greater than amount of resources: %d.",
+					"Given amount %d is greater than amount of resources: %d.",
 					numAsInt,
 					numResources));
 			}

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -56,6 +56,11 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 	public String getResourceNames() {
 		return resourceNames;
 	}
+	
+	public String getLabelName() {
+		return labelName;
+	}
+
 
 	public String getResourceNamesVar() {
 		return resourceNamesVar;
@@ -97,7 +102,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			String labelName = Util.fixEmptyAndTrim(json
 					.getString("labelName"));
 
-			if (resourceNames == null) {
+			if (resourceNames == null && labelName == null) {
 				return null;
 			}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -28,16 +28,21 @@ import org.kohsuke.stapler.StaplerRequest;
 public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
 	private final String resourceNames;
+	private final String labelName;
 	private final String resourceNamesVar;
 	private final String resourceNumber;
 
 	@DataBoundConstructor
-	public RequiredResourcesProperty(String resourceNames,
-			String resourceNamesVar, String resourceNumber) {
+	public RequiredResourcesProperty(
+			String resourceNames,
+			String resourceNamesVar,
+			String resourceNumber,
+			String labelName) {
 		super();
 		this.resourceNames = resourceNames;
 		this.resourceNamesVar = resourceNamesVar;
 		this.resourceNumber = resourceNumber;
+		this.labelName = labelName;
 	}
 
 	public String[] getResources() {
@@ -89,11 +94,15 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			String resourceNumber = Util.fixEmptyAndTrim(json
 					.getString("resourceNumber"));
 
-			if (resourceNames == null)
+			String labelName = Util.fixEmptyAndTrim(json
+					.getString("labelName"));
+
+			if (resourceNames == null) {
 				return null;
+			}
 
 			return new RequiredResourcesProperty(resourceNames,
-					resourceNamesVar, resourceNumber);
+					resourceNamesVar, resourceNumber, labelName);
 		}
 
 		public FormValidation doCheckResourceNames(@QueryParameter String value) {
@@ -124,6 +133,26 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			}
 		}
 
+		public FormValidation doCheckLabelName(
+				@QueryParameter String value,
+				@QueryParameter String resourceNames) {
+			String label = Util.fixEmptyAndTrim(value);
+			String names = Util.fixEmptyAndTrim(resourceNames);
+			if (label == null) {
+				return FormValidation.ok();
+			} else if (names != null) {
+					return FormValidation.error(
+							"Only label or resources can be defined, not both.");				
+			} else {
+				if (LockableResourcesManager.get().isValidLabel(label)) {
+					return FormValidation.ok();
+				} else {
+					return FormValidation.error(
+							"The label does not exist: " + label);
+				}
+			}
+		}
+
 		public FormValidation doCheckResourceNumber(@QueryParameter String value,
 			@QueryParameter String resourceNames) {
 			String number = Util.fixEmptyAndTrim(value);
@@ -147,6 +176,22 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 					numResources));
 			}
 			return FormValidation.ok();
+		}
+
+		public AutoCompletionCandidates doAutoCompleteLabelName(
+			@QueryParameter String value) {
+			AutoCompletionCandidates c = new AutoCompletionCandidates();
+
+			value = Util.fixEmptyAndTrim(value);
+
+			if (value != null) {
+				for (String l : LockableResourcesManager.get().getAllLabels()) {
+					if (l.startsWith(value)) {
+						c.add(l);
+					}
+				}
+			}
+			return c;
 		}
 
 		public AutoCompletionCandidates doAutoCompleteResourceNames(

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -83,6 +83,9 @@ public class LockableResourcesRootAction implements RootAction {
 		return LockableResourcesManager.get().getAllLabels();
 	}
 	
+	public int getNumberOfAllLabels() {
+		return LockableResourcesManager.get().getAllLabels().size();
+	}
 	
 	public void doUnlock(StaplerRequest req, StaplerResponse rsp)
 			throws IOException, ServletException {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -19,6 +19,7 @@ import hudson.security.PermissionScope;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 
@@ -74,6 +75,15 @@ public class LockableResourcesRootAction implements RootAction {
 		return LockableResourcesManager.get().getResources();
 	}
 
+	public int getFreeResourceAmount(String label) {
+		return LockableResourcesManager.get().getFreeResourceAmount(label);
+	}
+	
+	public Set<String> getAllLabels() {
+		return LockableResourcesManager.get().getAllLabels();
+	}
+	
+	
 	public void doUnlock(StaplerRequest req, StaplerResponse rsp)
 			throws IOException, ServletException {
 		Jenkins.getInstance().checkPermission(UNLOCK);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -39,7 +39,7 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 		if (proj != null) {
 			LockableResourcesStruct resources = Utils.requiredResources(proj);
 			if (resources != null) {
-				if (resources.requiredNumber != null) {
+				if (resources.requiredNumber != null || !resources.label.isEmpty()) {
 					required = LockableResourcesManager.get().
 						getResourcesFromProject(proj.getFullName());
 				} else {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -17,6 +17,7 @@ import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 public class LockableResourcesStruct {
 
 	public List<LockableResource> required;
+	public String label;
 	public String requiredVar;
 	public String requiredNumber;
 
@@ -29,14 +30,27 @@ public class LockableResourcesStruct {
 				this.required.add(r);
 			}
 		}
+		
+		this.label = property.getLabelName();
+		if (this.label == null)
+			this.label = "";
+		
 		this.requiredVar = property.getResourceNamesVar();
 		if (this.requiredVar != null && this.requiredVar.equals("")) {
 			this.requiredVar = null;
 		}
+		
 		this.requiredNumber = property.getResourceNumber();
 		if (this.requiredNumber != null && (this.requiredNumber.equals("") ||
 			this.requiredNumber.trim().equals("0"))) {
 			this.requiredNumber = null;
 		}
+	}
+	
+	public String toString() {
+		return "Required resources: " + this.required +
+			", Required label: " + this.label +
+			", Variable name: " + this.requiredVar +
+			", Number of resources: " + this.requiredNumber;
 	}
 }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -16,6 +16,9 @@
 	<f:entry title="${%Description}" field="description">
 		<f:textbox/>
 	</f:entry>
+	<f:entry title="${%Labels}" field="labels">
+		<f:textbox/>
+	</f:entry>
 	<f:entry title="${%Reserved by}" field="reservedBy">
 		<f:textbox/>
 	</f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
@@ -23,7 +23,7 @@
 			<f:entry title="${%Reserved resources variable name}" field="resourceNamesVar">
 				<f:textbox/>
 			</f:entry>
-			<f:entry title="${%Number of the listed resources to request}" field="resourceNumber">
+			<f:entry title="${%Number of resources to request}" field="resourceNumber">
 				<f:textbox/>
 			</f:entry>
 		</f:nested>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
@@ -17,6 +17,9 @@
 			<f:entry title="${%Resources}" field="resourceNames">
 				<f:textbox autoCompleteDelimChar=" "/>
 			</f:entry>
+			<f:entry title="${%Label}" field="labelName">
+				<f:textbox autoCompleteDelimChar=" "/>
+			</f:entry>
 			<f:entry title="${%Reserved resources variable name}" field="resourceNamesVar">
 				<f:textbox/>
 			</f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
@@ -1,0 +1,7 @@
+<div>
+<p>
+If you have created a pool of resources, i.e. a label, you can take it into use
+here. The build will select the resource(s) from the pool that includes all
+resources sharing the given label.
+</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
@@ -3,5 +3,6 @@
 If you have created a pool of resources, i.e. a label, you can take it into use
 here. The build will select the resource(s) from the pool that includes all
 resources sharing the given label.
+Either Label or Resources field must be empty.
 </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -105,33 +105,34 @@ function reset_resource_${i}() {
 <br></br>
 <br></br>
 
-<table class="pane" style="width: 50%;">
-	<tbody>
-		<tr>
-			<td class="pane-header">Label</td>
-			<td class="pane-header">Free resources</td>
-		</tr>
-		<j:forEach var="label" items="${it.getAllLabels()}">
+<j:if test="${it.getNumberOfAllLabels() != 0}">
+	<table class="pane" style="width: 50%;">
+		<tbody>
 			<tr>
-				<j:choose>
-					<j:when test="${it.getFreeResourceAmount(label) == 0}">
-						<td class="pane" style="color: red;">${label}</td>
-						<td class="pane" style="color: red;">0</td>
-					</j:when>
-					<j:when test="${it.getFreeResourceAmount(label) == 1}">
-						<td class="pane" style="color: darkorange;">${label}</td>
-						<td class="pane" style="color: darkorange;">1</td>
-					</j:when>
-					<j:otherwise>
-						<td class="pane" style="color: green;">${label}</td>
-						<td class="pane" style="color: green;">${it.getFreeResourceAmount(label)}</td>
-					</j:otherwise>
-				</j:choose>
+				<td class="pane-header">Label</td>
+				<td class="pane-header">Free resources</td>
 			</tr>
-		</j:forEach>
-	</tbody>
-</table>
-
+			<j:forEach var="label" items="${it.getAllLabels()}">
+				<tr>
+					<j:choose>
+						<j:when test="${it.getFreeResourceAmount(label) == 0}">
+							<td class="pane" style="color: red;">${label}</td>
+							<td class="pane" style="color: red;">0</td>
+						</j:when>
+						<j:when test="${it.getFreeResourceAmount(label) == 1}">
+							<td class="pane" style="color: darkorange;">${label}</td>
+							<td class="pane" style="color: darkorange;">1</td>
+						</j:when>
+						<j:otherwise>
+							<td class="pane" style="color: green;">${label}</td>
+							<td class="pane" style="color: green;">${it.getFreeResourceAmount(label)}</td>
+						</j:otherwise>
+					</j:choose>
+				</tr>
+			</j:forEach>
+		</tbody>
+	</table>
+</j:if>
 
 		</l:main-panel>
 	</l:layout>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -21,6 +21,7 @@
 					<tr>
 						<td class="pane-header">Resource</td>
 						<td class="pane-header">Status</td>
+						<td class="pane-header">Labels</td>
 						<td class="pane-header">Action</td>
 					</tr>
 <j:forEach var="resource" items="${it.resources}" indexVar="i">
@@ -50,10 +51,11 @@ function reset_resource_${i}() {
 								${resource.build.fullDisplayName}
 							</a>
 						</td>
+						<td class="pane">${resource.labels}</td>
 						<td class="pane">
-<j:if test="${h.hasPermission(it.UNLOCK)}">
-							<button onClick="unlock_resource_${i}();">Unlock</button>
-</j:if>
+	<j:if test="${h.hasPermission(it.UNLOCK)}">
+						<button onClick="unlock_resource_${i}();">Unlock</button>
+	</j:if>
 						</td>
 </j:if>
 <j:if test="${!resource.locked}">
@@ -61,6 +63,7 @@ function reset_resource_${i}() {
 						<td class="pane" style="color: red;">
 							<strong>RESERVED</strong> by <strong>${resource.reservedBy}</strong>
 						</td>
+						<td class="pane">${resource.labels}</td>
 						<td class="pane">
 		<j:if test="${h.hasPermission(it.RESERVE)}">
 			<j:if test="${it.UserName == resource.reservedBy or h.hasPermission(app.ADMINISTER)}">
@@ -71,31 +74,65 @@ function reset_resource_${i}() {
 	</j:if>
 	<j:if test="${resource.reservedBy == null}">
 		<j:if test="${resource.queued}">
-						<td class="pane" style="color: yellow;">
-							QUEUED by "${resource.queueItemProject} ${resource.queueItemId}"
-						</td>
-						<td class="pane">
-			<j:if test="${h.hasPermission(it.UNLOCK)}">
-							<button onClick="reset_resource_${i}();">ResetResource</button>
-			</j:if>
-						</td>
+			<td class="pane" style="color: yellow;">
+				QUEUED by "${resource.queueItemProject} ${resource.queueItemId}"
+			</td>
+			<td class="pane">${resource.labels}</td>
+			<td class="pane">
+				<j:if test="${h.hasPermission(it.UNLOCK)}">
+					<button onClick="reset_resource_${i}();">ResetResource</button>
+				</j:if>
+			</td>
 		</j:if>
 		<j:if test="${!resource.queued}">
-						<td class="pane" style="color: green;">
-							<strong>FREE</strong>
-						</td>
-						<td class="pane">
-			<j:if test="${h.hasPermission(it.RESERVE) and it.UserName != null}">
-								<button onClick="reserve_resource_${i}();">Reserve</button>
-			</j:if>
-						</td>
+			<td class="pane" style="color: green;">
+				<strong>FREE</strong>
+			</td>
+			<td class="pane">${resource.labels}</td>
+			<td class="pane">
+				<j:if test="${h.hasPermission(it.RESERVE) and it.UserName != null}">
+					<button onClick="reserve_resource_${i}();">Reserve</button>
+				</j:if>
+			</td>
 		</j:if>
 	</j:if>
 </j:if>
-					</tr>
+</tr>
 </j:forEach>
-				</tbody>
-			</table>
+</tbody>
+</table>
+
+<br></br>
+<br></br>
+
+<table class="pane" style="width: 50%;">
+	<tbody>
+		<tr>
+			<td class="pane-header">Label</td>
+			<td class="pane-header">Free resources</td>
+		</tr>
+		<j:forEach var="label" items="${it.getAllLabels()}">
+			<tr>
+				<j:choose>
+					<j:when test="${it.getFreeResourceAmount(label) == 0}">
+						<td class="pane" style="color: red;">${label}</td>
+						<td class="pane" style="color: red;">0</td>
+					</j:when>
+					<j:when test="${it.getFreeResourceAmount(label) == 1}">
+						<td class="pane" style="color: darkorange;">${label}</td>
+						<td class="pane" style="color: darkorange;">1</td>
+					</j:when>
+					<j:otherwise>
+						<td class="pane" style="color: green;">${label}</td>
+						<td class="pane" style="color: green;">${it.getFreeResourceAmount(label)}</td>
+					</j:otherwise>
+				</j:choose>
+			</tr>
+		</j:forEach>
+	</tbody>
+</table>
+
+
 		</l:main-panel>
 	</l:layout>
 </j:jelly>

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
@@ -1,0 +1,301 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Aki Asikainen.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins.plugins.lockableresources;
+
+
+import hudson.model.AbstractBuild;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author aki
+ */
+public class LockableResourceTest {
+	
+	LockableResource instance;
+	
+	public LockableResourceTest() {
+	}
+	
+	@BeforeClass
+	public static void setUpClass() {
+	}
+	
+	@AfterClass
+	public static void tearDownClass() {
+	}
+	
+	@Before
+	public void setUp() {
+		this.instance = new LockableResource("r1", "d1", "l1 l2", "");
+	}
+	
+	@After
+	public void tearDown() {
+	}
+
+	/**
+	 * Test of getName method, of class LockableResource.
+	 */
+	@Test
+	public void testGetName() {
+		System.out.println("getName");
+		
+		String expResult = "r1";
+		String result = instance.getName();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of getDescription method, of class LockableResource.
+	 */
+	@Test
+	public void testGetDescription() {
+		System.out.println("getDescription");
+		String expResult = "d1";
+		String result = instance.getDescription();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of getLabels method, of class LockableResource.
+	 */
+	 
+	@Test
+	public void testGetLabels() {
+		System.out.println("getLabels");
+		String expResult = "l1 l2";
+		String result = instance.getLabels();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of getReservedBy method, of class LockableResource.
+	 */
+	@Test
+	public void testGetReservedBy() {
+		System.out.println("getReservedBy");
+		String expResult = null;
+		String result = instance.getReservedBy();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of isReserved method, of class LockableResource.
+	 */
+	@Test
+	public void testIsReserved() {
+		System.out.println("isReserved");
+		boolean expResult = false;
+		boolean result = instance.isReserved();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of isQueued method, of class LockableResource.
+	 */
+	@Test
+	public void testIsQueued_0args() {
+		System.out.println("isQueued");
+		boolean expResult = false;
+		boolean result = instance.isQueued();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of isQueued method, of class LockableResource.
+	 */
+	@Test
+	public void testIsQueued_int() {
+		System.out.println("isQueued");
+		int taskId = 0;
+		boolean expResult = false;
+		boolean result = instance.isQueued(taskId);
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of isQueuedByTask method, of class LockableResource.
+	 */
+	@Test
+	public void testIsQueuedByTask() {
+		System.out.println("isQueuedByTask");
+		int taskId = 1;
+		boolean expResult = false;
+		boolean result = instance.isQueuedByTask(taskId);
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of unqueue method, of class LockableResource.
+	 */
+	@Test
+	public void testUnqueue() {
+		System.out.println("unqueue");
+		instance.unqueue();
+	}
+
+	/**
+	 * Test of isLocked method, of class LockableResource.
+	 */
+	@Test
+	public void testIsLocked() {
+		System.out.println("isLocked");
+		boolean expResult = false;
+		boolean result = instance.isLocked();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of getBuild method, of class LockableResource.
+	 */
+	@Test
+	public void testGetBuild() {
+		System.out.println("getBuild");
+		AbstractBuild expResult = null;
+		AbstractBuild result = instance.getBuild();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of setBuild method, of class LockableResource.
+	 */
+	@Test
+	public void testSetBuild() {
+		System.out.println("setBuild");
+		AbstractBuild lockedBy = null;
+		instance.setBuild(lockedBy)	;
+	}
+
+	/**
+	 * Test of getQueueItemId method, of class LockableResource.
+	 */
+	@Test
+	public void testGetQueueItemId() {
+		System.out.println("getQueueItemId");
+		int expResult = 0;
+		int result = instance.getQueueItemId();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of setQueueItemId method, of class LockableResource.
+	 */
+	@Test
+	public void testSetQueueItemId() {
+		System.out.println("setQueueItemId");
+		int queueItemId = 0;
+		instance.setQueueItemId(queueItemId);
+	}
+
+	/**
+	 * Test of getQueueItemProject method, of class LockableResource.
+	 */
+	@Test
+	public void testGetQueueItemProject() {
+		System.out.println("getQueueItemProject");
+		String expResult = null;
+		String result = instance.getQueueItemProject();
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of setQueueItemProject method, of class LockableResource.
+	 */
+	@Test
+	public void testSetQueueItemProject() {
+		System.out.println("setQueueItemProject");
+		String queueItemProject = "";
+		instance.setQueueItemProject(queueItemProject);
+	}
+
+	/**
+	 * Test of setReservedBy method, of class LockableResource.
+	 */
+	@Test
+	public void testSetReservedBy() {
+		System.out.println("setReservedBy");
+		String userName = "";
+		instance.setReservedBy(userName);
+	}
+
+	/**
+	 * Test of unReserve method, of class LockableResource.
+	 */
+	@Test
+	public void testUnReserve() {
+		System.out.println("unReserve");
+		instance.unReserve();
+	}
+
+	/**
+	 * Test of reset method, of class LockableResource.
+	 */
+	@Test
+	public void testReset() {
+		System.out.println("reset");
+		instance.reset();
+	}
+
+	/**
+	 * Test of toString method, of class LockableResource.
+	 */
+	@Test
+	public void testToString() {
+		System.out.println("toString");
+		String expResult = "r1";
+		String result = instance.toString();
+		assertEquals(expResult, result);
+	}
+
+
+	/**
+	 * Test of equals method, of class LockableResource.
+	 */
+	@Test
+	public void testEquals() {
+		System.out.println("equals");
+		Object obj = null;
+		boolean expResult = false;
+		boolean result = instance.equals(obj);
+		assertEquals(expResult, result);
+	}
+
+	/**
+	 * Test of hashCode method, of class LockableResource.
+	 */
+	@Test
+	public void testHashCode() {
+		System.out.println("hashCode");
+		int expResult = 0;
+		int result = instance.hashCode();
+	}
+	
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
@@ -206,16 +206,6 @@ public class LockableResourceTest {
 	}
 
 	/**
-	 * Test of setQueueItemId method, of class LockableResource.
-	 */
-	@Test
-	public void testSetQueueItemId() {
-		System.out.println("setQueueItemId");
-		int queueItemId = 0;
-		instance.setQueueItemId(queueItemId);
-	}
-
-	/**
 	 * Test of getQueueItemProject method, of class LockableResource.
 	 */
 	@Test
@@ -224,16 +214,6 @@ public class LockableResourceTest {
 		String expResult = null;
 		String result = instance.getQueueItemProject();
 		assertEquals(expResult, result);
-	}
-
-	/**
-	 * Test of setQueueItemProject method, of class LockableResource.
-	 */
-	@Test
-	public void testSetQueueItemProject() {
-		System.out.println("setQueueItemProject");
-		String queueItemProject = "";
-		instance.setQueueItemProject(queueItemProject);
 	}
 
 	/**


### PR DESCRIPTION
New parameter named Label added for lockable resources. With labels, resources can be grouped / tagged as pools, and builds can allocate resources from these pools instead of hard coded resource names.