### PR TITLE
Result variable for DSL

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -26,6 +26,10 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 
 	public int quantity = 0;
 
+	/** name of environment variable to store locked resources in */
+	@CheckForNull
+	public String variable = null;
+
 	public boolean inversePrecedence = false;
 
 	// it should be LockStep() - without params. But keeping this for backward compatibility
@@ -46,6 +50,13 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	public void setLabel(String label) {
 		if (label != null && !label.isEmpty()) {
 			this.label = label;
+		}
+	}
+
+	@DataBoundSetter
+	public void setVariable(String variable) {
+		if (variable != null && !variable.isEmpty()) {
+			this.variable = variable;
 		}
 	}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
+import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 
 import hudson.EnvVars;
@@ -22,7 +23,9 @@ import hudson.model.TaskListener;
 
 public class LockStepExecution extends AbstractStepExecutionImpl {
 
-	@Inject(optional = true)
+	private static final Joiner COMMA_JOINER = Joiner.on(',');
+
+    @Inject(optional = true)
 	private LockStep step;
 
 	@StepContextParameter
@@ -75,12 +78,11 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 				bodyInvoker.withContext(EnvironmentExpander.merge(context.get(EnvironmentExpander.class), new EnvironmentExpander() {
 					@Override
 					public void expand(EnvVars env) throws IOException, InterruptedException {
-						final String resources = resourcenames.toString();
-						final String resourcesString = resources.substring(1, resources.length()-1);
-								LOGGER.finest("Setting [" + variable + "] to [" + resourcesString
+						final String resources = COMMA_JOINER.join(resourcenames);
+								LOGGER.finest("Setting [" + variable + "] to [" + resources
 										+ "] for the duration of the block");
 						
-						env.override(variable, resourcesString);
+						env.override(variable, resources);
 					}
 				}));
 			bodyInvoker.start();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -48,7 +48,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, step.label, step.quantity);
 		// determine if there are enough resources available to proceed
 		List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
-		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.inversePrecedence)) {
+		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.variable, step.inversePrecedence)) {
 			listener.getLogger().println("[" + step + "] is locked, waiting...");
 			LockableResourcesManager.get().queueContext(getContext(), resourceHolder, step.toString());
 		} // proceed is called inside lock if execution is possible
@@ -76,7 +76,11 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 					@Override
 					public void expand(EnvVars env) throws IOException, InterruptedException {
 						final String resources = resourcenames.toString();
-						env.override(variable, resources.substring(1, resources.length()-1));
+						final String resourcesString = resources.substring(1, resources.length()-1);
+								LOGGER.finest("Setting [" + variable + "] to [" + resourcesString
+										+ "] for the duration of the block");
+						
+						env.override(variable, resourcesString);
 					}
 				}));
 			bodyInvoker.start();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -221,14 +221,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	}
 	
 	public synchronized boolean lock(List<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
-		return lock(resources, build, context, null, false);
+		return lock(resources, build, context, null, null, false);
 	}
 
 	/**
 	 * Try to lock the resource and return true if locked.
 	 */
 	public synchronized boolean lock(List<LockableResource> resources,
-			Run<?, ?> build, @Nullable StepContext context, @Nullable String logmessage, boolean inversePrecedence) {
+			Run<?, ?> build, @Nullable StepContext context, @Nullable String logmessage,
+			final String variable, boolean inversePrecedence) {
 		boolean needToWait = false;
 		for (LockableResource r : resources) {
 			if (r.isReserved() || r.isLocked()) {
@@ -248,7 +249,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 				for (LockableResource resource : resources) {
 					resourceNames.add(resource.getName());
 				}
-				LockStepExecution.proceed(resourceNames, context, logmessage, null, inversePrecedence);
+				LockStepExecution.proceed(resourceNames, context, logmessage, variable, inversePrecedence);
 			}
 		}
 		save();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -248,7 +248,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 				for (LockableResource resource : resources) {
 					resourceNames.add(resource.getName());
 				}
-				LockStepExecution.proceed(resourceNames, context, logmessage, inversePrecedence);
+				LockStepExecution.proceed(resourceNames, context, logmessage, null, inversePrecedence);
 			}
 		}
 		save();
@@ -356,7 +356,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			this.freeResources(freeResources, build);
 
 			// continue with next context
-			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), inversePrecedence);
+			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), nextContext.getResources().requiredVar, inversePrecedence);
 		}
 		save();
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -53,6 +53,11 @@ public class LockableResourcesStruct implements Serializable {
 		this(resources, null, 0);
 	}
 
+	public LockableResourcesStruct(@Nullable List<String> resources, @Nullable String label, int quantity, String variable) {
+		this(resources, label, quantity);
+		requiredVar = variable;
+	}
+
 	public LockableResourcesStruct(@Nullable List<String> resources, @Nullable String label, int quantity) {
 		required = new ArrayList<LockableResource>();
 		if (resources != null) {

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -62,7 +62,7 @@ public class LockStepTest {
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
 						"lock(label: 'label1', variable: 'var') {\n" +
-						"	echo 'Resource locked: ${env.var}'\n" +
+						"	echo \"Resource locked: ${env.var}\"\n" +
 						"}\n" +
 						"echo 'Finish'"
 				));

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -61,8 +61,8 @@ public class LockStepTest {
 				LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
-						"lock(label: 'label1') {\n" +
-						"	echo 'Resource locked'\n" +
+						"lock(label: 'label1', variable: 'var') {\n" +
+						"	echo 'Resource locked: ${env.var}'\n" +
 						"}\n" +
 						"echo 'Finish'"
 				));
@@ -70,6 +70,7 @@ public class LockStepTest {
 				story.j.waitForCompletion(b1);
 				story.j.assertBuildStatus(Result.SUCCESS, b1);
 				story.j.assertLogContains("Lock released on resource [Label: label1]", b1);
+				story.j.assertLogContains("Resource locked: resource1", b1);
 			}
 		});
 	}


### PR DESCRIPTION
This adds an extra parameter ("variable") to the DSL step. It is used as the name of an environment variable that will receive the comma separated list of the names of the locked resources while the block executes.