### PR TITLE
Fix infinite wait on invalid label

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -78,10 +78,14 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 
 	/**
 	 * Label and resource are mutual exclusive.
+	 * The label, if provided, must be configured (at least one resource must have this label).
 	 */
 	public static void validate(String resource, String label, int quantity) throws Exception {
 		if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
 			throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
+		}
+		if (label != null && !LockableResourcesManager.get().isValidLabel( label ) ) {
+			throw new IllegalArgumentException("The label does not exist: " + label);
 		}
 	}
 
@@ -107,6 +111,9 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 			}
 			if ((resourceLabel == null) && (resourceName == null)) {
 				return FormValidation.error("Either label or resource name must be specified.");
+			}
+			if (resourceLabel != null && !LockableResourcesManager.get().isValidLabel(resourceLabel)) {
+				return FormValidation.error("The label does not exist: " + resourceLabel);
 			}
 			return FormValidation.ok();
 		}


### PR DESCRIPTION
Currently, if we use the `lock` step in a pipeline script, and refer to a non-existing label (e.g. `label: 'invalidLabel'`), and ask for some quantity of resource explicitly (e.g. `quantity: 1`) the step will wait indefinitely. I'm not talking about a label whose resources are all locked, but about a label that has no corresponding resource, even a locked one.

This is annoying when running pipelines on Jenkins instances that do not have the required resources available: in this case, one would much rather see the pipeline branch fail, so that we know that something is wrong immediately.

Note that, when configuring locked resources through the UI, non-existing labels are already forbidden.

This PR changes the behavior to fail the step execution in the event of a non-existing label.