### PR TITLE
[FIXED JENKINS-46555] Protect against null LockableResources being crated/used

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -320,7 +320,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	private synchronized void freeResources(List<String> unlockResourceNames, @Nullable Run<?, ?> build) {
 		for (String unlockResourceName : unlockResourceNames) {
 			for (LockableResource resource : this.resources) {
-				if (resource.getName().equals(unlockResourceName)) {
+				if (resource != null && resource.getName() != null && resource.getName().equals(unlockResourceName)) {
 					if (build == null || (resource.getBuild() != null && build.getExternalizableId().equals(resource.getBuild().getExternalizableId()))) {
 						// No more contexts, unlock resource
 						resource.unqueue();
@@ -481,21 +481,25 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	 * Creates the resource if it does not exist.
 	 */
 	public synchronized boolean createResource(String name) {
-		LockableResource existent = fromName(name);
-		if (existent == null) {
-			getResources().add(new LockableResource(name));
-			save();
-			return true;
+		if (name != null) {
+			LockableResource existent = fromName(name);
+			if (existent == null) {
+				getResources().add(new LockableResource(name));
+				save();
+				return true;
+			}
 		}
 		return false;
 	}
 
 	public synchronized boolean createResourceWithLabel(String name, String label) {
-		LockableResource existent = fromName(name);
-		if (existent == null) {
-			getResources().add(new LockableResource(name, "", label, null));
-			save();
-			return true;
+		if (name !=null && label !=null) {
+			LockableResource existent = fromName(name);
+			if (existent == null) {
+				getResources().add(new LockableResource(name, "", label, null));
+				save();
+				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
Some users might be creating locks programmatically with [createResource](https://github.com/jenkinsci/lockable-resources-plugin/blob/lockable-resources-2.3/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java#L483) or [createResourceWithLabel](https://github.com/jenkinsci/lockable-resources-plugin/blob/lockable-resources-2.3/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java#L493) and it produces that sometimes null locks are created.

Entries without `<name>` tag are created on this case.

```
<org.jenkins.plugins.lockableresources.LockableResource>
<description></description>
<labels></labels>
<queueItemId>0</queueItemId>
<queuingStarted>0</queuingStarted>
<queuedContexts/>
</org.jenkins.plugins.lockableresources.LockableResource>
```

And the following stacktrace could be seen on the build console output - taken from version 1.11.2

```
java.lang.NullPointerException
	at org.jenkins.plugins.lockableresources.LockableResourcesManager.freeResources(LockableResourcesManager.java:261)
	at org.jenkins.plugins.lockableresources.LockableResourcesManager.unlockNames(LockableResourcesManager.java:300)
	at org.jenkins.plugins.lockableresources.LockableResourcesManager.unlock(LockableResourcesManager.java:285)
	at org.jenkins.plugins.lockableresources.LockableResourcesManager.unlock(LockableResourcesManager.java:273)
	at org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction.doUnlock(LockableResourcesRootAction.java:103)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:184)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:117)
	at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:129)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:715)
Caused: javax.servlet.ServletException
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:765)
```

The following code protects against these `NullPointerException`

@amuniz @abayer @dariver
