### PR TITLE
#94 : Add requiredVar to resourceHolder and proceed calls

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -54,7 +54,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 			}
 			resources.add(step.resource);
 		}
-		LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, step.label, step.quantity);
+		LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resources, step.label, step.quantity, step.variable);
 		// determine if there are enough resources available to proceed
 		List<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolder, listener.getLogger(), null);
 		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.variable, step.inversePrecedence)) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -585,7 +585,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			}
 
 			// continue with next context
-			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), null, false);
+			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), nextContext.getResources().requiredVar, false);
 		}
 		save();
 	}


### PR DESCRIPTION
When a resourceHolder of type LockableResourcesStruct was created, it wasn't set with the variable name from the step.  The variable name was only passed to resource allocation when the resource was readily available.  Therefore, queued resources lost access to the variable name and wouldn't set it properly.

There was also one proceed call which explicitly set the variable to 'null' but should at least attempt to set it to the variable name, if the variable name was set by the resource struct.