### PR TITLE
[JENKINS-43336] Add getLock/releaseLock steps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.24</version>
+		<version>2.29</version>
 		<relativePath />
 	</parent>
 
@@ -30,10 +30,7 @@
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Lockable+Resources+Plugin</url>
 
 	<properties>
-		<!-- First version including TailCall is 1.9, and the same baseline is maintained
-		until 1.14, so let's pick up the greatest -->
-		<workflow.version>1.14</workflow.version>
-		<jenkins.version>1.609.1</jenkins.version>
+		<jenkins.version>1.642.3</jenkins.version>
 		<!-- TODO activate this and fix findbugs errors -->
 		<findbugs.failOnError>false</findbugs.failOnError>
 	</properties>
@@ -72,12 +69,17 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.5</version>
+			<version>1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
-			<version>${workflow.version}</version>
+			<version>2.10</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>structs</artifactId>
+			<version>1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -87,39 +89,67 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>script-security</artifactId>
-			<version>1.26</version>
+			<version>1.29</version>
 		</dependency>
 		<dependency>
 			<groupId>com.infradna.tool</groupId>
 			<artifactId>bridge-method-annotation</artifactId>
-			<version>1.14</version>
+			<version>1.17</version>
 			<optional>true</optional>
+		</dependency>
+
+		<!-- Making requireUpperBounds happy -->
+		<dependency>
+			<groupId>org.jenkins-ci.modules</groupId>
+			<artifactId>instance-identity</artifactId>
+			<version>1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.modules</groupId>
+			<artifactId>ssh-cli-auth</artifactId>
+			<version>1.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci</groupId>
+			<artifactId>annotation-indexer</artifactId>
+			<version>1.9</version>
 		</dependency>
 
 		<!-- Testing scope -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-aggregator</artifactId>
-			<version>${workflow.version}</version>
+			<artifactId>workflow-cps</artifactId>
+			<version>2.30</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>2.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-basic-steps</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-support</artifactId>
-			<version>${workflow.version}</version>
+			<version>2.14</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 		<dependency> <!-- Required by workflow-cps-global-lib (transitive of git-server) -->
 			<groupId>org.jenkins-ci.modules</groupId>
 			<artifactId>sshd</artifactId>
-			<version>1.6</version>
+			<version>1.11</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency><!-- Required when testing against core > 1.575 -->
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.13</version>
+			<version>1.20</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
 			<version>2.10</version>
 		</dependency>
 		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-api</artifactId>
+			<version>2.18</version>
+		</dependency>
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>structs</artifactId>
 			<version>1.6</version>

