### PR TITLE
Fix a typo: "abel" -> "label"

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
@@ -5,7 +5,7 @@
 	<p>
 		e.g.:
 		<pre>
-lock(abel: 'label', variable: 'var') {
+lock(label: 'label', variable: 'var') {
     echo "Resource locked: ${env.var}"
 }
 		</pre>


### PR DESCRIPTION
Noticed the typo on the official Jenkins pipeline docs:
https://jenkins.io/doc/pipeline/steps/lockable-resources/