### PR TITLE
Trim trailing whitespace in resourcenames

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -43,7 +43,11 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			String resourceNamesVar, String resourceNumber,
 			String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
 		super();
-		this.resourceNames = resourceNames;
+		if (resourceNames != null) {
+			this.resourceNames = resourceNames.trim();
+		} else {
+			this.resourceNames = null;
+		}
 		this.resourceNamesVar = resourceNamesVar;
 		this.resourceNumber = resourceNumber;
 		if (resourceMatchScript != null) {


### PR DESCRIPTION
If not trimmed, the trailing whitespace will find it's way
to the jobs config.xml, causing confusion.

Trailing whitespaces in resourcenames are caused also by the
autocompletion script, that suggests resourcenames.

JIRA Issue: https://issues.jenkins-ci.org/browse/JENKINS-47235