### PR TITLE
Lock with priority

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -38,7 +38,7 @@ public final class BackwardCompatibility {
 					List<String> resourcesNames = new ArrayList<String>();
 					resourcesNames.add(resource.getName());
 					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-					LockableResourcesManager.get().queueContext(queuedContext, resourceHolder, resource.getName());
+					LockableResourcesManager.get().queueContext(queuedContext, resourceHolder, resource.getName(), 0);
 				}
 				queuedContexts.clear();
 			}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -28,6 +28,8 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 
 	public boolean inversePrecedence = false;
 
+	public int lockPriority = 0;
+
 	// it should be LockStep() - without params. But keeping this for backward compatibility
 	// so `lock('resource1')` still works and `lock(label: 'label1', quantity: 3)` works too (resource is not required)
 	@DataBoundConstructor
@@ -40,6 +42,11 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	@DataBoundSetter
 	public void setInversePrecedence(boolean inversePrecedence) {
 		this.inversePrecedence = inversePrecedence;
+	}
+
+	@DataBoundSetter
+	public void setLockPriority(int lockPriority) {
+		this.lockPriority = lockPriority;
 	}
 
 	@DataBoundSetter
@@ -98,26 +105,34 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	}
 
 	public String toString() {
+		StringBuilder instanceString = new StringBuilder();
 		// a label takes always priority
 		if (this.label != null) {
-			if (this.quantity > 0) {
-				return "Label: " + this.label + ", Quantity: " + this.quantity;
-			}
-			return "Label: " + this.label;
+			instanceString.append("Label: ").append(this.label);
+		} else if (this.resource != null) {
+			instanceString.append(this.resource);
+		} else {
+			return "[no resource/label specified - probably a bug]";
 		}
-		// make sure there is an actual resource specified
-		if (this.resource != null) {
-			return this.resource;
+		if (this.quantity > 0) {
+			 instanceString.append(", Quantity: ").append(this.quantity);
 		}
-		return "[no resource/label specified - probably a bug]";
+		if (this.lockPriority > 0) {
+			instanceString.append(", LockPriority: ").append(this.lockPriority);
+		}
+		return instanceString.toString();
 	}
 
 	/**
-	 * Label and resource are mutual exclusive.
+	 * Label and resource are mutually exclusive.
+	 * LockPriority must be positive
 	 */
 	public void validate() throws Exception {
 		if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
 			throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
+		}
+		if (this.lockPriority < 0) {
+			throw new IllegalArgumentException("LockPriority must be 0 or positive");
 		}
 	}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -46,7 +46,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
 		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.inversePrecedence)) {
 			listener.getLogger().println("[" + step + "] is locked, waiting...");
-			LockableResourcesManager.get().queueContext(getContext(), resourceHolder, step.toString());
+			LockableResourcesManager.get().queueContext(getContext(), resourceHolder, step.toString(), step.lockPriority);
 		} // proceed is called inside lock if execution is possible
 		return false;
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -572,27 +572,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		// start with an empty set of selected resources
 		List<LockableResource> selected = new ArrayList<LockableResource>();
 
-		// some resources might be already locked, but will be freeed.
-		// Determine if these resources can be reused
-		if (lockedResourcesAboutToBeUnlocked != null) {
-			for (LockableResource candidate : candidates) {
-				if (lockedResourcesAboutToBeUnlocked.contains(candidate.getName())) {
-					selected.add(candidate);
-				}
-			}
-			// if none of the currently locked resources can be reussed,
-			// this context is not suitable to be continued with
-			if (selected.size() == 0) {
-				return null;
-			}
-		}
-
-		for (LockableResource rs : candidates) {
+		// Check resource candidates if they are not reserved and not locked or are about to be unlocked
+		for (LockableResource candidate : candidates) {
 			if (selected.size() >= requiredAmount) {
 				break;
 			}
-			if (!rs.isReserved() && !rs.isLocked()) {
-				selected.add(rs);
+			if ((!candidate.isReserved() && !candidate.isLocked()) ||
+					(lockedResourcesAboutToBeUnlocked != null && lockedResourcesAboutToBeUnlocked.contains(candidate.getName()))) {
+				selected.add(candidate);
 			}
 		}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -38,6 +38,11 @@ public class QueuedContextStruct implements Serializable {
 	private String resourceDescription;
 
 	/*
+	 * Priority this context should have in the queue. Lowest priority being 0.
+	 */
+	private int lockPriority = 0;
+
+	/*
 	 * Constructor for the QueuedContextStruct class.
 	 */
 	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription) {
@@ -45,7 +50,17 @@ public class QueuedContextStruct implements Serializable {
 		this.lockableResourcesStruct = lockableResourcesStruct;
 		this.resourceDescription = resourceDescription;
 	}
-	
+
+	/*
+	 * Constructor for the QueuedContextStruct class.
+	 */
+	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription, int lockPriority) {
+		this.context = context;
+		this.lockableResourcesStruct = lockableResourcesStruct;
+		this.resourceDescription = resourceDescription;
+		this.lockPriority = lockPriority;
+	}
+
 	/*
 	 * Gets the pipeline step context.
 	 */
@@ -66,6 +81,10 @@ public class QueuedContextStruct implements Serializable {
 	public String getResourceDescription() {
 		return this.resourceDescription;
 	}
-	
+
+	public int getLockPriority() {
+		return this.lockPriority;
+	}
+
 	private static final long serialVersionUID = 1L;
 }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -13,4 +13,7 @@
 	<f:entry title="${%Inverse precedence}" field="inversePrecedence">
 		<f:checkbox/>
 	</f:entry>
+	<f:entry title="${%Lock Priority}" field="lockPriority">
+		<f:number/>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-lockPriority.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-lockPriority.html
@@ -1,0 +1,9 @@
+<div>
+	<p>
+		By default waiting builds get the lock in the same order they requested to acquire it.
+		By specifying a higher priority, a waiting build will acquire a lock before lower
+		priority builds. Builds with the same priority still get lock in the order they were
+		requested.
+		Priority must be 0 or higher. 0 being the lowest priority.
+	</p>
+</div>


### PR DESCRIPTION
This adds an optional lockPriority integer parameter to the lock function. Defaults to 0, which is the lowest priority.
Higher priority lock requests will be processed before lower priority requests, but those with the same priority, will be processed in the order they were requested.
e.g.
```lock(resource: 'resource1', lockPriority: 10)```

Also included in the PR is a fix for free resources being re-assigned. I noticed the problem as I was writing the tests for this functionality. Included in the commit is a test that would fail without the changes to LockableResourcesManager.

The ability to prioritise lock requests is important to some of our workflows, so we have been running with this functionality merged in for a while.
In our case we use a labelled collection of locks to manage access to a pool of databases. When a build has finished with a db, a rebuild job needs to take the specific lock for that db as a high priority. When the db rebuild has completed, the lock is handed back to the pool for any jobs that are waiting on the pool at a lower priority.

This addresses #61 