--- a/src/main/java/org/jenkins/plugins/lockableresources/GetLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/GetLockStep.java
@@ -1,0 +1,169 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class GetLockStep extends Step {
+    private static final Logger LOGGER = Logger.getLogger(GetLockStep.class.getName());
+
+    @CheckForNull
+    private String resource;
+
+    @CheckForNull
+    private String label;
+
+    private int quantity = 0;
+
+    @DataBoundConstructor
+    public GetLockStep() {
+    }
+
+    @DataBoundSetter
+    public void setResource(String resource) {
+        this.resource = Util.fixEmpty(resource);
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = Util.fixEmpty(label);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(this, context);
+    }
+
+    /**
+     * Label and resource are mutual exclusive.
+     */
+    public void validate() throws Exception {
+        if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
+            throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
+        }
+    }
+
+
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "getLock";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Acquires a lock on shared resources";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+
+        public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
+            return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+        }
+
+        public static FormValidation doCheckLabel(@QueryParameter String value, @QueryParameter String resource) {
+            return LockStep.DescriptorImpl.doCheckLabel(value, resource);
+        }
+
+        public static FormValidation doCheckResource(@QueryParameter String value, @QueryParameter String label) {
+            return doCheckLabel(label, value);
+        }
+    }
+
+    public static class Execution extends StepExecution {
+
+        private static final long serialVersionUID = 1L;
+
+        private transient final GetLockStep step;
+
+        Execution(GetLockStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        public boolean start() throws Exception {
+            step.validate();
+
+            LockUtils.queueLock(step, step.getResource(), step.getLabel(), step.getQuantity(), false, getContext());
+
+            return false;
+        }
+
+        @Override
+        public void stop(@Nonnull Throwable cause) {
+            boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
+            if (!cleaned) {
+                LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource witing list. The context is not in the waiting list.");
+            }
+            getContext().onFailure(cause);
+
+        }
+
+        @Override
+        public String getStatus() {
+            LockableResourcesStruct struct = LockableResourcesManager.get().getResourceForQueuedContext(getContext());
+            if (struct == null) {
+                return "waiting without a pending lock";
+            } else {
+                if (struct.label != null) {
+                    return "waiting on label " + struct.label;
+                } else {
+                    return "waiting on resources " + struct.required;
+                }
+            }
+        }
+
+        public static void proceed(@Nonnull List<String> resourceNames, @Nonnull StepContext context,
+                                   @CheckForNull String resourceDescription, boolean inversePrecedence) {
+            try {
+                context.get(TaskListener.class).getLogger().println("Lock acquired on [" + resourceDescription + "]");
+                context.get(FlowNode.class).addAction(new LockedResourcesAction(resourceNames, resourceDescription, inversePrecedence));
+                context.onSuccess(null);
+            } catch (Exception e) {
+                context.onFailure(e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/GetLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/GetLockStep.java
@@ -5,6 +5,7 @@ import hudson.Util;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import org.jenkins.plugins.lockableresources.actions.LockedFlowNodeAction;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -135,7 +136,7 @@ public class GetLockStep extends Step {
         public void stop(@Nonnull Throwable cause) {
             boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
             if (!cleaned) {
-                LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource witing list. The context is not in the waiting list.");
+                LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource waiting list. The context is not in the waiting list.");
             }
             getContext().onFailure(cause);
 
@@ -159,7 +160,7 @@ public class GetLockStep extends Step {
                                    @CheckForNull String resourceDescription, boolean inversePrecedence) {
             try {
                 context.get(TaskListener.class).getLogger().println("Lock acquired on [" + resourceDescription + "]");
-                context.get(FlowNode.class).addAction(new LockedResourcesAction(resourceNames, resourceDescription, inversePrecedence));
+                context.get(FlowNode.class).addAction(new LockedFlowNodeAction(resourceNames, resourceDescription, inversePrecedence));
                 context.onSuccess(null);
             } catch (Exception e) {
                 context.onFailure(e);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -33,21 +33,8 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 	public boolean start() throws Exception {
 		step.validate();
 
-		listener.getLogger().println("Trying to acquire lock on [" + step + "]");
-		List<String> resources = new ArrayList<String>();
-		if (step.resource != null) {
-			if (LockableResourcesManager.get().createResource(step.resource)) {
-				listener.getLogger().println("Resource [" + step + "] did not exist. Created.");
-			}
-			resources.add(step.resource);
-		}
-		LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, step.label, step.quantity);
-		// determine if there are enough resources available to proceed
-		List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
-		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.inversePrecedence)) {
-			listener.getLogger().println("[" + step + "] is locked, waiting...");
-			LockableResourcesManager.get().queueContext(getContext(), resourceHolder, step.toString());
-		} // proceed is called inside lock if execution is possible
+		LockUtils.queueLock(step, step.resource, step.label, step.quantity, step.inversePrecedence, getContext());
+
 		return false;
 	}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -81,7 +81,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 	public void stop(Throwable cause) throws Exception {
 		boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
 		if (!cleaned) {
-			LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource witing list. The context is not in the waiting list.");
+			LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource waiting list. The context is not in the waiting list.");
 		}
 		getContext().onFailure(cause);
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockUtils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockUtils.java
@@ -1,0 +1,44 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
+import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LockUtils {
+
+    public static void queueLock(@Nonnull Step step, @CheckForNull String resource, String label, int quantity,
+                                 boolean inversePrecedence, @Nonnull StepContext context) throws Exception {
+        Run<?,?> run = context.get(Run.class);
+        TaskListener listener = context.get(TaskListener.class);
+
+        if (listener == null) {
+            throw new MissingContextVariableException(TaskListener.class);
+        }
+
+        boolean nonBlock = step instanceof GetLockStep;
+        listener.getLogger().println("Trying to acquire lock on [" + step + "]");
+        List<String> resources = new ArrayList<String>();
+        if (resource != null) {
+            if (LockableResourcesManager.get().createResource(resource)) {
+                listener.getLogger().println("Resource [" + step + "] did not exist. Created.");
+            }
+            resources.add(resource);
+        }
+        LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, label, quantity);
+        // determine if there are enough resources available to proceed
+        List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
+        if (available == null || !LockableResourcesManager.get().lock(available, run, context, step.toString(), inversePrecedence,
+                nonBlock)) {
+            listener.getLogger().println("[" + step + "] is locked, waiting...");
+            LockableResourcesManager.get().queueContext(context, resourceHolder, step.toString(), nonBlock);
+        } // proceed is called inside lock if execution is possible
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -10,7 +10,6 @@ package org.jenkins.plugins.lockableresources;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import java.io.IOException;
@@ -427,7 +426,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			freeResources(freeResources, build);
 
 			// continue with next context
-			if (nextContext.isNonBlock()) {
+			if (nextContext.isNonBlockScoped()) {
 				GetLockStep.Execution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(),
 						inversePrecedence);
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockedResourcesAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockedResourcesAction.java
@@ -1,0 +1,44 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.model.InvisibleAction;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LockedResourcesAction extends InvisibleAction {
+    private List<String> resourceNames = new ArrayList<>();
+    private boolean inversePrecedence;
+    private String resourceDescription;
+    private boolean released;
+
+    public LockedResourcesAction(@Nonnull List<String> resourceNames, @CheckForNull String resourceDescription,
+                                 boolean inversePrecedence) {
+        this.resourceNames.addAll(resourceNames);
+        this.resourceDescription = resourceDescription;
+        this.inversePrecedence = inversePrecedence;
+    }
+
+    @Nonnull
+    public List<String> getResourceNames() {
+        return resourceNames;
+    }
+
+    @CheckForNull
+    public String getResourceDescription() {
+        return resourceDescription;
+    }
+
+    public boolean isInversePrecedence() {
+        return inversePrecedence;
+    }
+
+    public void release() {
+        this.released = true;
+    }
+
+    public boolean isReleased() {
+        return released;
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
@@ -1,0 +1,81 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.LinearScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class ReleaseLockStep extends Step {
+
+    @DataBoundConstructor
+    public ReleaseLockStep() {
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new ReleaseLockStep.Execution(context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "releaseLock";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Releases the previous lock acquired by the getLock step";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+
+    }
+
+    public static class Execution extends SynchronousStepExecution<Void> {
+
+        Execution(StepContext context) {
+            super(context);
+        }
+
+        @Override
+        public Void run() throws Exception {
+            FlowNode thisNode = getContext().get(FlowNode.class);
+            LinearScanner scanner = new LinearScanner();
+
+            FlowNode getLock = scanner.findFirstMatch(thisNode, new NodeStepTypePredicate("getLock"));
+
+            if (getLock != null) {
+                LockedResourcesAction action = getLock.getAction(LockedResourcesAction.class);
+                if (action != null && !action.isReleased()) {
+                    LockableResourcesManager.get().unlockNames(action.getResourceNames(), getContext().get(Run.class),
+                            action.isInversePrecedence());
+                    action.release();
+                    getContext().get(TaskListener.class).getLogger()
+                            .println("Lock released on resource [" + action.getResourceDescription()+ "]");
+                } else {
+                    // Last getLock has no action, meaning it never really locked anything, so...eh?
+                    getContext().get(TaskListener.class).getLogger().println("No active lock, proceeding.");
+                }
+            } else {
+                // No previous lock step, so we should error out, maybe? Not sure yet. Just gonna log for now.
+                getContext().get(TaskListener.class).getLogger().println("No previous getLock step, proceeding.");
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.lockableresources;
 import hudson.Extension;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.jenkins.plugins.lockableresources.actions.LockedFlowNodeAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
@@ -60,7 +61,7 @@ public class ReleaseLockStep extends Step {
             FlowNode getLock = scanner.findFirstMatch(thisNode, new NodeStepTypePredicate("getLock"));
 
             if (getLock != null) {
-                LockedResourcesAction action = getLock.getAction(LockedResourcesAction.class);
+                LockedFlowNodeAction action = getLock.getAction(LockedFlowNodeAction.class);
                 if (action != null && !action.isReleased()) {
                     LockableResourcesManager.get().unlockNames(action.getResourceNames(), getContext().get(Run.class),
                             action.isInversePrecedence());

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedFlowNodeAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedFlowNodeAction.java
@@ -1,4 +1,4 @@
-package org.jenkins.plugins.lockableresources;
+package org.jenkins.plugins.lockableresources.actions;
 
 import hudson.model.InvisibleAction;
 
@@ -7,14 +7,14 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LockedResourcesAction extends InvisibleAction {
+public class LockedFlowNodeAction extends InvisibleAction {
     private List<String> resourceNames = new ArrayList<>();
     private boolean inversePrecedence;
     private String resourceDescription;
     private boolean released;
 
-    public LockedResourcesAction(@Nonnull List<String> resourceNames, @CheckForNull String resourceDescription,
-                                 boolean inversePrecedence) {
+    public LockedFlowNodeAction(@Nonnull List<String> resourceNames, @CheckForNull String resourceDescription,
+                                boolean inversePrecedence) {
         this.resourceNames.addAll(resourceNames);
         this.resourceDescription = resourceDescription;
         this.inversePrecedence = inversePrecedence;

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -15,57 +15,75 @@ import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-/* 
+/**
  * This class is used to queue pipeline contexts 
  * which shall be executed once the necessary
  * resources are free'd.
  */
 public class QueuedContextStruct implements Serializable {
 
-	/*
+	/**
 	 * Reference to the pipeline step context.
 	 */
 	private StepContext context;
 	
-	/*
+	/**
 	 * Reference to the resources required by the step context.
 	 */
 	private LockableResourcesStruct lockableResourcesStruct;
 	
-	/*
+	/**
 	 * Description of the required resources used within logging messages.
 	 */
 	private String resourceDescription;
 
-	/*
+	/**
+	 * True if the relevant step is "getLock" rather than "lock"
+	 */
+	private boolean nonBlock = false;
+
+	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription) {
+		this(context, lockableResourcesStruct, resourceDescription, false);
+	}
+
+	/**
 	 * Constructor for the QueuedContextStruct class.
 	 */
-	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription) {
+	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription,
+							   boolean nonBlock) {
 		this.context = context;
 		this.lockableResourcesStruct = lockableResourcesStruct;
 		this.resourceDescription = resourceDescription;
+		this.nonBlock = nonBlock;
 	}
 	
-	/*
+	/**
 	 * Gets the pipeline step context.
 	 */
 	public StepContext getContext() {
 		return this.context;
 	}
 	
-	/*
+	/**
 	 * Gets the required resources.
 	 */
 	public LockableResourcesStruct getResources() {
 		return this.lockableResourcesStruct;
 	}
 
-	/*
+	/**
 	 * Gets the resource description for logging messages.
 	 */
 	public String getResourceDescription() {
 		return this.resourceDescription;
 	}
-	
+
+	/**
+	 * True if the relevant step is "getLock" (and therefore not block-scoped)
+	 */
+	public boolean isNonBlock() {
+		return nonBlock;
+	}
+
 	private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -11,9 +11,6 @@ package org.jenkins.plugins.lockableresources.queue;
 import java.io.Serializable;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * This class is used to queue pipeline contexts 
@@ -40,7 +37,7 @@ public class QueuedContextStruct implements Serializable {
 	/**
 	 * True if the relevant step is "getLock" rather than "lock"
 	 */
-	private boolean nonBlock = false;
+	private boolean nonBlockScoped = false;
 
 	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription) {
 		this(context, lockableResourcesStruct, resourceDescription, false);
@@ -50,11 +47,11 @@ public class QueuedContextStruct implements Serializable {
 	 * Constructor for the QueuedContextStruct class.
 	 */
 	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription,
-							   boolean nonBlock) {
+							   boolean nonBlockScoped) {
 		this.context = context;
 		this.lockableResourcesStruct = lockableResourcesStruct;
 		this.resourceDescription = resourceDescription;
-		this.nonBlock = nonBlock;
+		this.nonBlockScoped = nonBlockScoped;
 	}
 	
 	/**
@@ -81,8 +78,8 @@ public class QueuedContextStruct implements Serializable {
 	/**
 	 * True if the relevant step is "getLock" (and therefore not block-scoped)
 	 */
-	public boolean isNonBlock() {
-		return nonBlock;
+	public boolean isNonBlockScoped() {
+		return nonBlockScoped;
 	}
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
[JENKINS-43336](https://issues.jenkins-ci.org/browse/JENKINS-43336)

This is specifically to support usage of locking across stages in
Declarative. The use case is something like this:
```
stage('foo') {
  steps {
    getLock resource:'some-resource'
    // do some other stuff
  }
}

stage('bar') {
  steps {
    // do some other stuff
    releaseLock()
  }
}
```

- [x] Implementation.
- [ ] Tests (both of `getLock`/`releaseLock` and interoperability between them, the block-scoped `lock` step, and locking freestyle builds).
- [ ] Snippet generator/`help.html`.

cc @reviewbybees and @jglick (who I'd like to assign as a reviewer but can't because he's not a contributor to the repo!)
