### PR TITLE
[JENKINS-36479] First work on auto-clearing invalid locks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 bin/
 work/
 .*
+.idea
+*.iml

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -61,7 +61,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		return matching;
 	}
 
-	public List<LockableResource> getResourcesFromBuild(AbstractBuild<?, ?> build) {
+	public List<LockableResource> getResourcesFromBuild(Run<?, ?> build) {
 		List<LockableResource> matching = new ArrayList<LockableResource>();
 		for (LockableResource r : resources) {
 			Run<?, ?> rBuild = r.getBuild();

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -10,12 +10,10 @@ package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.Extension;
 import hudson.matrix.MatrixBuild;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.listeners.RunListener;
-import hudson.model.ParametersAction;
-import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 
 import java.util.ArrayList;
@@ -28,20 +26,20 @@ import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
 import org.jenkins.plugins.lockableresources.actions.ResourceVariableNameAction;
 
 @Extension
-public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
+public class LockRunListener extends RunListener<Run<?, ?>> {
 
 	static final String LOG_PREFIX = "[lockable-resources]";
 	static final Logger LOGGER = Logger.getLogger(LockRunListener.class
 			.getName());
 
 	@Override
-	public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
+	public void onStarted(Run<?, ?> build, TaskListener listener) {
 		// Skip locking for multiple configuration projects,
 		// only the child jobs will actually lock resources.
 		if (build instanceof MatrixBuild)
 			return;
 
-		AbstractProject<?, ?> proj = Utils.getProject(build);
+		Job<?, ?> proj = Utils.getProject(build);
 		List<LockableResource> required = new ArrayList<LockableResource>();
 		if (proj != null) {
 			LockableResourcesStruct resources = Utils.requiredResources(proj);
@@ -75,7 +73,7 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 	}
 
 	@Override
-	public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
+	public void onCompleted(Run<?, ?> build, TaskListener listener) {
 		// Skip unlocking for multiple configuration projects,
 		// only the child jobs will actually unlock resources.
 		if (build instanceof MatrixBuild)
@@ -95,7 +93,7 @@ public class LockRunListener extends RunListener<AbstractBuild<?, ?>> {
 	}
 
 	@Override
-	public void onDeleted(AbstractBuild<?, ?> build) {
+	public void onDeleted(Run<?, ?> build) {
 		// Skip unlocking for multiple configuration projects,
 		// only the child jobs will actually unlock resources.
 		if (build instanceof MatrixBuild)

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -12,6 +12,7 @@ import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.queue.QueueTaskDispatcher;
 import hudson.model.queue.CauseOfBlockage;
@@ -37,7 +38,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 		if (item.task instanceof MatrixProject)
 			return null;
 
-		AbstractProject<?, ?> project = Utils.getProject(item);
+		Job<?, ?> project = Utils.getProject(item);
 		if (project == null)
 			return null;
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
@@ -10,35 +10,33 @@ package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.EnvVars;
 import hudson.matrix.MatrixConfiguration;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Queue;
 
+import hudson.model.Run;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 
 public class Utils {
 
-	public static AbstractProject<?, ?> getProject(Queue.Item item) {
-		if (item.task instanceof AbstractProject)
-			return (AbstractProject<?, ?>) item.task;
+	public static Job<?, ?> getProject(Queue.Item item) {
+		if (item.task instanceof Job)
+			return (Job<?, ?>) item.task;
 		return null;
 	}
 
-	public static AbstractProject<?, ?> getProject(AbstractBuild<?, ?> build) {
+	public static Job<?, ?> getProject(Run<?, ?> build) {
 		Object p = build.getParent();
-		if (p instanceof AbstractProject)
-			return (AbstractProject<?, ?>) p;
-		return null;
+		return (Job<?, ?>) p;
 	}
 
 	public static LockableResourcesStruct requiredResources(
-			AbstractProject<?, ?> project) {
+			Job<?, ?> project) {
 		RequiredResourcesProperty property = null;
 		EnvVars env = new EnvVars();
 
 		if (project instanceof MatrixConfiguration) {
 			env.putAll(((MatrixConfiguration) project).getCombination());
-			project = (AbstractProject<?, ?>) project.getParent();
+			project = (Job<?, ?>) project.getParent();
 		}
 
 		property = project.getProperty(RequiredResourcesProperty.class);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -12,6 +12,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 
@@ -292,6 +293,111 @@ public class LockStepTest {
 				}
 
 				story.j.waitForMessage("acquired lock on [resource1]", fb1);
+			}
+		});
+	}
+
+	@Issue("JENKINS-36479")
+	@Test public void hardKillNewBuildClearsLock() throws Exception {
+		story.addStep(new Statement() {
+			@Override public void evaluate() throws Throwable {
+				LockableResourcesManager.get().createResource("resource1");
+
+				WorkflowJob p1 = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p1.setDefinition(new CpsFlowDefinition("lock('resource1') { echo 'locked!'; semaphore 'wait-inside' }"));
+				WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("locked!", b1);
+				SemaphoreStep.waitForStart("wait-inside/1", b1);
+
+				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+				p2.setDefinition(new CpsFlowDefinition(
+						"lock('resource1') {\n"
+						+ "  semaphore 'wait-inside'\n"
+						+ "}"));
+				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+
+				// Make sure that b2 is blocked on b1's lock.
+				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
+
+				// Now b2 is still sitting waiting for a lock. Create b3 and launch it to clear the lock.
+				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
+				p3.setDefinition(new CpsFlowDefinition(
+						"lock('resource1') {\n"
+								+ "  semaphore 'wait-inside'\n"
+								+ "}"));
+				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("[resource1] is locked, waiting...", b3);
+
+				// Kill b1 hard.
+				b1.doKill();
+				story.j.waitForMessage("Hard kill!", b1);
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.ABORTED, b1);
+
+
+				// Verify that b2 gets the lock.
+				story.j.waitForMessage("Lock acquired on [resource1]", b2);
+				SemaphoreStep.success("wait-inside/2", b2);
+				// Verify that b2 releases the lock and finishes successfully.
+				story.j.waitForMessage("Lock released on resource [resource1]", b2);
+				story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b2));
+
+				// Now b3 should get the lock and do its thing.
+				story.j.waitForMessage("Lock acquired on [resource1]", b3);
+				SemaphoreStep.success("wait-inside/3", b3);
+				story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b3));
+			}
+		});
+	}
+
+	// TODO: Figure out what to do about the IOException thrown during clean up, since we don't care about it. It's just
+	// a result of the first build being deleted and is nothing but noise here.
+	@Issue("JENKINS-36479")
+	@Test public void deleteRunningBuildNewBuildClearsLock() throws Exception {
+		story.addStep(new Statement() {
+			@Override public void evaluate() throws Throwable {
+				LockableResourcesManager.get().createResource("resource1");
+
+				WorkflowJob p1 = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p1.setDefinition(new CpsFlowDefinition("lock('resource1') { echo 'locked!'; semaphore 'wait-inside' }"));
+				WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("locked!", b1);
+				SemaphoreStep.waitForStart("wait-inside/1", b1);
+
+				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+				p2.setDefinition(new CpsFlowDefinition(
+						"lock('resource1') {\n"
+								+ "  semaphore 'wait-inside'\n"
+								+ "}"));
+				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+
+				// Now b2 is still sitting waiting for a lock. Create b3 and launch it to clear the lock.
+				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
+				p3.setDefinition(new CpsFlowDefinition(
+						"lock('resource1') {\n"
+								+ "  semaphore 'wait-inside'\n"
+								+ "}"));
+				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+
+
+				// Make sure that b2 is blocked on b1's lock.
+				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
+				story.j.waitForMessage("[resource1] is locked, waiting...", b3);
+
+				b1.delete();
+
+
+				// Verify that b2 gets the lock.
+				story.j.waitForMessage("Lock acquired on [resource1]", b2);
+				SemaphoreStep.success("wait-inside/2", b2);
+				// Verify that b2 releases the lock and finishes successfully.
+				story.j.waitForMessage("Lock released on resource [resource1]", b2);
+				story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b2));
+
+				// Now b3 should get the lock and do its thing.
+				story.j.waitForMessage("Lock acquired on [resource1]", b3);
+				SemaphoreStep.success("wait-inside/3", b3);
+				story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b3));
 			}
 		});
 	}


### PR DESCRIPTION
[JENKINS-36479](https://issues.jenkins-ci.org/browse/JENKINS-36479)

Update LockRunListener to work with Runs rather than just
AbstractProjects - this means that onCompleted and onDeleted will fire
correctly, obviating the need for anything more special-case/complex.

Probably supersedes #34 - this is a more general case solution that doesn't require new lock requests to clear the defunct locks.

cc @reviewbybees, esp @jglick and @amuniz 