### PR TITLE
Log the QueuedContexts collection each time it changes and add a panel to the LockableResources page on Jenkins UI to display the QueuedContexts

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -361,7 +361,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		// remove context from queue and process it
 		requiredResourceForNextContext = checkResourcesAvailability(nextContext.getResources(), null, resourceNamesToUnLock);
 		this.queuedContexts.remove(nextContext);
-			
+		LOGGER.log(Level.INFO, "Queued Contexts " + this.queuedContexts);
+
 		// resourceNamesToUnlock contains the names of the previous resources.
 		// requiredResourceForNextContext contains the resource objects which are required for the next context.
 		// It is guaranteed that there is an overlap between the two - the resources which are to be reused.
@@ -618,6 +619,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		this.queuedContexts.add(new QueuedContextStruct(context, requiredResources, resourceDescription));
+		LOGGER.log(Level.INFO, "Queued Contexts " + this.queuedContexts);
 		save();
 	}
 
@@ -625,6 +627,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		for (Iterator<QueuedContextStruct> iter = this.queuedContexts.listIterator(); iter.hasNext(); ) {
 			if (iter.next().getContext() == context) {
 				iter.remove();
+				LOGGER.log(Level.INFO, "Queued Contexts " + this.queuedContexts);
 				save();
 				return true;
 			}
@@ -635,6 +638,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	public static LockableResourcesManager get() {
 		return (LockableResourcesManager) Jenkins.getInstance()
 				.getDescriptorOrDie(LockableResourcesManager.class);
+	}
+
+	public synchronized int getQueuedContextsSize() {
+		return this.queuedContexts.size();
+	}
+
+	public synchronized ArrayList<QueuedContextStruct> getQueuedContexts() {
+		return new ArrayList<>(this.queuedContexts);
 	}
 
 	public synchronized void save() {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -28,6 +28,7 @@ import jenkins.model.Jenkins;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.Messages;
+import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -86,6 +87,14 @@ public class LockableResourcesRootAction implements RootAction {
 
 	public int getNumberOfAllLabels() {
 		return LockableResourcesManager.get().getAllLabels().size();
+	}
+
+	public ArrayList<QueuedContextStruct> getQueuedContexts() {
+		return LockableResourcesManager.get().getQueuedContexts();
+	}
+
+	public int getNumberQueuedContexts() {
+		return LockableResourcesManager.get().getQueuedContextsSize();
 	}
 
 	public void doUnlock(StaplerRequest req, StaplerResponse rsp)

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -8,18 +8,24 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources.queue;
 
+import java.io.IOException;
 import java.io.Serializable;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /* 
  * This class is used to queue pipeline contexts 
  * which shall be executed once the necessary
  * resources are free'd.
  */
+@ExportedBean(defaultVisibility = 999)
 public class QueuedContextStruct implements Serializable {
 
 	/*
@@ -37,6 +43,10 @@ public class QueuedContextStruct implements Serializable {
 	 */
 	private String resourceDescription;
 
+	// build information in the requesting context. Useful for displaying on the ui and logging
+	private transient volatile Run<?, ?> build = null;
+	private transient volatile String buildExternalizableId = null;
+
 	/*
 	 * Constructor for the QueuedContextStruct class.
 	 */
@@ -52,7 +62,36 @@ public class QueuedContextStruct implements Serializable {
 	public StepContext getContext() {
 		return this.context;
 	}
-	
+
+	@Exported
+	public String getBuildExternalizableId() {
+		if (this.buildExternalizableId == null) {
+			// getting the externalizableId can fail for many reasons, set to null if it fails for some reason
+			try {
+				buildExternalizableId = this.context.get(Run.class).getExternalizableId();
+			} catch (Exception e) {
+				buildExternalizableId = null;
+			}
+		}
+		return this.buildExternalizableId;
+	}
+
+	@WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
+	public Run<?, ?> getBuild() {
+		if (build == null) {
+			build = Run.fromExternalizableId(getBuildExternalizableId());
+		}
+		return build;
+	}
+
+	@Exported
+	public String getBuildName() {
+		if (getBuild() != null)
+			return getBuild().getFullDisplayName();
+		else
+			return null;
+	}
+
 	/*
 	 * Gets the required resources.
 	 */
@@ -63,9 +102,15 @@ public class QueuedContextStruct implements Serializable {
 	/*
 	 * Gets the resource description for logging messages.
 	 */
+	@Exported
 	public String getResourceDescription() {
 		return this.resourceDescription;
 	}
 	
 	private static final long serialVersionUID = 1L;
+
+	@Override
+	public String toString() {
+		return "Build(" + getBuildExternalizableId() + ") Resource(" + resourceDescription + ")";
+	}
 }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -131,6 +131,31 @@ function reset_resource_${i}() {
 			</table>
 </j:if>
 
+<h3>Resource queue</h3>
+<j:choose>
+    <j:when test="${it.getNumberQueuedContexts() != 0}">
+       <table class="pane" style="width: 50%;">
+            <tbody>
+                <tr>
+                    <td class="pane-header">Resource requested</td>
+                    <td class="pane-header">Requested by</td>
+                </tr>
+                <j:forEach var="context" items="${it.getQueuedContexts()}">
+                    <tr>
+                        <td class="pane" >${context.resourceDescription}</td>
+                        <td class="pane" >
+                            <a href="${rootURL}/${context.build.url}">
+                                ${context.build.fullDisplayName}
+                            </a>
+                        </td>
+                    </tr>
+                </j:forEach>
+            </tbody>
+        </table>
+    </j:when>
+    <j:otherwise><h4>Empty</h4></j:otherwise>
+</j:choose>
+
 		</l:main-panel>
 	</l:layout>
 </j:jelly>


### PR DESCRIPTION
Logging the queued contexts is useful in debugging problems in a running system as well as when writing tests.

Displaying the resource queue on the Jenkins UI is useful to  understand any backlogs that are occurring.
This is what it looks like in the UI. 
Note this is showing lock priorities in the UI, just because I was running against a version of the code that had my lock priority change in. That is in a separate PR. This PR doesn't depend on it.

![image](https://user-images.githubusercontent.com/1135376/31796398-3bb20cb4-b521-11e7-9f49-9a2967859171.png)

This addresses #69 