### PR TITLE
JENKINS-55182 / #121: add support for configuration as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This plugins allows to define "lockable resources" in the global configuration.
 These resources can then be "required" by jobs. If a job requires a resource
 which is already locked, it will be put in queue until the resource is released.
+
+## Configuration as Code
+This plugin can be configured via [Configuration-as-Code](https://github.com/jenkinsci/configuration-as-code-plugin).
+For details, please see the [demo configuration](https://github.com/jenkinsci/configuration-as-code-plugin).


### PR DESCRIPTION
Currently without unit test due to the old jenkins 1.609.1 version.

If the jenkins version for unit-tests will be updated to 2.60.3 or newer, we can write a unit test according to  https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/REQUIREMENTS.md
