### PR TITLE
[FIXED JENKINS-29529] Ignore matrix parent builds when locking resources

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -9,6 +9,7 @@
 package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.Extension;
+import hudson.matrix.MatrixBuild;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -31,9 +32,16 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 	static final String LOG_PREFIX = "[lockable-resources]";
 	static final Logger LOGGER = Logger.getLogger(LockRunListener.class
 			.getName());
-
+        
 	@Override
 	public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
+                if (build instanceof MatrixBuild) {
+                    listener.getLogger().printf("%s Skipping acquire for %s as it is parent matrix build\n",
+                            LOG_PREFIX, build.toString());
+                    LOGGER.fine("Skipping acquire for " + build.getFullDisplayName()
+                            + " as it is parent matrix build");
+                    return;
+                }
 		AbstractProject<?, ?> proj = Utils.getProject(build);
 		List<LockableResource> required = new ArrayList<LockableResource>();
 		if (proj != null) {


### PR DESCRIPTION
The problem was that we have always locked the resources. However, this makes no sense for parent build of matrix projects since they dont actually do anything. To fix the problem we just ignore matrix builds (that do nothing but spawn configuration builds). Now we consume exactly the same number of resource instances as actually needed.