### PR TITLE
[JENKINS-46494] Add guard in LockableResourcesManager that avoid locking more resources than required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
 			<version>1.13</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.24</version>
+		<version>2.29</version>
 		<relativePath />
 	</parent>
 
@@ -116,16 +116,16 @@
 			<version>1.6</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.7.22</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency><!-- Required when testing against core > 1.575 -->
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.13</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
+			<version>1.20</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -571,7 +571,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		// start with an empty set of selected resources
 		List<LockableResource> selected = new ArrayList<LockableResource>();
 
-		// some resources might be already locked, but will be freeed.
+		// some resources might be already locked, but will be freed.
 		// Determine if these resources can be reused
 		if (lockedResourcesAboutToBeUnlocked != null) {
 			for (LockableResource candidate : candidates) {
@@ -579,7 +579,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 					selected.add(candidate);
 				}
 			}
-			// if none of the currently locked resources can be reussed,
+			// if none of the currently locked resources can be reused,
 			// this context is not suitable to be continued with
 			if (selected.size() == 0) {
 				return null;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -588,6 +588,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 		for (LockableResource rs : candidates) {
 			if (selected.size() >= requiredAmount) {
+				if (requiredAmount != 0 && selected.size() > requiredAmount) {
+					selected = selected.subList(0, requiredAmount);
+				}
 				break;
 			}
 			if (!rs.isReserved() && !rs.isLocked()) {

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Aki Asikainen.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins.plugins.lockableresources;
+
+import static org.mockito.Mockito.*;
+import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
+import org.junit.*;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * @author Marcus Antonsson
+ */
+public class LockableResourcesManagerTest {
+
+	LockableResourcesManager resourceManager;
+
+	public LockableResourcesManagerTest() {	}
+
+	@Before
+	public void setUp() {
+		resourceManager = mock(LockableResourcesManager.class);
+	}
+
+	@Test
+	public void checkAvailabilityShouldNotReturnMoreThanRequiredResources() {
+		// Configure partial mock for SUT and mock underlying classes
+		when(resourceManager.checkResourcesAvailability(any(LockableResourcesStruct.class), isNull(PrintStream.class), any(ArrayList.class)))
+				.thenCallRealMethod();
+
+		ArrayList<LockableResource> candidateList = new ArrayList<LockableResource>();
+
+		// In order to create resources named r0, r1, ..., r(n)
+		for (int i = 0; i < 5; ++i) {
+			LockableResource l = mock(LockableResource.class);
+			when(l.getName()).thenReturn("r" + i);
+			candidateList.add(l);
+		}
+
+		when(resourceManager.getResourcesWithLabel(any(String.class), any(Map.class)))
+				.thenReturn(candidateList);
+
+		LockableResourcesStruct resourceStructMock = mock(LockableResourcesStruct.class);
+		resourceStructMock.label = "LABEL";
+		resourceStructMock.requiredNumber = "2";
+
+		// Size of soonToBeUnlocked need to be lower than requiredNumber
+		ArrayList<String> soonToBeUnlockedList = new ArrayList<>();
+		soonToBeUnlockedList.add("r1");
+		soonToBeUnlockedList.add("r2");
+		soonToBeUnlockedList.add("r4");
+
+		List<LockableResource> lockableResources = resourceManager.checkResourcesAvailability(resourceStructMock, null, soonToBeUnlockedList);
+
+		// Make sure that the manager can figure out we need 2 resources even though there are more on the way
+		Assert.assertNotNull(lockableResources);
+		Assert.assertEquals(2, lockableResources.size());
+	}
+
+	@Test
+	public void checkAvailabilityShouldReturnNullResources() {
+		// Configure partial mock for SUT and mock underlying classes
+		when(resourceManager.checkResourcesAvailability(any(LockableResourcesStruct.class), isNull(PrintStream.class), any(ArrayList.class)))
+				.thenCallRealMethod();
+
+		ArrayList<LockableResource> candidateList = new ArrayList<LockableResource>();
+
+		// In order to create resources named r0, r1, ..., r(n)
+		for (int i = 0; i < 5; ++i) {
+			LockableResource l = mock(LockableResource.class);
+			when(l.getName()).thenReturn("r" + i);
+			candidateList.add(l);
+		}
+
+		when(resourceManager.getResourcesWithLabel(any(String.class), any(Map.class)))
+				.thenReturn(candidateList);
+
+		LockableResourcesStruct resourceStructMock = mock(LockableResourcesStruct.class);
+		resourceStructMock.label = "LABEL";
+		resourceStructMock.requiredNumber = "10";
+
+		// Size of soonToBeUnlocked need to be lower than requiredNumber
+		ArrayList<String> soonToBeUnlockedList = new ArrayList<>();
+		soonToBeUnlockedList.add("r1");
+		soonToBeUnlockedList.add("r2");
+		soonToBeUnlockedList.add("r4");
+
+		List<LockableResource> lockableResources = resourceManager.checkResourcesAvailability(resourceStructMock, null, soonToBeUnlockedList);
+
+		// There are not enough resources to meet requirement so return value should be null
+		Assert.assertNull(lockableResources);
+	}
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
@@ -27,6 +27,7 @@ package org.jenkins.plugins.lockableresources;
 import static org.mockito.Mockito.*;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.junit.*;
+import org.mockito.ArgumentMatchers;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -51,7 +52,8 @@ public class LockableResourcesManagerTest {
 	@Test
 	public void checkAvailabilityShouldNotReturnMoreThanRequiredResources() {
 		// Configure partial mock for SUT and mock underlying classes
-		when(resourceManager.checkResourcesAvailability(any(LockableResourcesStruct.class), isNull(PrintStream.class), any(ArrayList.class)))
+		when(resourceManager.checkResourcesAvailability(any(LockableResourcesStruct.class),
+			ArgumentMatchers.<PrintStream>isNull(), any(ArrayList.class)))
 				.thenCallRealMethod();
 
 		ArrayList<LockableResource> candidateList = new ArrayList<LockableResource>();
@@ -63,7 +65,7 @@ public class LockableResourcesManagerTest {
 			candidateList.add(l);
 		}
 
-		when(resourceManager.getResourcesWithLabel(any(String.class), any(Map.class)))
+		when(resourceManager.getResourcesWithLabel(any(String.class), ArgumentMatchers.<Map<String, Object>>isNull()))
 				.thenReturn(candidateList);
 
 		LockableResourcesStruct resourceStructMock = mock(LockableResourcesStruct.class);
@@ -76,10 +78,11 @@ public class LockableResourcesManagerTest {
 		soonToBeUnlockedList.add("r2");
 		soonToBeUnlockedList.add("r4");
 
-		List<LockableResource> lockableResources = resourceManager.checkResourcesAvailability(resourceStructMock, null, soonToBeUnlockedList);
+		List<LockableResource> lockableResources = resourceManager.checkResourcesAvailability(resourceStructMock,
+				null, soonToBeUnlockedList);
 
 		// Make sure that the manager can figure out we need 2 resources even though there are more on the way
-		Assert.assertNotNull(lockableResources);
+		Assert.assertNotNull("checkResourcesAvailability returned null when expecting a list of LockableResources", lockableResources);
 		Assert.assertEquals(2, lockableResources.size());
 	}
 


### PR DESCRIPTION
Without the check, in certain edge cases the resource manager would lock more resources than it actually require

Can be recreated using the following pipeline and trigger a bunch of them using different NUM_RESOURCES as values. 
I had 4 resources with label "xmamama" configured. 

After about 4-10 builds the error will start to appear.

```
properties([
    parameters ([
        string(name: 'NUM_RESOURCES')
    ])
]);

node {
    def askFor = params.NUM_RESOURCES as Integer
    lock(label: "xmamama", quantity: askFor) {
        def clients = org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())
        echo("Asked for ${askFor} resources, got ${clients.size()}: ${clients.toString()}")
        sleep (60 * 10)
        if (askFor != clients.size()) {
            error ("Wrong amount of resources aquired")
        }
    }
}
```

![image](https://user-images.githubusercontent.com/29950178/27915920-ee07c06e-6267-11e7-9fcb-dde8e805e601.png)
