### PR TITLE
Fix locking for freestyle jobs

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -158,12 +158,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	}
 
 	public synchronized boolean queue(List<LockableResource> resources,
-			long queueItemId) {
+			long queueItemId, String queueProjectName) {
 		for (LockableResource r : resources)
 			if (r.isReserved() || r.isQueued(queueItemId) || r.isLocked())
 				return false;
-		for (LockableResource r : resources)
-			r.setQueued(queueItemId);
+		for (LockableResource r : resources) {
+			r.setQueued(queueItemId, queueProjectName);
+		}
 		return true;
 	}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -140,7 +140,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 			}
 
 		} else {
-			if (LockableResourcesManager.get().queue(resources.required, item.getId())) {
+			if (LockableResourcesManager.get().queue(resources.required, item.getId(), project.getFullDisplayName())) {
 				LOGGER.finest(project.getName() + " reserved resources " + resources.required);
 				return null;
 			} else {


### PR DESCRIPTION
Freestyle jobs did not hold the resource locks properly,
as they did not record the queueProjectName to the queue.
Any blocked jobs would give up waiting after QUEUE_TIMEOUT
seconds in the queue, even if there was a job blocking.

Fixes: JENKINS-47754