### PR TITLE
Add requiredVar to resourceHolder and proceed calls as defaulted to n…

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -59,7 +59,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 				}
 				resources.add(resource.resource);
 			}
-			resourceHolderList.add(new LockableResourcesStruct(resources, resource.label, resource.quantity));
+			resourceHolderList.add(new LockableResourcesStruct(resources, resource.label, resource.quantity, step.variable));
 		}
 
 		// determine if there are enough resources available to proceed

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -593,7 +593,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			}
 
 			// continue with next context
-			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), null, false);
+			LockStepExecution.proceed(resourceNamesToLock, nextContext.getContext(), nextContext.getResourceDescription(), nextContext.getResources().requiredVar, false);
 		}
 		save();
 	}


### PR DESCRIPTION
When a resourceHolder of type LockableResourcesStruct was created, it wasn't set with the variable name from the step. The variable name was only passed to resource allocation when the resource was readily available. Therefore, queued resources lost access to the variable name and wouldn't set it properly.

There was also one proceed call which explicitly set the variable to 'null' but should at least attempt to set it to the variable name, if the variable name was set by the resource struct.

This is basically a dup of @boblloyd's PR (https://github.com/jenkinsci/lockable-resources-plugin/pull/95).  Just trying to get traction on whether the build failures were something intermittent as boblloyd hasn't responded in a while on his initial proposal.  