### PR TITLE
add the permission control of viewing lockable resources

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -45,15 +45,15 @@ public class LockableResourcesRootAction implements RootAction {
 			Messages._LockableResourcesRootAction_ReservePermission_Description(), Jenkins.ADMINISTER,
 			PermissionScope.JENKINS);
 
+	public static final Permission VIEW = new Permission(PERMISSIONS_GROUP,
+			Messages.LockableResourcesRootAction_ViewPermission(),
+			Messages._LockableResourcesRootAction_ViewPermission_Description(), Jenkins.ADMINISTER,
+			PermissionScope.JENKINS);
+	
 	public static final String ICON = "/plugin/lockable-resources/img/device-24x24.png";
 
 	public String getIconFileName() {
-		if (User.current() != null) {
-			// only show if logged in
-			return ICON;
-		} else {
-			return null;
-		}
+		return (Jenkins.getInstance().hasPermission(VIEW)) ? ICON : null;
 	}
 
 	public String getUserName() {
@@ -69,7 +69,7 @@ public class LockableResourcesRootAction implements RootAction {
 	}
 
 	public String getUrlName() {
-		return "lockable-resources";
+		return (Jenkins.getInstance().hasPermission(VIEW)) ? "lockable-resources" : "";
 	}
 
 	public List<LockableResource> getResources() {

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
@@ -14,3 +14,7 @@ LockableResourcesRootAction.UnlockPermission.Description=This permission grants 
 LockableResourcesRootAction.ReservePermission=Reserve
 LockableResourcesRootAction.ReservePermission.Description=This permission grants the ability to manually \
   reserve lockable resources outside of a build.
+LockableResourcesRootAction.ViewPermission=View
+LockableResourcesRootAction.ViewPermission.Description=This permission grants the ability to view \
+  lockable resources.
+  


### PR DESCRIPTION
It won't show the lockable resources action when no security realm setting. 
I use the permission checking in Jenkins to make this work
and add the view permission to be more flexible.