### PR TITLE
Jenkins 29585

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -8,6 +8,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources;
 
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -17,11 +19,18 @@ import hudson.model.Queue;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class LockableResource extends AbstractDescribableImpl<LockableResource> {
-
+    
+        public static final String GROOVY_LABEL_MARKER = "groovy:";
+	private static final Logger LOGGER = Logger.getLogger(LockableResource.class.getName());
 	public static final int NOT_QUEUED = 0;
 	private static final int QUEUE_TIMEOUT = 60;
 
@@ -56,9 +65,45 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 		return labels;
 	}
 
-	public Boolean isValidLabel(String candidate) {
-		return Arrays.asList(labels.split("\\s+")).contains(candidate);
+	public Boolean isValidLabel(String candidate, Map<String, Object> params) {
+            return candidate.startsWith(GROOVY_LABEL_MARKER)
+                    ? expressionMatches(candidate, params)
+                    : labelsContain(candidate);
 	}
+
+        private boolean labelsContain(String candidate) {
+            return makeLabelsList().contains(candidate);
+        }
+
+        private List<String> makeLabelsList() {
+            return Arrays.asList(labels.split("\\s+"));
+        }
+
+        private boolean expressionMatches(String expression, Map<String, Object> params) {
+            Map<String, Object> allParams = new HashMap<String, Object>(params);
+            allParams.put("resourceName", name);
+            allParams.put("resourceDescription", description);
+            allParams.put("resourceLabels", makeLabelsList());
+            String expressionToEvaluate = expression.substring(GROOVY_LABEL_MARKER.length());
+            Binding binding = new Binding(allParams);
+            GroovyShell shell = new GroovyShell(binding);
+            try {
+                Object result = shell.evaluate(expressionToEvaluate);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine("Checked resource " + name 
+                            + " for " + expression 
+                            + " with " + allParams 
+                            + " -> " + result);
+                }
+                return (Boolean) result;
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE,
+                        "Cannot get boolean result out of groovy expression '"
+                        + expressionToEvaluate + "' on (" + allParams + ")",
+                        e);
+                return false;
+            }
+        }
 
 	public String getReservedBy() {
 		return reservedBy;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -69,7 +70,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	public Boolean isValidLabel(String label)
 	{
-		return this.getAllLabels().contains(label);
+		return label.startsWith(LockableResource.GROOVY_LABEL_MARKER)
+                        || this.getAllLabels().contains(label);
 	}
 
 	public Set<String> getAllLabels()
@@ -96,10 +98,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		return free;
 	}
 
