### PR TITLE
Fix setting the variable with the locks taken for pipeline steps

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -36,7 +36,7 @@ public final class BackwardCompatibility {
 					List<String> resourcesNames = new ArrayList<>();
 					resourcesNames.add(resource.getName());
 					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-					LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName());
+					LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName(), null);
 				}
 				queuedContexts.clear();
 			}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -81,7 +81,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
         listener.getLogger().println("[" + step + "] is locked, waiting...");
       }
       LockableResourcesManager.get()
-          .queueContext(getContext(), resourceHolderList, step.toString());
+          .queueContext(getContext(), resourceHolderList, step.toString(), step.variable);
     } // proceed is called inside lock if execution is possible
     return false;
   }
@@ -113,7 +113,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
           context
               .newBodyInvoker()
               .withCallback(
-                  new Callback(resourcenames, resourceDescription, variable, inversePrecedence));
+                  new Callback(resourcenames, resourceDescription, inversePrecedence));
       if (variable != null && variable.length() > 0)
         // set the variable for the duration of the block
         bodyInvoker.withContext(
@@ -143,24 +143,21 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 
     private final List<String> resourceNames;
     private final String resourceDescription;
-    private final String variable;
     private final boolean inversePrecedence;
 
     Callback(
         List<String> resourceNames,
         String resourceDescription,
-        String variable,
         boolean inversePrecedence) {
       this.resourceNames = resourceNames;
       this.resourceDescription = resourceDescription;
-      this.variable = variable;
       this.inversePrecedence = inversePrecedence;
     }
 
     protected void finished(StepContext context) throws Exception {
       LockableResourcesManager.get()
           .unlockNames(
-              this.resourceNames, context.get(Run.class), this.variable, this.inversePrecedence);
+              this.resourceNames, context.get(Run.class), this.inversePrecedence);
       context
           .get(TaskListener.class)
           .getLogger()

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -397,13 +397,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   public synchronized void unlock(
       List<LockableResource> resourcesToUnLock, @Nullable Run<?, ?> build) {
-    unlock(resourcesToUnLock, build, null, false);
+    unlock(resourcesToUnLock, build, false);
   }
 
   public synchronized void unlock(
       @Nullable List<LockableResource> resourcesToUnLock,
       @Nullable Run<?, ?> build,
-      String requiredVar,
       boolean inversePrecedence) {
     List<String> resourceNamesToUnLock = new ArrayList<>();
     if (resourcesToUnLock != null) {
@@ -412,13 +411,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
       }
     }
 
-    this.unlockNames(resourceNamesToUnLock, build, requiredVar, inversePrecedence);
+        this.unlockNames(resourceNamesToUnLock, build, inversePrecedence);
   }
 
   public synchronized void unlockNames(
       @Nullable List<String> resourceNamesToUnLock,
       @Nullable Run<?, ?> build,
-      String requiredVar,
       boolean inversePrecedence) {
     // make sure there is a list of resource names to unlock
     if (resourceNamesToUnLock == null || (resourceNamesToUnLock.isEmpty())) {
@@ -482,7 +480,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
                     + " hard killed. More information at Level.FINE if debug is needed.");
             LOGGER.log(
                 Level.FINE, "Can not get the Run object from the context to proceed with lock", e);
-            unlockNames(remainingResourceNamesToUnLock, build, requiredVar, inversePrecedence);
+            unlockNames(remainingResourceNamesToUnLock, build, inversePrecedence);
             return;
           }
         }
@@ -512,7 +510,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
             resourceNamesToLock,
             nextContext.getContext(),
             nextContext.getResourceDescription(),
-            requiredVar,
+            nextContext.getVariableName(),
             inversePrecedence);
       }
     }
@@ -701,7 +699,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
           resourceNamesToLock,
           nextContext.getContext(),
           nextContext.getResourceDescription(),
-          null,
+          nextContext.getVariableName(),
           false);
     }
     save();
@@ -856,7 +854,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
   public synchronized void queueContext(
       StepContext context,
       List<LockableResourcesStruct> requiredResources,
-      String resourceDescription) {
+      String resourceDescription,
+      String variableName) {
     for (QueuedContextStruct entry : this.queuedContexts) {
       if (entry.getContext() == context) {
         return;
@@ -864,7 +863,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     this.queuedContexts.add(
-        new QueuedContextStruct(context, requiredResources, resourceDescription));
+        new QueuedContextStruct(context, requiredResources, resourceDescription, variableName));
     save();
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -36,12 +36,18 @@ public class QueuedContextStruct implements Serializable {
 	private String resourceDescription;
 
 	/*
+	 * Name of the variable to save the locks taken.
+	 */
+	private String variableName;
+
+	/*
 	 * Constructor for the QueuedContextStruct class.
 	 */
-	public QueuedContextStruct(StepContext context, List<LockableResourcesStruct> lockableResourcesStruct, String resourceDescription) {
+	public QueuedContextStruct(StepContext context, List<LockableResourcesStruct> lockableResourcesStruct, String resourceDescription, String variableName) {
 		this.context = context;
 		this.lockableResourcesStruct = lockableResourcesStruct;
 		this.resourceDescription = resourceDescription;
+		this.variableName = variableName;
 	}
 
 	/*
@@ -63,6 +69,13 @@ public class QueuedContextStruct implements Serializable {
 	 */
 	public String getResourceDescription() {
 		return this.resourceDescription;
+	}
+
+	/*
+	 * Gets the variable name to save the locks taken.
+	 */
+	public String getVariableName() {
+		return this.variableName;
 	}
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
The setting of the given variable with the locks taken for pipeline step was broken. It did not work as intended when the lock was not available directly. This is now fixed.