### PR TITLE
JENKINS-36479 - clean up hard killed/deleted builds' locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 bin/
 work/
 .*
+.idea
+*.iml

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -220,6 +220,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			Run<?, ?> build, @Nullable StepContext context, boolean inversePrecedence) {
 		boolean needToWait = false;
 		for (LockableResource r : resources) {
+			Run lockingRun = r.getBuild();
+			// Check if the resource is locked by a null or not-building build. Unlock it if that's the case.
+			if (r.isLocked() && (lockingRun == null || !lockingRun.isBuilding())) {
+				unlock(resources, null, context, false);
+			}
+
 			if (r.isReserved() || r.isLocked()) {
 				needToWait = true;
 				if (context != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -222,7 +222,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		for (LockableResource r : resourcesToLock) {
 			Run lockingRun = r.getBuild();
 			// Check if the resource is locked by a null or not-building build. Unlock it if that's the case.
-			if (r.isLocked() && (lockingRun == null || !lockingRun.isBuilding())) {
+			if (r.isLocked()
+					&& (lockingRun == null
+					    || !lockingRun.isBuilding()
+					    || lockingRun.getParent().getBuild(lockingRun.getId()) == null)) {
 				performUnlocking(r, lockingRun, inversePrecedence);
 			}
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -298,7 +298,7 @@ public class LockStepTest {
 	}
 
 	@Issue("JENKINS-36479")
-	@Test(timeout=10000) public void hardKillNewBuildClearsLock() throws Exception {
+	@Test public void hardKillNewBuildClearsLock() throws Exception {
 		story.addStep(new Statement() {
 			@Override public void evaluate() throws Throwable {
 				LockableResourcesManager.get().createResource("resource1");
@@ -309,7 +309,6 @@ public class LockStepTest {
 				story.j.waitForMessage("locked!", b1);
 				SemaphoreStep.waitForStart("wait-inside/1", b1);
 
-				// TODO: Actually make this fail instead of waiting forever if it can't get the lock.
 				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
 				p2.setDefinition(new CpsFlowDefinition(
 						"lock('resource1') {\n"
@@ -349,10 +348,10 @@ public class LockStepTest {
 		});
 	}
 
-	// TODO: Get this to not hang forever in failure case, figure out what to do about the IOException thrown during
-	// clean up, since we don't care about it.
+	// TODO: Figure out what to do about the IOException thrown during clean up, since we don't care about it. It's just
+	// a result of the first build being deleted and is nothing but noise here.
 	@Issue("JENKINS-36479")
-	@Test(timeout=10000) public void deleteRunningBuildNewBuildClearsLock() throws Exception {
+	@Test public void deleteRunningBuildNewBuildClearsLock() throws Exception {
 		story.addStep(new Statement() {
 			@Override public void evaluate() throws Throwable {
 				LockableResourcesManager.get().createResource("resource1");
@@ -363,7 +362,6 @@ public class LockStepTest {
 				story.j.waitForMessage("locked!", b1);
 				SemaphoreStep.waitForStart("wait-inside/1", b1);
 
-				// TODO: Actually make this fail instead of waiting forever if it can't get the lock.
 				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
 				p2.setDefinition(new CpsFlowDefinition(
 						"lock('resource1') {\n"


### PR DESCRIPTION
[JENKINS-36479](https://issues.jenkins-ci.org/browse/JENKINS-36479)

- [x] Successfully clear locks from hard killed/deleted builds on next lock request.
- [x] Write tests for both hard kill and deleted build scenarios.
- [ ] Decide whether this is sufficient or if we need to automatically clear those locks without needing a new lock request.

cc @reviewbybees, esp @jglick and @amuniz 