### PR TITLE
[JENKINS-31437] attach properties to resources, inject properties at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
 			</roles>
 			<timezone>CET</timezone>
 		</developer>
+		<developer>
+			<id>McFoggy</id>
+			<name>Matthieu Brouillard</name>
+			<email>matthieu@brouillard.fr</email>
+			<roles>
+				<role>contributor</role>
+			</roles>
+			<timezone>CET</timezone>
+		</developer>
 	</developers>
 
 	<dependencies>

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -13,7 +13,6 @@ import hudson.model.AutoCompletionCandidates;
 import hudson.util.FormValidation;
 import hudson.Util;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public class LockStep extends AbstractStepImpl implements Serializable {
@@ -29,6 +28,10 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	/** name of environment variable to store locked resources in */
 	@CheckForNull
 	public String variable = null;
+
+	public boolean injectProperties;
+	public boolean prefixProperties;
+	public boolean uppercaseProperties;
 
 	public boolean inversePrecedence = false;
 
@@ -46,7 +49,22 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 		this.inversePrecedence = inversePrecedence;
 	}
 
-	@DataBoundSetter
+    @DataBoundSetter
+    public void setInjectProperties(boolean injectProperties) {
+        this.injectProperties = injectProperties;
+    }
+
+    @DataBoundSetter
+    public void setPrefixProperties(boolean prefixProperties) {
+        this.prefixProperties = prefixProperties;
+    }
+
+    @DataBoundSetter
+    public void setUppercaseProperties(boolean uppercaseProperties) {
+        this.uppercaseProperties = uppercaseProperties;
+    }
+
+    @DataBoundSetter
 	public void setLabel(String label) {
 		if (label != null && !label.isEmpty()) {
 			this.label = label;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepData.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepData.java
@@ -1,0 +1,54 @@
+package org.jenkins.plugins.lockableresources;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LockStepData implements Serializable {
+    private String name;
+    private String description;
+    private String labels;
+    private String reservedBy = null;
+    private String reservedByEmail;
+    private Map<String, String> properties = new HashMap<String, String>();
+
+    public static LockStepData from(LockableResource res) {
+        LockStepData d = new LockStepData();
+        d.name = res.getName();
+        d.description = res.getDescription();
+        d.labels = res.getLabels();
+        d.reservedBy = res.getReservedBy();
+        d.reservedByEmail = res.getReservedByEmail();
+        for (LockableResourceProperty lrp : res.getProperties()) {
+            d.properties.put(lrp.getName(), lrp.getValue());
+        }
+        return d;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLabels() {
+        return labels;
+    }
+
+    public String getReservedBy() {
+        return reservedBy;
+    }
+
+    public String getReservedByEmail() {
+        return reservedByEmail;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties==null?Collections.<String, String>emptyMap():properties;
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -64,6 +64,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	private String description = "";
 	private String labels = "";
 	private String reservedBy = null;
+	private List<LockableResourceProperty> properties = new ArrayList<LockableResourceProperty>();
 
 	private long queueItemId = NOT_QUEUED;
 	private String queueItemProject = null;
@@ -98,6 +99,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 		if (queuedContexts == null) { // this field was added after the initial version if this class
 			queuedContexts = new ArrayList<StepContext>();
 		}
+		if (properties == null) {
+		    properties = new ArrayList<LockableResourceProperty>();
+        }
 		return this;
 	}
 
@@ -130,6 +134,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	public String getLabels() {
 		return labels;
 	}
+
+    @Exported
+    public List<LockableResourceProperty> getProperties() {
+        return properties;
+    }
+
+    @DataBoundSetter
+    public void setProperties(List<LockableResourceProperty> properties) {
+	    this.properties = properties==null?new ArrayList<LockableResourceProperty>():properties;
+    }
 
 	public boolean isValidLabel(String candidate, Map<String, Object> params) {
 		return labelsContain(candidate);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
@@ -1,0 +1,45 @@
+package org.jenkins.plugins.lockableresources;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+@ExportedBean
+public class LockableResourceProperty extends AbstractDescribableImpl<LockableResourceProperty> {
+	private String name;
+	private String value;
+	
+	@DataBoundConstructor
+	public LockableResourceProperty(String name, String value) {
+		super();
+		this.name = name;
+		this.value = value;
+	}
+	
+	@Exported
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	@Exported
+	public String getValue() {
+		return value;
+	}
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Extension
+    public static class DescriptorImpl extends Descriptor<LockableResourceProperty> {
+        @Override
+        public String getDisplayName() {
+        	return "";
+        }
+    } 
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -477,7 +477,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	 * Creates the resource if it does not exist.
 	 */
 	public synchronized boolean createResource(String name, String...propertiesKeysValues) {
-		return createResourceWithLabel(name, null, propertiesKeysValues);
+		return createResourceWithLabel(name, "", propertiesKeysValues);
 	}
 
 	public synchronized boolean createResourceWithLabel(String name, String label, String...propertiesKeysValues) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -36,12 +36,15 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 	private final String resourceNamesVar;
 	private final String resourceNumber;
 	private final String labelName;
+	private final boolean injectResourcesProperties;
+    private final boolean prefixResourcesProperties;
+    private final boolean upperCaseResourcesProperties;
 	private final @CheckForNull SecureGroovyScript resourceMatchScript;
 
 	@DataBoundConstructor
 	public RequiredResourcesProperty(String resourceNames,
 			String resourceNamesVar, String resourceNumber,
-			String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
+			String labelName, boolean injectResourcesProperties, boolean prefixResourcesProperties, boolean upperCaseResourcesProperties, @CheckForNull SecureGroovyScript resourceMatchScript) {
 		super();
 		
 		if (resourceNames == null || resourceNames.trim().isEmpty()) {
@@ -71,19 +74,30 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			this.resourceMatchScript = null;
 			this.labelName = labelNamePreparation;
 		}
+		this.injectResourcesProperties = injectResourcesProperties;
+		this.prefixResourcesProperties = prefixResourcesProperties;
+		this.upperCaseResourcesProperties = upperCaseResourcesProperties;
+	}
+
+    @Deprecated
+    public RequiredResourcesProperty(String resourceNames,
+                                     String resourceNamesVar, String resourceNumber,
+                                     String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
+        this(resourceNames, resourceNamesVar, resourceNumber, labelName, false, false, false, resourceMatchScript);
 	}
 
 	@Deprecated
 	public RequiredResourcesProperty(String resourceNames,
 									 String resourceNamesVar, String resourceNumber,
 									 String labelName) {
-		this(resourceNames, resourceNamesVar, resourceNumber, labelName, null);
+		this(resourceNames, resourceNamesVar, resourceNumber, labelName, false, false, false, null);
 	}
 
 	private Object readResolve() {
 		// SECURITY-368 migration logic
 		if (resourceMatchScript == null && labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
 			return new RequiredResourcesProperty(resourceNames, resourceNamesVar, resourceNumber, null,
+                    false, false, false,
 					new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()), false, null)
 							.configuring(ApprovalContext.create()));
 		}
@@ -115,7 +129,19 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 		return labelName;
 	}
 
-	/**
+    public boolean isInjectResourcesProperties() {
+        return injectResourcesProperties;
+    }
+
+    public boolean isPrefixResourcesProperties() {
+        return prefixResourcesProperties;
+    }
+
+    public boolean isUpperCaseResourcesProperties() {
+        return upperCaseResourcesProperties;
+    }
+
+    /**
 	 * Gets a system Groovy script to be executed in order to determine if the {@link LockableResource} matches the condition.
 	 * @return System Groovy Script if defined
 	 * @since TODO

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
@@ -1,6 +1,7 @@
 package org.jenkins.plugins.lockableresources.actions;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -32,12 +33,12 @@ public class ResourceVariableNameAction extends InvisibleAction {
 		@Override
 		public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener)
 				throws IOException, InterruptedException {
-			ResourceVariableNameAction a = r.getAction(ResourceVariableNameAction.class);
-			if (a != null && a.getParameter() != null && a.getParameter().getValue() != null) {
-				envs.put(a.getParameter().getName(), String.valueOf(a.getParameter().getValue()));
+			List<ResourceVariableNameAction> actions = r.getActions(ResourceVariableNameAction.class);
+			for (ResourceVariableNameAction a : actions) {
+				if (a != null && a.getParameter() != null && a.getParameter().getValue() != null) {
+					envs.put(a.getParameter().getName(), String.valueOf(a.getParameter().getValue()));
+				}
 			}
 		}
-
 	}
-
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -19,8 +19,10 @@ import hudson.model.StringParameterValue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
+import org.jenkins.plugins.lockableresources.LockableResourceProperty;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
@@ -65,6 +67,26 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 							build.addAction(new ResourceVariableNameAction(new StringParameterValue(
 									resources.requiredVar,
 									required.toString().replaceAll("[\\]\\[]", ""))));
+						}
+
+						if (resources.injectResourcesProperties) {
+							for (LockableResource lr : required) {
+								List<LockableResourceProperty> properties = lr.getProperties();
+								for (LockableResourceProperty lrp : properties) {
+                                    String propertyName = lrp.getName();
+                                    String propertyValue = lrp.getValue();
+
+                                    if (resources.prefixResourcesProperties && resources.requiredVar != null) {
+                                        propertyName = resources.requiredVar + "_" + propertyName;
+                                    }
+                                    if (resources.upperCaseResourcesProperties) {
+                                        propertyName = propertyName.toUpperCase(Locale.ENGLISH);
+                                    }
+                                    build.addAction(new ResourceVariableNameAction(new StringParameterValue(
+                                            propertyName,
+                                            propertyValue)));
+								}
+							}
 						}
 					} else {
 						listener.getLogger().printf("%s failed to lock %s%n",

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -31,6 +31,9 @@ public class LockableResourcesStruct implements Serializable {
 	public String label;
 	public String requiredVar;
 	public String requiredNumber;
+	public boolean injectResourcesProperties;
+	public boolean prefixResourcesProperties;
+	public boolean upperCaseResourcesProperties;
 
 	@CheckForNull
 	private final SerializableSecureGroovyScript serializableResourceMatchScript;
@@ -59,8 +62,12 @@ public class LockableResourcesStruct implements Serializable {
 		requiredVar = property.getResourceNamesVar();
 
 		requiredNumber = property.getResourceNumber();
-		if (requiredNumber != null && requiredNumber.equals("0"))
+		injectResourcesProperties = property.isInjectResourcesProperties();
+		prefixResourcesProperties = property.isPrefixResourcesProperties();
+		upperCaseResourcesProperties = property.isUpperCaseResourcesProperties();
+		if (requiredNumber != null && requiredNumber.equals("0")) {
 			requiredNumber = null;
+		}
 	}
 
 	/**

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -23,4 +23,14 @@
 	<f:entry title="${%Reserved by}" field="reservedBy">
 		<f:textbox/>
 	</f:entry>
+	<f:entry title="Properties">
+		<f:repeatable field="properties" header="Property" minimum="0" add="Add Property">
+			<table width="100%">
+				<st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockableResourceProperty"/>
+				<f:entry title="">
+					<div align="right"><f:repeatableDeleteButton/></div>
+				</f:entry>
+			</table>
+		</f:repeatable>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourceProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourceProperty/config.jelly
@@ -1,0 +1,10 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="Name" field="name">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="Value" field="value">
+		<f:textbox/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
@@ -28,6 +28,15 @@
 			<f:entry title="${%Number of resources to request}" field="resourceNumber">
 				<f:textbox/>
 			</f:entry>
+			<f:entry title="${%Inject properties of resources}" field="injectResourcesProperties">
+				<f:checkbox/>
+			</f:entry>
+			<f:entry title="${%Prefix properties of resources with variable name}" field="prefixResourcesProperties">
+				<f:checkbox/>
+			</f:entry>
+			<f:entry title="${%Properties keys are uppercase}" field="upperCaseResourcesProperties">
+				<f:checkbox/>
+			</f:entry>
 		</f:nested>
 	</f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-injectResourcesProperties.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-injectResourcesProperties.html
@@ -1,0 +1,7 @@
+<div>
+<p>
+	check this field to have properties defined at resource level to be injected as parameters of the job.
+	<br/>
+	If the same property is defined on several resources and then only the latest injected value is visible for the job.
+</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-injectResourcesProperties.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-injectResourcesProperties.html
@@ -2,6 +2,6 @@
 <p>
 	check this field to have properties defined at resource level to be injected as parameters of the job.
 	<br/>
-	If the same property is defined on several resources and then only the latest injected value is visible for the job.
+	If the same property is defined on several resources, then only the latest injected value is visible for the job.
 </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-prefixResourcesProperties.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-prefixResourcesProperties.html
@@ -1,0 +1,5 @@
+<div>
+<p>
+	check this field to prefix properties using the above variable name (if one is defined).
+</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-upperCaseResourcesProperties.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-upperCaseResourcesProperties.html
@@ -1,0 +1,5 @@
+<div>
+<p>
+	check this field to uppercase injected properties.
+</p>
+</div>


### PR DESCRIPTION
This PR allows to define properties, a list of key/value pairs, attached to each resource.
On the project then you can decide to receive (as build parameters) the properties of the elected resources.

I use this feature to define named pools of resources that I can then use at build time. Especially, by product family (named pool) I am able to define resources and for each I define for example the `host name`, `host ip`, `communication ports`, ...

![image](https://cloud.githubusercontent.com/assets/1119660/10094924/d93f87b4-6365-11e5-8bb4-2670ef12ca84.png)
