### PR TITLE
groovy and number of resources fixed

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -225,7 +225,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			candidates = getResourcesWithLabel(requiredResources.label, params);
 		} else {
 			candidates = getResourcesMatchingScript(systemGroovyScript, params);
-			candidatesByScript=true;
+			candidatesByScript = true;
 		}
 
 		for (LockableResource rs : candidates) {
@@ -236,17 +236,17 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		// if did not get wanted amount or did not get all
-        final int required_amount;
-        if (candidatesByScript && candidates.size() == 0) {
-            /**
-             * If the groovy script does not return any candidates, it means nothing is needed, even
-             * if a higher amount is specified. A valid use case is a Matrix job, when not all
-             * configurations need resources.
-             */
-            required_amount = 0;
-        } else {
-            required_amount = number == 0 ? candidates.size() : number;
-        }
+		final int required_amount;
+		if (candidatesByScript && candidates.size() == 0) {
+		/**
+		  * If the groovy script does not return any candidates, it means nothing is needed, even
+		  * if a higher amount is specified. A valid use case is a Matrix job, when not all
+		  * configurations need resources.
+		  */
+			required_amount = 0;
+		} else {
+			required_amount = number == 0 ? candidates.size() : number;
+		}
 
 		if (selected.size() != required_amount) {
 			log.log(Level.FINEST, "{0} found {1} resource(s) to queue." +

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -216,6 +216,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			return null;
 		}
 
+		boolean candidatesByScript=false;
 		List<LockableResource> candidates = new ArrayList<LockableResource>();
                 final SecureGroovyScript systemGroovyScript = requiredResources.getResourceMatchScript();
 		if (requiredResources.label != null && requiredResources.label.isEmpty() && systemGroovyScript == null) {
@@ -224,6 +225,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			candidates = getResourcesWithLabel(requiredResources.label, params);
 		} else {
 			candidates = getResourcesMatchingScript(systemGroovyScript, params);
+			candidatesByScript=true;
 		}
 
 		for (LockableResource rs : candidates) {
@@ -234,7 +236,17 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		// if did not get wanted amount or did not get all
-		int required_amount = number == 0 ? candidates.size() : number;
+        final int required_amount;
+        if (candidatesByScript && candidates.size() == 0) {
+            /**
+             * If the groovy script does not return any candidates, it means nothing is needed, even
+             * if a higher amount is specified. A valid use case is a Matrix job, when not all
+             * configurations need resources.
+             */
+            required_amount = 0;
+        } else {
+            required_amount = number == 0 ? candidates.size() : number;
+        }
 
 		if (selected.size() != required_amount) {
 			log.log(Level.FINEST, "{0} found {1} resource(s) to queue." +

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -206,11 +206,14 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
 		public FormValidation doCheckResourceNumber(@QueryParameter String value,
 				@QueryParameter String resourceNames,
-				@QueryParameter String labelName) {
+                @QueryParameter String labelName,
+                @QueryParameter String resourceMatchScript)
+        {
 
 			String number = Util.fixEmptyAndTrim(value);
 			String names = Util.fixEmptyAndTrim(resourceNames);
 			String label = Util.fixEmptyAndTrim(labelName);
+            String script = Util.fixEmptyAndTrim(resourceMatchScript);
 
 			if (number == null || number.equals("") || number.trim().equals("0")) {
 				return FormValidation.ok();
@@ -226,9 +229,9 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			int numResources = 0;
 			if (names != null) {
 				numResources = names.split("\\s+").length;
-			} else if (label != null) {
-				numResources = Integer.MAX_VALUE;
-			}
+            } else if (label != null || script != null) {
+                	numResources = Integer.MAX_VALUE;
+            }
 
 			if (numResources < numAsInt) {
 				return FormValidation.error(String.format(

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
@@ -14,4 +14,12 @@ public class LockableResourcesCandidatesStruct {
 		this.candidates = candidates;
 		this.requiredAmount = requiredAmount;
 	}
+
+    @Override
+    public String toString()
+    {
+        return "LockableResourcesCandidatesStruct [candidates=" + candidates + ", requiredAmount=" + requiredAmount
+                + ", selected=" + selected + "]";
+    }
+
 }


### PR DESCRIPTION
The configuration with a groovy script didn't work well with labels.
The job always blocked all of the resources of the label. Now it is
possible to configure also the amount of needed resources.

Changed:

- Configuration doesn't warn about given number of resources in
  combination with groovy script
- When the execution of the groovy for the job doesn't return any
  candidates, the plugin will not try to block any resources, even
  if a number of resources is given. This important e.g. for Matrix
  jobs, not every of the configurations may need a resource and this
  is a good use case for the groovy script.