### PR TITLE
regular expressions in resources list

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -79,6 +79,19 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		return null;
 	}
 
+	public List<LockableResource> fromRegex(String resourceRegex) {
+		List<LockableResource> matched = new ArrayList<LockableResource>();
+		if (resourceRegex != null) {
+			for (LockableResource r : resources) {
+				try {
+					if (r.getName().matches(resourceRegex))
+						matched.add(r);
+				} catch ( java.util.regex.PatternSyntaxException e){};
+			}
+		}
+		return matched;
+	}
+
 	public synchronized boolean queue(List<LockableResource> resources,
 			int queueItemId) {
 		for (LockableResource r : resources)

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -119,6 +119,10 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 				if (wrongNames.isEmpty()) {
 					return FormValidation.ok();
 				} else {
+					if( names.indexOf("${") >= 0) {
+						return FormValidation
+								.warning("Resource names can't be validated when build parameters are used.");
+					}
 					return FormValidation
 							.error("The following resources do not exist: "
 									+ wrongNames);
@@ -153,11 +157,15 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			}
 
 			if (numResources < numAsInt) {
+				if( resourceNames.indexOf("${") >= 0) {
+					return FormValidation
+							.warning("Amount of resources can't be validated when build parameters are used.");
+				}
 				return FormValidation.error(String.format(
 					"Given amount %d in greater than amount of available resources: %d.",
 					numAsInt,
 					numResources));
-			}
+ 			}
 			return FormValidation.ok();
 		}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -37,7 +37,7 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 		AbstractProject<?, ?> proj = Utils.getProject(build);
 		List<LockableResource> required = new ArrayList<LockableResource>();
 		if (proj != null) {
-			LockableResourcesStruct resources = Utils.requiredResources(proj);
+			LockableResourcesStruct resources = Utils.requiredResources(build);
 			if (resources != null) {
 				if (resources.requiredNumber != null) {
 					required = LockableResourcesManager.get().

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -33,7 +33,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 		if (project == null)
 			return null;
 
-		LockableResourcesStruct resources = Utils.requiredResources(project);
+		LockableResourcesStruct resources = Utils.requiredResources(project, Utils.getQueueItemParams(item));
 		if (resources == null || resources.required.isEmpty())
 			return null;
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -10,6 +10,8 @@ package org.jenkins.plugins.lockableresources.queue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import hudson.Util;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
@@ -20,9 +22,10 @@ public class LockableResourcesStruct {
 	public String requiredVar;
 	public String requiredNumber;
 
-	public LockableResourcesStruct(RequiredResourcesProperty property) {
+	public LockableResourcesStruct(RequiredResourcesProperty property, Map<String,String> vars) {
 		this.required = new ArrayList<LockableResource>();
 		for (String name : property.getResources()) {
+			if( vars != null) name = Util.replaceMacro(name,vars);
 			LockableResource r = LockableResourcesManager.get().fromName(
 				name);
 			if (r != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -27,6 +27,12 @@ public class LockableResourcesStruct {
 				name);
 			if (r != null) {
 				this.required.add(r);
+			} else {
+				// exact name not found, might be regex
+				List<LockableResource> list = LockableResourcesManager.get().fromRegex(name);
+				for(LockableResource regRes: list) {
+					this.required.add(regRes);
+				}
 			}
 		}
 		this.requiredVar = property.getResourceNamesVar();

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNames.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNames.html
@@ -6,6 +6,10 @@ be queued until they are released. It is possible to specify an amount for
 requested resources below.
 </p>
 <p>
+Resources here are space separated resource names defined in global configuration.
+You can use exact names or regular expressions here.
+</p>
+<p>
 By default, all builds have the same lock priority (defined in the global
 configuration). If you want a specific job to have a different priority, you
 need to add a parameter to the job. The priority must be an integer (lowest


### PR DESCRIPTION
Problem:
  It is very uncomfortable to enumerate all resources on large poll.

Solution:
  Allow use regular expressions for resource name. For backward
  compatibility, full name is always checked first. If it is not
  found, regex is applied.
