### PR TITLE
[JENKINS-40879] Only proceed to next context with resources to lock

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -324,10 +324,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			save();
 			return;
 		} else {
+			List<String> resourceNamesToLock = new ArrayList<String>();
+
 			// lock all (old and new resources)
 			for (LockableResource requiredResource : requiredResourceForNextContext) {
 				try {
 					requiredResource.setBuild(nextContext.getContext().get(Run.class));
+					resourceNamesToLock.add(requiredResource.getName());
 				} catch (Exception e) {
 					throw new IllegalStateException("Can not access the context of a running build", e);
 				}
@@ -353,11 +356,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			this.freeResources(freeResources, build);
 
 			// continue with next context
-			List<String> resourceNames = new ArrayList<String>();
-			for (LockableResource resource : this.resources) {
-				resourceNames.add(resource.getName());
-			}
-			LockStepExecution.proceed(resourceNames, nextContext.getContext(), nextContext.getResourceDescription(), inversePrecedence);
+			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), inversePrecedence);
 		}
 		save();
 	}


### PR DESCRIPTION
[JENKINS-40879](https://issues.jenkins-ci.org/browse/JENKINS-40879)

Previously, we were calling LockStepExecution.proceed with the full
list of resources - which was resulting in *everything* getting
unlocked if there was a next context, i.e., if anything else was
waiting on a resource to be unlocked. That was wrong, obviously.

This changes to instead only call proceed with the list of resource
names we actually need to lock for the next context, which fixes the
test in the previous commit.

cc @reviewbybees esp @amuniz 