-	public List<LockableResource> getResourcesWithLabel(String label) {
+	public List<LockableResource> getResourcesWithLabel(String label, Map<String, Object> params) {
 		List<LockableResource> found = new ArrayList<LockableResource>();
 		for (LockableResource r : this.resources) {
-			if (r.isValidLabel(label))
+			if (r.isValidLabel(label, params))
 				found.add(r);
 		}
 		return found;
@@ -137,7 +139,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	                                                 int queueItemId,
 	                                                 String queueItemProject,
 	                                                 int number,  // 0 means all
-	                                                 Logger log) {
+	                                                 Logger log,
+                                                         Map<String, Object> params) {
 		List<LockableResource> selected = new ArrayList<LockableResource>();
 
 		if (!checkCurrentResourcesStatus(selected, queueItemProject, queueItemId, log)) {
@@ -152,7 +155,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		if (requiredResources.label != null && requiredResources.label.isEmpty()) {
 			candidates = requiredResources.required;
 		} else {
-			candidates = getResourcesWithLabel(requiredResources.label);
+			candidates = getResourcesWithLabel(requiredResources.label, params);
 		}
 
 		for (LockableResource rs : candidates) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -176,9 +176,8 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			int numResources = 0;
 			if (names != null) {
 				numResources = names.split("\\s+").length;
-			} else if (label != null) {
-				numResources = LockableResourcesManager.get().
-					getResourcesWithLabel(label).size();
+			} else if (label != null ) {
+				numResources = Integer.MAX_VALUE;
 			}
 
 			if (numResources < numAsInt) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -9,6 +9,7 @@
 package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.Extension;
+import hudson.matrix.MatrixBuild;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -31,9 +32,16 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 	static final String LOG_PREFIX = "[lockable-resources]";
 	static final Logger LOGGER = Logger.getLogger(LockRunListener.class
 			.getName());
-
+        
 	@Override
 	public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
+                if (build instanceof MatrixBuild) {
+                    listener.getLogger().printf("%s Skipping acquire for %s as it is parent matrix build\n",
+                            LOG_PREFIX, build.toString());
+                    LOGGER.fine("Skipping acquire for " + build.getFullDisplayName()
+                            + " as it is parent matrix build");
+                    return;
+                }
 		AbstractProject<?, ?> proj = Utils.getProject(build);
 		List<LockableResource> required = new ArrayList<LockableResource>();
 		if (proj != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 
 import java.util.List;
 import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
 
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.LockableResource;
@@ -53,12 +54,22 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 					LOGGER.fine(build.getFullDisplayName()
 							+ " acquired lock on " + required);
 					if (resources.requiredVar != null) {
-						List<ParameterValue> params = new ArrayList<ParameterValue>();
-						params.add(new StringParameterValue(
-							resources.requiredVar,
+						List<ParameterValue> parameterList = new ArrayList<ParameterValue>();
+						parameterList.add(new StringParameterValue(
+                                                        resources.requiredVar,
 							required.toString().replaceAll("[\\]\\[]", "")));
-						build.addAction(new ParametersAction(params));
-					}
+                                                ParametersAction oldParams = build.getAction(ParametersAction.class);
+                                                if (oldParams != null) {
+                                                    for(ParameterValue oldParameter : oldParams.getParameters()) {
+                                                        if(!StringUtils.equals(oldParameter.getName(), resources.requiredVar)) {
+                                                            parameterList.add(oldParameter);
+                                                        }
+                                                    }
+                                                    build.getActions().remove(oldParams);
+                                                }
+                                                ParametersAction newParams = new ParametersAction(parameterList);
+                                                build.addAction(newParams);
+                                        }
 				} else {
 					listener.getLogger().printf("%s failed to lock %s\n",
 							LOG_PREFIX, required);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -9,7 +9,6 @@
 package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.Extension;
-import hudson.matrix.MatrixBuild;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -32,16 +31,9 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 	static final String LOG_PREFIX = "[lockable-resources]";
 	static final Logger LOGGER = Logger.getLogger(LockRunListener.class
 			.getName());
-        
+
 	@Override
 	public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
-                if (build instanceof MatrixBuild) {
-                    listener.getLogger().printf("%s Skipping acquire for %s as it is parent matrix build\n",
-                            LOG_PREFIX, build.toString());
-                    LOGGER.fine("Skipping acquire for " + build.getFullDisplayName()
-                            + " as it is parent matrix build");
-                    return;
-                }
 		AbstractProject<?, ?> proj = Utils.getProject(build);
 		List<LockableResource> required = new ArrayList<LockableResource>();
 		if (proj != null) {

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
@@ -5,4 +5,22 @@ here. The build will select the resource(s) from the pool that includes all
 resources sharing the given label.
 Either Label or Resources field must be empty.
 </p>
+<p>
+If label starts with groovy: then it is treated as a groovy expression to be
+evaluated each time a resource is checked to be appropriate for a build. The
+expression must result into a boolean value. The following variables are available:
+</p>
+<ul>
+    <li>resourceName - as per resource configuration</li>
+    <li>resourceDescription - as per resource configuration</li>
+    <li>resourceLabels - java.util.List&lt;String&gt; of labels as per resource configuration</li>
+</ul>
+<p>
+For matrix jobs, axis names and axis values are referencable as well. Examples:
+</p>
+<ul>
+    <li>groovy:resourceLabels.contains("hardcoded")</li>
+    <li>groovy:resourceLabels.contains(axisName)</li>
+    <li>groovy:resourceName == axisName</li>
+</ul>
 </div>


### PR DESCRIPTION
The change allows to use resource label in job config as a groovy expression evaluated against each resource during resource selection phase. Parameters of matrix jobs are available to this expression. As a result, executions of matrix jobs can intelligently select which resources they need. See https://issues.jenkins-ci.org/browse/JENKINS-29585 for description of scenario where this is needed.
5c8ef49 reverts 17fb8d so there are no changes for other jira issues. 