### PR TITLE
Locking multiple resources in pipeline

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -13,6 +13,7 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -38,7 +39,7 @@ public final class BackwardCompatibility {
 					List<String> resourcesNames = new ArrayList<String>();
 					resourcesNames.add(resource.getName());
 					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-					LockableResourcesManager.get().queueContext(queuedContext, resourceHolder, resource.getName());
+					LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName());
 				}
 				queuedContexts.clear();
 			}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -22,12 +22,12 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 public class LockStep extends AbstractStepImpl implements Serializable {
 
 	@CheckForNull
-	private String resource = null;
+	public String resource = null;
 
 	@CheckForNull
-	private String label = null;
+	public String label = null;
 
-	private int quantity = 0;
+	public int quantity = 0;
 
 	/** name of environment variable to store locked resources in */
 	@CheckForNull
@@ -36,7 +36,7 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	public boolean inversePrecedence = false;
 
 	@CheckForNull
-	private List<LockStepResource> extra = null;
+	public List<LockStepResource> extra = null;
 
 	// it should be LockStep() - without params. But keeping this for backward compatibility
 	// so `lock('resource1')` still works and `lock(label: 'label1', quantity: 3)` works too (resource is not required)
@@ -129,11 +129,11 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 	public void validate() throws Exception {
 		LockStepResource.validate(resource, label, quantity);
 	}
-	
+
 	public List<LockStepResource> getResources() {
 		List<LockStepResource> resources = new ArrayList<>();
 		resources.add(new LockStepResource(resource, label, quantity));
-		
+
 		if (extra != null) {
 			resources.addAll(extra);
 		}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.lockableresources;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,19 +48,25 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 
 		node.addAction(new PauseAction("Lock"));
 		listener.getLogger().println("Trying to acquire lock on [" + step + "]");
-		List<String> resources = new ArrayList<String>();
-		if (step.resource != null) {
-			if (LockableResourcesManager.get().createResource(step.resource)) {
-				listener.getLogger().println("Resource [" + step + "] did not exist. Created.");
+		
+		List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
+		
+		for (LockStepResource resource : step.getResources()) {
+			List<String> resources = new ArrayList<String>();
+			if (resource.resource != null) {
+				if (LockableResourcesManager.get().createResource(resource.resource)) {
+					listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
+				}
+				resources.add(resource.resource);
 			}
-			resources.add(step.resource);
+			resourceHolderList.add(new LockableResourcesStruct(resources, resource.label, resource.quantity));
 		}
-		LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, step.label, step.quantity);
+		
 		// determine if there are enough resources available to proceed
-		List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
+		Set<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
 		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.variable, step.inversePrecedence)) {
 			listener.getLogger().println("[" + step + "] is locked, waiting...");
-			LockableResourcesManager.get().queueContext(getContext(), resourceHolder, step.toString());
+			LockableResourcesManager.get().queueContext(getContext(), resourceHolderList, step.toString());
 		} // proceed is called inside lock if execution is possible
 		return false;
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -1,0 +1,122 @@
+package org.jenkins.plugins.lockableresources;
+
+import java.io.Serializable;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.Util;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+public class LockStepResource extends AbstractDescribableImpl<LockStepResource> implements Serializable {
+
+	@CheckForNull
+	public String resource = null;
+
+	@CheckForNull
+	public String label = null;
+
+	public int quantity = 0;
+
+	LockStepResource(String resource, String label, int quantity) {
+		this.resource = resource;
+		this.label = label;
+		this.quantity = quantity;
+	}
+
+	@DataBoundConstructor
+	public LockStepResource(String resource) {
+		if (resource != null && !resource.isEmpty()) {
+			this.resource = resource;
+		}
+	}
+
+	@DataBoundSetter
+	public void setLabel(String label) {
+		if (label != null && !label.isEmpty()) {
+			this.label = label;
+		}
+	}
+
+	@DataBoundSetter
+	public void setQuantity(int quantity) {
+		this.quantity = quantity;
+	}
+
+	public String toString() {
+		return toString(resource, label, quantity);
+	}
+	
+	public static String toString(String resource, String label, int quantity) {
+		// a label takes always priority
+		if (label != null) {
+			if (quantity > 0) {
+				return "Label: " + label + ", Quantity: " + quantity;
+			}
+			return "Label: " + label;
+		}
+		// make sure there is an actual resource specified
+		if (resource != null) {
+			return resource;
+		}
+		return "[no resource/label specified - probably a bug]";
+	}
+
+	/**
+	 * Label and resource are mutual exclusive.
+	 */
+	public void validate() throws Exception {
+		validate(resource, label, quantity);
+	}
+
+	/**
+	 * Label and resource are mutual exclusive.
+	 */
+	public static void validate(String resource, String label, int quantity) throws Exception {
+		if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
+			throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
+		}
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	@Extension
+	public static class DescriptorImpl extends Descriptor<LockStepResource> {
+
+		@Override
+		public String getDisplayName() {
+			return "Resource";
+		}
+
+		public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
+			return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+		}
+
+		public static FormValidation doCheckLabel(@QueryParameter String value, @QueryParameter String resource) {
+			String resourceLabel = Util.fixEmpty(value);
+			String resourceName = Util.fixEmpty(resource);
+			if (resourceLabel != null && resourceName != null) {
+				return FormValidation.error("Label and resource name cannot be specified simultaneously.");
+			}
+			if ((resourceLabel == null) && (resourceName == null)) {
+				return FormValidation.error("Either label or resource name must be specified.");
+			}
+			return FormValidation.ok();
+		}
+
+		public static FormValidation doCheckResource(@QueryParameter String value, @QueryParameter String label) {
+			return doCheckLabel(label, value);
+		}
+	}
+
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -531,8 +531,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		// check if there are resources which can be unlocked (and shall not be unlocked)
-		List<LockableResource> requiredResourceForNextContext = null;
-		QueuedContextStruct nextContext = this.getNextQueuedContext(resourceNamesToUnreserve, false);
+		Set<LockableResource> requiredResourceForNextContext = null;
+		QueuedContextStruct nextContext = this.getNextQueuedContext(resourceNamesToUnreserve, false, null);
 
 		// no context is queued which can be started once these resources are free'd.
 		if (nextContext == null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -278,14 +279,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		return true;
 	}
 
-	public synchronized boolean lock(List<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
+	public synchronized boolean lock(Set<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
 		return lock(resources, build, context, null, null, false);
 	}
 
 	/**
 	 * Try to lock the resource and return true if locked.
 	 */
-	public synchronized boolean lock(List<LockableResource> resources,
+	public synchronized boolean lock(Set<LockableResource> resources,
 			Run<?, ?> build, @Nullable StepContext context, @Nullable String logmessage,
 			final String variable, boolean inversePrecedence) {
 		boolean needToWait = false;
@@ -350,79 +351,82 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		if (resourceNamesToUnLock == null || (resourceNamesToUnLock.size() == 0)) {
 			return;
 		}
+		
+		// process as many contexts as possible
+		List<String> remainingResourceNamesToUnLock = new ArrayList<>(resourceNamesToUnLock);
 
-		// check if there are resources which can be unlocked (and shall not be unlocked)
-		List<LockableResource> requiredResourceForNextContext = null;
-		QueuedContextStruct nextContext = this.getNextQueuedContext(resourceNamesToUnLock, inversePrecedence);
-
-		// no context is queued which can be started once these resources are free'd.
-		if (nextContext == null) {
-			this.freeResources(resourceNamesToUnLock, build);
-			save();
-			return;
-		}
-
-		// remove context from queue and process it
-		requiredResourceForNextContext = checkResourcesAvailability(nextContext.getResources(), null, resourceNamesToUnLock);
-		unqueueContext(nextContext.getContext());
-
-		// resourceNamesToUnlock contains the names of the previous resources.
-		// requiredResourceForNextContext contains the resource objects which are required for the next context.
-		// It is guaranteed that there is an overlap between the two - the resources which are to be reused.
-		boolean needToWait = false;
-		for (LockableResource requiredResource : requiredResourceForNextContext) {
-			if (!resourceNamesToUnLock.contains(requiredResource.getName())) {
-				if (requiredResource.isReserved() || requiredResource.isLocked()) {
-					needToWait = true;
-					break;
-				}
+		QueuedContextStruct nextContext = null;
+		while (!remainingResourceNamesToUnLock.isEmpty()) {
+			// check if there are resources which can be unlocked (and shall not be unlocked)
+			Set<LockableResource> requiredResourceForNextContext = null;
+			nextContext = this.getNextQueuedContext(remainingResourceNamesToUnLock, inversePrecedence, nextContext);
+	
+			// no context is queued which can be started once these resources are free'd.
+			if (nextContext == null) {
+				this.freeResources(remainingResourceNamesToUnLock, build);
+				save();
+				return;
 			}
-		}
-
-		if (needToWait) {
-			freeResources(resourceNamesToUnLock, build);
-			save();
-			return;
-		} else {
-			List<String> resourceNamesToLock = new ArrayList<String>();
-
-			// lock all (old and new resources)
+	
+			requiredResourceForNextContext = checkResourcesAvailability(nextContext.getResources(), null, remainingResourceNamesToUnLock);
+	
+			// resourceNamesToUnlock contains the names of the previous resources.
+			// requiredResourceForNextContext contains the resource objects which are required for the next context.
+			// It is guaranteed that there is an overlap between the two - the resources which are to be reused.
+			boolean needToWait = false;
 			for (LockableResource requiredResource : requiredResourceForNextContext) {
-				try {
-					requiredResource.setBuild(nextContext.getContext().get(Run.class));
-					resourceNamesToLock.add(requiredResource.getName());
-				} catch (Exception e) {
-					// skip this context, as the build cannot be retrieved (maybe it was deleted while running?)
-					LOGGER.log(Level.WARNING, "Skipping queued context for lock. Can not get the Run object from the context to proceed with lock, " +
-							"this could be a legitimate status if the build waiting for the lock was deleted or" +
-							" hard killed. More information at Level.FINE if debug is needed.");
-					LOGGER.log(Level.FINE, "Can not get the Run object from the context to proceed with lock", e);
-					unlockNames(resourceNamesToUnLock, build, inversePrecedence);
-					return;
-				}
-			}
-
-			// determine old resources no longer needed
-			List<String> freeResources = new ArrayList<String>();
-			for (String resourceNameToUnlock : resourceNamesToUnLock) {
-				boolean resourceStillNeeded = false;
-				for (LockableResource requiredResource : requiredResourceForNextContext) {
-					if (resourceNameToUnlock != null && resourceNameToUnlock.equals(requiredResource.getName())) {
-						resourceStillNeeded = true;
+				if (!remainingResourceNamesToUnLock.contains(requiredResource.getName())) {
+					if (requiredResource.isReserved() || requiredResource.isLocked()) {
+						needToWait = true;
 						break;
 					}
 				}
-
-				if (!resourceStillNeeded) {
-					freeResources.add(resourceNameToUnlock);
-				}
 			}
-
-			// free old resources no longer needed
-			freeResources(freeResources, build);
-
-			// continue with next context
-			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), nextContext.getResources().requiredVar, inversePrecedence);
+	
+			if (!needToWait) {
+				// remove context from queue and process it
+				unqueueContext(nextContext.getContext());
+	
+				List<String> resourceNamesToLock = new ArrayList<String>();
+	
+				// lock all (old and new resources)
+				for (LockableResource requiredResource : requiredResourceForNextContext) {
+					try {
+						requiredResource.setBuild(nextContext.getContext().get(Run.class));
+						resourceNamesToLock.add(requiredResource.getName());
+					} catch (Exception e) {
+						// skip this context, as the build cannot be retrieved (maybe it was deleted while running?)
+						LOGGER.log(Level.WARNING, "Skipping queued context for lock. Can not get the Run object from the context to proceed with lock, " +
+								"this could be a legitimate status if the build waiting for the lock was deleted or" +
+								" hard killed. More information at Level.FINE if debug is needed.");
+						LOGGER.log(Level.FINE, "Can not get the Run object from the context to proceed with lock", e);
+						unlockNames(remainingResourceNamesToUnLock, build, inversePrecedence);
+						return;
+					}
+				}
+	
+				// determine old resources no longer needed
+				List<String> freeResources = new ArrayList<String>();
+				for (String resourceNameToUnlock : remainingResourceNamesToUnLock) {
+					boolean resourceStillNeeded = false;
+					for (LockableResource requiredResource : requiredResourceForNextContext) {
+						if (resourceNameToUnlock != null && resourceNameToUnlock.equals(requiredResource.getName())) {
+							resourceStillNeeded = true;
+							break;
+						}
+					}
+	
+					if (!resourceStillNeeded) {
+						freeResources.add(resourceNameToUnlock);
+					}
+				}
+	
+				// keep unused resources
+				remainingResourceNamesToUnLock.retainAll(freeResources);
+	
+				// continue with next context
+				LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), nextContext.getResources().requiredVar, inversePrecedence);
+			}
 		}
 		save();
 	}
@@ -435,11 +439,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	 * @return the context or null
 	 */
 	@CheckForNull
-	private QueuedContextStruct getNextQueuedContext(List<String> resourceNamesToUnLock, boolean inversePrecedence) {
+	private QueuedContextStruct getNextQueuedContext(List<String> resourceNamesToUnLock, boolean inversePrecedence, QueuedContextStruct from) {
 		QueuedContextStruct newestEntry = null;
 		List<LockableResource> requiredResourceForNextContext = null;
+		int fromIndex = from != null ? this.queuedContexts.indexOf(from) + 1 : 0;
 		if (!inversePrecedence) {
-			for (QueuedContextStruct entry : this.queuedContexts) {
+			for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
+				QueuedContextStruct entry = this.queuedContexts.get(i);
 				if (checkResourcesAvailability(entry.getResources(), null, resourceNamesToUnLock) != null) {
 					return entry;
 				}
@@ -447,7 +453,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		} else {
 			long newest = 0;
 			List<QueuedContextStruct> orphan = new ArrayList<QueuedContextStruct>();
-			for (QueuedContextStruct entry : this.queuedContexts) {
+			for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
+				QueuedContextStruct entry = this.queuedContexts.get(i);
 				if (checkResourcesAvailability(entry.getResources(), null, resourceNamesToUnLock) != null) {
 					try {
 						Run<?, ?> run = entry.getContext().get(Run.class);
@@ -628,70 +635,101 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	 * within requiredResources and returns the necessary available resources.
 	 * If not enough resources are available, returns null.
 	 */
-	public synchronized List<LockableResource> checkResourcesAvailability(LockableResourcesStruct requiredResources,
+	public synchronized Set<LockableResource> checkResourcesAvailability(List<LockableResourcesStruct> requiredResourcesList,
 			@Nullable PrintStream logger, @Nullable List<String> lockedResourcesAboutToBeUnlocked) {
-		// get possible resources
-		int requiredAmount = 0; // 0 means all
-		List<LockableResource> candidates = new ArrayList<>();
-		if (requiredResources.label != null && requiredResources.label.isEmpty()) {
-			candidates.addAll(requiredResources.required);
-		} else {
-			candidates.addAll(getResourcesWithLabel(requiredResources.label, null));
-			if (requiredResources.requiredNumber != null) {
-				try {
-					requiredAmount = Integer.parseInt(requiredResources.requiredNumber);
-				} catch (NumberFormatException e) {
-					requiredAmount = 0;
+		
+		// Build possible resources for each requirement
+		Map<List<LockableResource>, Integer> allCandidates = new HashMap<>();
+		
+		for (LockableResourcesStruct requiredResources : requiredResourcesList) {
+			// get possible resources
+			int requiredAmount = 0; // 0 means all
+			List<LockableResource> candidates = new ArrayList<>();
+			if (requiredResources.label != null && requiredResources.label.isEmpty()) {
+				candidates.addAll(requiredResources.required);
+			} else {
+				candidates.addAll(getResourcesWithLabel(requiredResources.label, null));
+				if (requiredResources.requiredNumber != null) {
+					try {
+						requiredAmount = Integer.parseInt(requiredResources.requiredNumber);
+					} catch (NumberFormatException e) {
+						requiredAmount = 0;
+					}
 				}
 			}
+	
+			if (requiredAmount == 0) {
+				requiredAmount = candidates.size();
+			}
+			
+			allCandidates.put(candidates, requiredAmount);
 		}
-
-		if (requiredAmount == 0) {
-			requiredAmount = candidates.size();
-		}
-
-		// start with an empty set of selected resources
-		List<LockableResource> selected = new ArrayList<LockableResource>();
-
-		// some resources might be already locked, but will be freeed.
-		// Determine if these resources can be reused
-		if (lockedResourcesAboutToBeUnlocked != null) {
-			for (LockableResource candidate : candidates) {
-				if (lockedResourcesAboutToBeUnlocked.contains(candidate.getName())) {
-					selected.add(candidate);
+		
+		// Process freed resources
+		Map<Map.Entry<List<LockableResource>, Integer>, List<LockableResource>> currentSelection = new HashMap<>();
+		int totalSelected = 0;
+		
+		for (Map.Entry<List<LockableResource>, Integer> entry : allCandidates.entrySet()) {
+			List<LockableResource> candidates = entry.getKey();
+			
+			// start with an empty set of selected resources
+			List<LockableResource> selected = new ArrayList<LockableResource>();
+			
+			// some resources might be already locked, but will be freed.
+			// Determine if these resources can be reused
+			if (lockedResourcesAboutToBeUnlocked != null) {
+				for (LockableResource candidate : candidates) {
+					if (lockedResourcesAboutToBeUnlocked.contains(candidate.getName())) {
+						selected.add(candidate);
+					}
 				}
 			}
-			// if none of the currently locked resources can be reussed,
-			// this context is not suitable to be continued with
-			if (selected.size() == 0) {
-				return null;
-			}
+			
+			totalSelected += selected.size();
+			currentSelection.put(entry, selected);
 		}
-
-		for (LockableResource rs : candidates) {
-			if (selected.size() >= requiredAmount) {
-				break;
-			}
-			if (!rs.isReserved() && !rs.isLocked()) {
-				selected.add(rs);
-			}
-		}
-
-		if (selected.size() < requiredAmount) {
-			if (logger != null) {
-				logger.println("Found " + selected.size() + " available resource(s). Waiting for correct amount: " + requiredAmount + ".");
-			}
+		
+		// if none of the currently locked resources can be reused,
+		// this context is not suitable to be continued with
+		if (lockedResourcesAboutToBeUnlocked != null && totalSelected == 0) {
 			return null;
 		}
+	
+		// Find remaining resources
+		Set<LockableResource> allSelected = new HashSet<>();
+		
+		for (Map.Entry<Map.Entry<List<LockableResource>, Integer>, List<LockableResource>> entry : currentSelection.entrySet()) {
+			List<LockableResource> candidates = entry.getKey().getKey();
+			List<LockableResource> selected = entry.getValue();
+			int requiredAmount = entry.getKey().getValue();
+			
+			for (LockableResource rs : candidates) {
+				if (selected.size() >= requiredAmount) {
+					break;
+				}
+				if (!rs.isReserved() && !rs.isLocked()) {
+					selected.add(rs);
+				}
+			}
+	
+			if (selected.size() < requiredAmount) {
+				if (logger != null) {
+					logger.println("Found " + selected.size() + " available resource(s). Waiting for correct amount: " + requiredAmount + ".");
+				}
+				return null;
+			}
+			
+			allSelected.addAll(selected);
+		}
 
-		return selected;
+		return allSelected;
 	}
 
 	/*
 	 * Adds the given context and the required resources to the queue if
 	 * this context is not yet queued.
 	 */
-	public synchronized void queueContext(StepContext context, LockableResourcesStruct requiredResources, String resourceDescription) {
+	public synchronized void queueContext(StepContext context, List<LockableResourcesStruct> requiredResources, String resourceDescription) {
 		for (QueuedContextStruct entry : this.queuedContexts) {
 			if (entry.getContext() == context) {
 				return;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -671,6 +671,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		
 		for (Map.Entry<List<LockableResource>, Integer> entry : allCandidates.entrySet()) {
 			List<LockableResource> candidates = entry.getKey();
+			int requiredAmount = entry.getValue();
 			
 			// start with an empty set of selected resources
 			List<LockableResource> selected = new ArrayList<LockableResource>();
@@ -679,6 +680,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			// Determine if these resources can be reused
 			if (lockedResourcesAboutToBeUnlocked != null) {
 				for (LockableResource candidate : candidates) {
+					if (selected.size() >= requiredAmount) {
+						break;
+					}
 					if (lockedResourcesAboutToBeUnlocked.contains(candidate.getName())) {
 						selected.add(candidate);
 					}

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -11,6 +11,7 @@ package org.jenkins.plugins.lockableresources.actions;
 import hudson.model.Action;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.jenkins.plugins.lockableresources.LockableResource;
@@ -40,7 +41,7 @@ public class LockedResourcesBuildAction implements Action {
 	}
 
 	public static LockedResourcesBuildAction fromResources(
-			List<LockableResource> resources) {
+			Collection<LockableResource> resources) {
 		List<ResourcePOJO> resPojos = new ArrayList<ResourcePOJO>();
 		for (LockableResource r : resources)
 			resPojos.add(new ResourcePOJO(r));

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -18,7 +18,9 @@ import hudson.model.listeners.RunListener;
 import hudson.model.StringParameterValue;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
@@ -42,7 +44,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
 		if (build instanceof AbstractBuild) {
 			Job<?, ?> proj = Utils.getProject(build);
-			List<LockableResource> required = new ArrayList<LockableResource>();
+			Set<LockableResource> required = new HashSet<LockableResource>();
 			if (proj != null) {
 				LockableResourcesStruct resources = Utils.requiredResources(proj);
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
@@ -1,0 +1,17 @@
+package org.jenkins.plugins.lockableresources.queue;
+
+import java.util.List;
+
+import org.jenkins.plugins.lockableresources.LockableResource;
+
+public class LockableResourcesCandidatesStruct {
+
+	public List<LockableResource> candidates;
+	public int requiredAmount;
+	public List<LockableResource> selected;
+
+	public LockableResourcesCandidatesStruct(List<LockableResource> candidates, int requiredAmount) {
+		this.candidates = candidates;
+		this.requiredAmount = requiredAmount;
+	}
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -9,6 +9,7 @@
 package org.jenkins.plugins.lockableresources.queue;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
@@ -30,7 +31,7 @@ public class QueuedContextStruct implements Serializable {
 	/*
 	 * Reference to the resources required by the step context.
 	 */
-	private LockableResourcesStruct lockableResourcesStruct;
+	private List<LockableResourcesStruct> lockableResourcesStruct;
 
 	/*
 	 * Description of the required resources used within logging messages.
@@ -40,7 +41,7 @@ public class QueuedContextStruct implements Serializable {
 	/*
 	 * Constructor for the QueuedContextStruct class.
 	 */
-	public QueuedContextStruct(StepContext context, LockableResourcesStruct lockableResourcesStruct, String resourceDescription) {
+	public QueuedContextStruct(StepContext context, List<LockableResourcesStruct> lockableResourcesStruct, String resourceDescription) {
 		this.context = context;
 		this.lockableResourcesStruct = lockableResourcesStruct;
 		this.resourceDescription = resourceDescription;
@@ -56,7 +57,7 @@ public class QueuedContextStruct implements Serializable {
 	/*
 	 * Gets the required resources.
 	 */
-	public LockableResourcesStruct getResources() {
+	public List<LockableResourcesStruct> getResources() {
 		return this.lockableResourcesStruct;
 	}
 

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -13,4 +13,14 @@
 	<f:entry title="${%Inverse precedence}" field="inversePrecedence">
 		<f:checkbox/>
 	</f:entry>
+	<f:entry title="${%Extra resources}">
+		<f:repeatable field="extra" header="" minimum="0" add="${%Add Resource}">
+			<table width="100%">
+				<st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockStepResource"/>
+				<f:entry title="">
+					<div align="right"><f:repeatableDeleteButton/></div>
+				</f:entry>
+			</table>
+		</f:repeatable>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -10,6 +10,9 @@
 	<f:entry title="${%Quantity}" field="quantity">
 		<f:number/>
 	</f:entry>
+	<f:entry title="${%Result variable}" field="variable">
+		<f:textbox/>
+	</f:entry>
 	<f:entry title="${%Inverse precedence}" field="inversePrecedence">
 		<f:checkbox/>
 	</f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
@@ -1,0 +1,13 @@
+<div>
+	<p>
+		Name of an environment variable that will receive the comma separated list of the names of the locked resources while the block executes.
+	</p>
+	<p>
+		e.g.:
+		<pre>
+lock(abel: 'label', variable: 'var') {
+    echo "Resource locked: ${env.var}"
+}
+		</pre>
+	</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="${%Resource}" field="resource">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="${%Label}" field="label">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="${%Quantity}" field="quantity">
+		<f:number/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		The label of the resources to be locked as defined in Global settings.
+		Either a resource or a label need to be specified.
+	</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-quantity.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-quantity.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		The quantity of resources with the specified label to be locked as defined in Global settings.
+		Either a resource or a label need to be specified.
+	</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-resource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-resource.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		The resource name to lock as defined in Global settings.
+		If the resource does not exist in Global Settings it will be automatically created on build execution.
+		Either a resource or a label need to be specified.
+	</p>
+</div>

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -860,4 +860,56 @@ public class LockStepTest {
 		assertEquals(count, pauseActions);
 		assertEquals(effectivePauses, pausedActions);
 	}
+
+	@Test
+	public void lockMultipleResources() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				LockableResourcesManager.get().createResource("resource1");
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"lock(resource: 'resource1', extra: [[resource: 'resource2']]) {\n" +
+						"	semaphore 'wait-inside'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait-inside/1", b1);
+
+				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+				p2.setDefinition(new CpsFlowDefinition(
+						"lock('resource1') {\n" +
+						"	semaphore 'wait-inside-p2'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
+				
+				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
+				p3.setDefinition(new CpsFlowDefinition(
+						"lock('resource2') {\n" +
+						"	semaphore 'wait-inside-p3'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("[resource2] is locked, waiting...", b3);
+
+				// Unlock resources
+				SemaphoreStep.success("wait-inside/1", null);
+				story.j.waitForMessage("Lock released on resource [{resource1},{resource2},]", b1);
+
+				// Both get their lock
+				story.j.waitForMessage("Lock acquired on [resource1]", b2);
+				story.j.waitForMessage("Lock acquired on [resource2]", b3);
+				
+				SemaphoreStep.success("wait-inside-p2/1", null);
+				SemaphoreStep.success("wait-inside-p3/1", null);
+				story.j.waitForMessage("Finish", b2);
+				story.j.waitForMessage("Finish", b3);
+			}
+		});
+	}
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -218,6 +218,7 @@ public class LockStepTest {
 				// Ensure that b2 reaches the lock before b3
 				story.j.waitForMessage("[Label: label1, Quantity: 2] is locked, waiting...", b2);
 				story.j.waitForMessage("Found 0 available resource(s). Waiting for correct amount: 2.", b2);
+				isPaused(b2, 1, 1);
 
 				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
 				p3.setDefinition(new CpsFlowDefinition(
@@ -229,19 +230,23 @@ public class LockStepTest {
 				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[Label: label1, Quantity: 1] is locked, waiting...", b3);
 				story.j.waitForMessage("Found 0 available resource(s). Waiting for correct amount: 1.", b3);
+				isPaused(b3, 1, 1);
 
 				// Unlock Label: label1
 				SemaphoreStep.success("wait-inside/1", null);
 				story.j.waitForMessage("Lock released on resource [Label: label1]", b1);
+				isPaused(b1, 1, 0);
 
 				// Both get their lock
 				story.j.waitForMessage("Lock acquired on [Label: label1, Quantity: 2]", b2);
 				story.j.waitForMessage("Lock acquired on [Label: label1, Quantity: 1]", b3);
-				
+
 				SemaphoreStep.success("wait-inside-quantity2/1", null);
 				SemaphoreStep.success("wait-inside-quantity1/1", null);
 				story.j.waitForMessage("Finish", b2);
 				story.j.waitForMessage("Finish", b3);
+				isPaused(b2, 1, 0);
+				isPaused(b3, 1, 0);
 			}
 		});
 	}
@@ -943,7 +948,8 @@ public class LockStepTest {
 				));
 				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
-				
+				isPaused(b2, 1, 1);
+
 				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
 				p3.setDefinition(new CpsFlowDefinition(
 						"lock('resource2') {\n" +
@@ -953,19 +959,23 @@ public class LockStepTest {
 				));
 				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[resource2] is locked, waiting...", b3);
+				isPaused(b3, 1, 1);
 
 				// Unlock resources
 				SemaphoreStep.success("wait-inside/1", null);
 				story.j.waitForMessage("Lock released on resource [{resource1},{resource2},]", b1);
+				isPaused(b1, 1, 0);
 
 				// Both get their lock
 				story.j.waitForMessage("Lock acquired on [resource1]", b2);
 				story.j.waitForMessage("Lock acquired on [resource2]", b3);
-				
+
 				SemaphoreStep.success("wait-inside-p2/1", null);
 				SemaphoreStep.success("wait-inside-p3/1", null);
 				story.j.waitForMessage("Finish", b2);
 				story.j.waitForMessage("Finish", b3);
+				isPaused(b2, 1, 0);
+				isPaused(b3, 1, 0);
 			}
 		});
 	}
@@ -997,7 +1007,8 @@ public class LockStepTest {
 				));
 				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
-				
+				isPaused(b2, 1, 1);
+
 				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
 				p3.setDefinition(new CpsFlowDefinition(
 						"lock(label: 'label1') {\n" +
@@ -1007,19 +1018,23 @@ public class LockStepTest {
 				));
 				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[Label: label1] is locked, waiting...", b3);
+				isPaused(b3, 1, 1);
 
 				// Unlock resources
 				SemaphoreStep.success("wait-inside/1", null);
 				story.j.waitForMessage("Lock released on resource [{Label: label1},{resource1},]", b1);
+				isPaused(b2, 1, 0);
 
 				// Both get their lock
 				story.j.waitForMessage("Lock acquired on [resource1]", b2);
 				story.j.waitForMessage("Lock acquired on [Label: label1]", b3);
-				
+
 				SemaphoreStep.success("wait-inside-p2/1", null);
 				SemaphoreStep.success("wait-inside-p3/1", null);
 				story.j.waitForMessage("Finish", b2);
 				story.j.waitForMessage("Finish", b3);
+				isPaused(b2, 1, 0);
+				isPaused(b3, 1, 0);
 			}
 		});
 	}
@@ -1051,7 +1066,8 @@ public class LockStepTest {
 				));
 				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[resource1] is locked, waiting...", b2);
-				
+				isPaused(b2, 1, 1);
+
 				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
 				p3.setDefinition(new CpsFlowDefinition(
 						"lock(label: 'label1') {\n" +
@@ -1061,18 +1077,22 @@ public class LockStepTest {
 				));
 				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[Label: label1] is locked, waiting...", b3);
+				isPaused(b3, 1, 1);
 
 				// Unlock resources
 				SemaphoreStep.success("wait-inside/1", null);
 				story.j.waitForMessage("Lock released on resource [{Label: label1},{resource1},]", b1);
+				isPaused(b1, 1, 0);
 
 				// #2 gets the lock before #3 (in the order as they requested the lock)
 				story.j.waitForMessage("Lock acquired on [resource1]", b2);
 				SemaphoreStep.success("wait-inside-p2/1", null);
 				story.j.waitForMessage("Finish", b2);
+				isPaused(b2, 1, 0);
 				story.j.waitForMessage("Lock acquired on [Label: label1]", b3);
 				SemaphoreStep.success("wait-inside-p3/1", null);
 				story.j.waitForMessage("Finish", b3);
+				isPaused(b3, 1, 0);
 			}
 		});
 	}
@@ -1088,7 +1108,10 @@ public class LockStepTest {
 				LockableResourcesManager.get().createResourceWithLabel("resource4", "label1");
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
-						"lock(resource: 'resource4', extra: [[resource: 'resource2'], [label: 'label1', quantity: 2]]) {\n" +
+						"lock(resource: 'resource4', variable: 'var', extra: [[resource: 'resource2'], [label: 'label1', quantity: 2]]) {\n" +
+						"	def lockedResources = env.var.split(',')\n" +
+						"	Arrays.sort(lockedResources)\n" +
+						"	echo \"Resources locked: ${lockedResources}\"\n" +
 						"	semaphore 'wait-inside'\n" +
 						"}\n" +
 						"echo 'Finish'"
@@ -1099,7 +1122,10 @@ public class LockStepTest {
 
 				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
 				p2.setDefinition(new CpsFlowDefinition(
-						"lock(label: 'label1', quantity: 3) {\n" +
+						"lock(label: 'label1', variable: 'var', quantity: 3) {\n" +
+						"	def lockedResources = env.var.split(',')\n" +
+						"	Arrays.sort(lockedResources)\n" +
+						"	echo \"Resources locked: ${lockedResources}\"\n" +
 						"	semaphore 'wait-inside-quantity3'\n" +
 						"}\n" +
 						"echo 'Finish'"
@@ -1107,10 +1133,14 @@ public class LockStepTest {
 				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 				story.j.waitForMessage("[Label: label1, Quantity: 3] is locked, waiting...", b2);
 				story.j.waitForMessage("Found 2 available resource(s). Waiting for correct amount: 3.", b2);
-				
+				isPaused(b2, 1, 1);
+
 				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
 				p3.setDefinition(new CpsFlowDefinition(
-						"lock(label: 'label1', quantity: 2) {\n" +
+						"lock(label: 'label1', variable: 'var', quantity: 2) {\n" +
+						"	def lockedResources = env.var.split(',')\n" +
+						"	Arrays.sort(lockedResources)\n" +
+						"	echo \"Resources locked: ${lockedResources}\"\n" +
 						"	semaphore 'wait-inside-quantity2'\n" +
 						"}\n" +
 						"echo 'Finish'"
@@ -1121,15 +1151,22 @@ public class LockStepTest {
 				// Let 3 finish
 				SemaphoreStep.success("wait-inside-quantity2/1", null);
 				story.j.waitForMessage("Finish", b3);
+				story.j.assertLogContains("Resources locked: [resource1, resource3]", b3);
+				isPaused(b3, 1, 0);
 
 				// Unlock resources
 				SemaphoreStep.success("wait-inside/1", null);
 				story.j.waitForMessage("Lock released on resource [{resource4},{resource2},{Label: label1, Quantity: 2},]", b1);
+				story.j.assertLogContains("Resources locked: [resource2, resource4]", b1);
+				isPaused(b1, 1, 0);
 
 				// #2 gets the lock
 				story.j.waitForMessage("Lock acquired on [Label: label1, Quantity: 3]", b2);
 				SemaphoreStep.success("wait-inside-quantity3/1", null);
 				story.j.waitForMessage("Finish", b2);
+				// Could be any 3 resources, so just check the beginning of the message
+				story.j.assertLogContains("Resources locked: [resource", b2);
+				isPaused(b2, 1, 0);
 			}
 		});
 	}

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -190,6 +190,63 @@ public class LockStepTest {
 	}
 
 	@Test
+	public void lockOrderLabelQuantityFreedResources() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
+				LockableResourcesManager.get().createResourceWithLabel("resource2", "label1");
+				LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"lock(label: 'label1') {\n" +
+						"	semaphore 'wait-inside'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait-inside/1", b1);
+
+				WorkflowJob p2 = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+				p2.setDefinition(new CpsFlowDefinition(
+						"lock(label: 'label1', quantity: 2) {\n" +
+						"	semaphore 'wait-inside-quantity2'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+				// Ensure that b2 reaches the lock before b3
+				story.j.waitForMessage("[Label: label1, Quantity: 2] is locked, waiting...", b2);
+				story.j.waitForMessage("Found 0 available resource(s). Waiting for correct amount: 2.", b2);
+
+				WorkflowJob p3 = story.j.jenkins.createProject(WorkflowJob.class, "p3");
+				p3.setDefinition(new CpsFlowDefinition(
+						"lock(label: 'label1', quantity: 1) {\n" +
+						"	semaphore 'wait-inside-quantity1'\n" +
+						"}\n" +
+						"echo 'Finish'"
+				));
+				WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+				story.j.waitForMessage("[Label: label1, Quantity: 1] is locked, waiting...", b3);
+				story.j.waitForMessage("Found 0 available resource(s). Waiting for correct amount: 1.", b3);
+
+				// Unlock Label: label1
+				SemaphoreStep.success("wait-inside/1", null);
+				story.j.waitForMessage("Lock released on resource [Label: label1]", b1);
+
+				// Both get their lock
+				story.j.waitForMessage("Lock acquired on [Label: label1, Quantity: 2]", b2);
+				story.j.waitForMessage("Lock acquired on [Label: label1, Quantity: 1]", b3);
+				
+				SemaphoreStep.success("wait-inside-quantity2/1", null);
+				SemaphoreStep.success("wait-inside-quantity1/1", null);
+				story.j.waitForMessage("Finish", b2);
+				story.j.waitForMessage("Finish", b3);
+			}
+		});
+	}
+
+	@Test
 	public void lockOrder() {
 		story.addStep(new Statement() {
 			@Override


### PR DESCRIPTION

I've added the ability to lock multiple disjoint resources by specifying extra resources to lock (by name or labels). The locks are taken only if all the locks can be taken. 

The most important thing is this is fully backwards compatible so this PR will not break any existing pipeline scripts.

Inverse precedence can only be specified on the "Main" lock.

It will try to be efficient and take as few locks as it can.
i.e.: If a lock is taken on a resource by name, and another lock is taken on a label with a quantity and the named resource also has the label, then that resource will be used for both locks.
Be careful of the order the locks  are specified though, if the label is specified first, there is no guarantee the named resource will be taken as part of the label lock and it will possibly result in more resources being locked than is necessary.

![image](https://user-images.githubusercontent.com/595214/34573639-cd102990-f142-11e7-8ff6-f93b3d609e64.png)


I've added a few unit tests to cover different scenarios mixing different types of locks.

