### PR TITLE
Modernize build (Require Java 8 & Jenkins 2.60.3)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
-buildPlugin()
+#!groovy
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.24</version>
+		<version>3.37</version>
 		<relativePath />
 	</parent>
 
@@ -27,15 +27,12 @@
 		computers) that can be used by builds. If a build requires an external
 		resource which is already locked, it will wait for the resource to be free.
 	</description>
-	<url>https://wiki.jenkins-ci.org/display/JENKINS/Lockable+Resources+Plugin</url>
+	<url>https://wiki.jenkins.io/display/JENKINS/Lockable+Resources+Plugin</url>
 
 	<properties>
-		<!-- First version including TailCall is 1.9, and the same baseline is maintained
-		until 1.14, so let's pick up the greatest -->
-		<workflow.version>1.14</workflow.version>
-		<jenkins.version>1.609.1</jenkins.version>
-		<!-- TODO activate this and fix findbugs errors -->
-		<findbugs.failOnError>false</findbugs.failOnError>
+		<java.level>8</java.level>
+		<workflow-support.version>2.12</workflow-support.version>
+		<jenkins.version>2.60.3</jenkins.version>
 	</properties>
 
 	<licenses>
@@ -72,17 +69,12 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.5</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-step-api</artifactId>
-			<version>${workflow.version}</version>
+			<version>1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-support</artifactId>
-			<version>${workflow.version}</version>
+			<version>${workflow-support.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -92,39 +84,45 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>script-security</artifactId>
-			<version>1.26</version>
+			<version>1.33</version>
 		</dependency>
 		<dependency>
 			<groupId>com.infradna.tool</groupId>
 			<artifactId>bridge-method-annotation</artifactId>
 			<version>1.14</version>
-			<optional>true</optional>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jenkins-ci</groupId>
+					<artifactId>annotation-indexer</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Testing scope -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-aggregator</artifactId>
-			<version>${workflow.version}</version>
+			<artifactId>workflow-support</artifactId>
+			<version>${workflow-support.version}</version>
+			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-support</artifactId>
-			<version>${workflow.version}</version>
-			<classifier>tests</classifier>
+			<artifactId>workflow-basic-steps</artifactId>
+			<version>2.2</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency> <!-- Required by workflow-cps-global-lib (transitive of git-server) -->
-			<groupId>org.jenkins-ci.modules</groupId>
-			<artifactId>sshd</artifactId>
-			<version>1.6</version>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<version>2.10</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency><!-- Required when testing against core > 1.575 -->
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>junit</artifactId>
-			<version>1.13</version>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>2.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -143,7 +141,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.2</version>
 				<configuration>
 					<updateDependencies>false</updateDependencies>
 				</configuration>
@@ -154,14 +151,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 
@@ -169,7 +166,7 @@
 		<connection>scm:git:https://github.com/jenkinsci/lockable-resources-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/lockable-resources-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/lockable-resources-plugin</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 </project>

--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -18,9 +18,6 @@ import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
-import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
-import org.jenkins.plugins.lockableresources.LockableResource;
-import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,9 +31,9 @@ public final class BackwardCompatibility {
 		List<LockableResource> resources = LockableResourcesManager.get().getResources();
 		for (LockableResource resource : resources) {
 			List<StepContext> queuedContexts = resource.getQueuedContexts();
-			if (queuedContexts.size() > 0) {
+			if (!queuedContexts.isEmpty()) {
 				for (StepContext queuedContext : queuedContexts) {
-					List<String> resourcesNames = new ArrayList<String>();
+					List<String> resourcesNames = new ArrayList<>();
 					resourcesNames.add(resource.getName());
 					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
 					LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName());

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -2,7 +2,6 @@ package org.jenkins.plugins.lockableresources;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
@@ -14,9 +13,7 @@ import org.kohsuke.stapler.QueryParameter;
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
 import hudson.util.FormValidation;
-import hudson.Util;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public class LockStep extends AbstractStepImpl implements Serializable {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -52,7 +52,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
 
 		for (LockStepResource resource : step.getResources()) {
-			List<String> resources = new ArrayList<String>();
+			List<String> resources = new ArrayList<>();
 			if (resource.resource != null) {
 				if (LockableResourcesManager.get().createResource(resource.resource)) {
 					listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
@@ -87,8 +87,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		try {
 			PauseAction.endCurrentPause(node);
 			BodyInvoker bodyInvoker = context.newBodyInvoker().
-				withCallback(new Callback(resourcenames, resourceDescription, variable, inversePrecedence)).
-				withDisplayName(null);
+				withCallback(new Callback(resourcenames, resourceDescription, variable, inversePrecedence));
 			if(variable != null && variable.length()>0)
 				// set the variable for the duration of the block
 				bodyInvoker.withContext(EnvironmentExpander.merge(context.get(EnvironmentExpander.class), new EnvironmentExpander() {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -2,8 +2,6 @@ package org.jenkins.plugins.lockableresources;
 
 import java.io.Serializable;
 
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -15,7 +13,6 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.Util;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public class LockStepResource extends AbstractDescribableImpl<LockStepResource> implements Serializable {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -9,9 +9,7 @@
 package org.jenkins.plugins.lockableresources;
 
 import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
 import hudson.Extension;
-import hudson.PluginManager;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.AbstractBuild;
@@ -23,11 +21,9 @@ import hudson.model.Queue.Task;
 import hudson.model.User;
 import hudson.tasks.Mailer.UserProperty;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -37,7 +33,6 @@ import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jinterop.winreg.IJIWinReg.saveFile;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.Exported;
@@ -78,7 +73,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	 * could be locked at once. See queuedContexts in {@link LockableResourcesManager}.
 	 */
 	@Deprecated
-	private List<StepContext> queuedContexts = new ArrayList<StepContext>();
+	private List<StepContext> queuedContexts = new ArrayList<>();
 
 	@Deprecated
 	public LockableResource(
@@ -96,7 +91,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 
 	private Object readResolve() {
 		if (queuedContexts == null) { // this field was added after the initial version if this class
-			queuedContexts = new ArrayList<StepContext>();
+			queuedContexts = new ArrayList<>();
 		}
 		return this;
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -11,7 +11,6 @@ package org.jenkins.plugins.lockableresources;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.BulkChange;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -59,10 +57,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	 * Only used when this lockable resource is tried to be locked by {@link LockStep},
 	 * otherwise (freestyle builds) regular Jenkins queue is used.
 	 */
-	private List<QueuedContextStruct> queuedContexts = new ArrayList<QueuedContextStruct>();
+	private List<QueuedContextStruct> queuedContexts = new ArrayList<>();
 
 	public LockableResourcesManager() {
-		resources = new ArrayList<LockableResource>();
+		resources = new ArrayList<>();
 		load();
 	}
 
@@ -71,7 +69,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	}
 
 	public List<LockableResource> getResourcesFromProject(String fullName) {
-		List<LockableResource> matching = new ArrayList<LockableResource>();
+		List<LockableResource> matching = new ArrayList<>();
 		for (LockableResource r : resources) {
 			String rName = r.getQueueItemProject();
 			if (rName != null && rName.equals(fullName)) {
@@ -82,7 +80,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	}
 
 	public List<LockableResource> getResourcesFromBuild(Run<?, ?> build) {
-		List<LockableResource> matching = new ArrayList<LockableResource>();
+		List<LockableResource> matching = new ArrayList<>();
 		for (LockableResource r : resources) {
 			Run<?, ?> rBuild = r.getBuild();
 			if (rBuild != null && rBuild == build) {
@@ -99,7 +97,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	public Set<String> getAllLabels()
 	{
-		Set<String> labels = new HashSet<String>();
+		Set<String> labels = new HashSet<>();
 		for (LockableResource r : this.resources) {
 			String rl = r.getLabels();
 			if (rl == null || "".equals(rl))
@@ -123,7 +121,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	public List<LockableResource> getResourcesWithLabel(String label,
 			Map<String, Object> params) {
-		List<LockableResource> found = new ArrayList<LockableResource>();
+		List<LockableResource> found = new ArrayList<>();
 		for (LockableResource r : this.resources) {
 			if (r.isValidLabel(label, params))
 				found.add(r);
@@ -143,7 +141,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	@Nonnull
 	public List<LockableResource> getResourcesMatchingScript(@Nonnull SecureGroovyScript script,
                                                              @CheckForNull Map<String, Object> params) throws ExecutionException{
-		List<LockableResource> found = new ArrayList<LockableResource>();
+		List<LockableResource> found = new ArrayList<>();
 		for (LockableResource r : this.resources) {
 			if (r.scriptMatches(script, params))
 				found.add(r);
@@ -206,7 +204,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	public synchronized List<LockableResource> tryQueue(LockableResourcesStruct requiredResources,
 			long queueItemId, String queueItemProject, int number,
 			Map<String, Object> params, Logger log) throws ExecutionException {
-		List<LockableResource> selected = new ArrayList<LockableResource>();
+		List<LockableResource> selected = new ArrayList<>();
 
 		if (!checkCurrentResourcesStatus(selected, queueItemProject, queueItemId, log)) {
 			// The project has another buildable item waiting -> bail out
@@ -217,7 +215,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		}
 
 		boolean candidatesByScript=false;
-		List<LockableResource> candidates = new ArrayList<LockableResource>();
+		List<LockableResource> candidates = new ArrayList<>();
                 final SecureGroovyScript systemGroovyScript = requiredResources.getResourceMatchScript();
 		if (requiredResources.label != null && requiredResources.label.isEmpty() && systemGroovyScript == null) {
 			candidates = requiredResources.required;
@@ -237,7 +235,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 		// if did not get wanted amount or did not get all
 		final int required_amount;
-		if (candidatesByScript && candidates.size() == 0) {
+		if (candidatesByScript && candidates.isEmpty()) {
 		/**
 		  * If the groovy script does not return any candidates, it means nothing is needed, even
 		  * if a higher amount is specified. A valid use case is a Matrix job, when not all
@@ -318,7 +316,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			if (context != null) {
 				// since LockableResource contains transient variables, they cannot be correctly serialized
 				// hence we use their unique resource names
-				List<String> resourceNames = new ArrayList<String>();
+				List<String> resourceNames = new ArrayList<>();
 				for (LockableResource resource : resources) {
 					resourceNames.add(resource.getName());
 				}
@@ -349,7 +347,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	public synchronized void unlock(@Nullable List<LockableResource> resourcesToUnLock,
 									@Nullable Run<?, ?> build, String requiredVar, boolean inversePrecedence) {
-		List<String> resourceNamesToUnLock = new ArrayList<String>();
+		List<String> resourceNamesToUnLock = new ArrayList<>();
 		if (resourcesToUnLock != null) {
 			for (LockableResource r : resourcesToUnLock) {
 				resourceNamesToUnLock.add(r.getName());
@@ -361,7 +359,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	public synchronized void unlockNames(@Nullable List<String> resourceNamesToUnLock, @Nullable Run<?, ?> build, String requiredVar, boolean inversePrecedence) {
 		// make sure there is a list of resource names to unlock
-		if (resourceNamesToUnLock == null || (resourceNamesToUnLock.size() == 0)) {
+		if (resourceNamesToUnLock == null || (resourceNamesToUnLock.isEmpty())) {
 			return;
 		}
 
@@ -400,7 +398,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 				// remove context from queue and process it
 				unqueueContext(nextContext.getContext());
 
-				List<String> resourceNamesToLock = new ArrayList<String>();
+				List<String> resourceNamesToLock = new ArrayList<>();
 
 				// lock all (old and new resources)
 				for (LockableResource requiredResource : requiredResourceForNextContext) {
@@ -419,7 +417,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 				}
 
 				// determine old resources no longer needed
-				List<String> freeResources = new ArrayList<String>();
+				List<String> freeResources = new ArrayList<>();
 				for (String resourceNameToUnlock : remainingResourceNamesToUnLock) {
 					boolean resourceStillNeeded = false;
 					for (LockableResource requiredResource : requiredResourceForNextContext) {
@@ -454,7 +452,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	@CheckForNull
 	private QueuedContextStruct getNextQueuedContext(List<String> resourceNamesToUnLock, boolean inversePrecedence, QueuedContextStruct from) {
 		QueuedContextStruct newestEntry = null;
-		List<LockableResource> requiredResourceForNextContext = null;
 		int fromIndex = from != null ? this.queuedContexts.indexOf(from) + 1 : 0;
 		if (!inversePrecedence) {
 			for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
@@ -465,7 +462,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			}
 		} else {
 			long newest = 0;
-			List<QueuedContextStruct> orphan = new ArrayList<QueuedContextStruct>();
+			List<QueuedContextStruct> orphan = new ArrayList<>();
 			for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
 				QueuedContextStruct entry = this.queuedContexts.get(i);
 				if (checkResourcesAvailability(entry.getResources(), null, resourceNamesToUnLock) != null) {
@@ -538,7 +535,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	}
 	public synchronized void unreserve(List<LockableResource> resources) {
 		// make sure there is a list of resources to unreserve
-		if (resources == null || (resources.size() == 0)) {
+		if (resources == null || (resources.isEmpty())) {
 			return;
 		}
 		List<String> resourceNamesToUnreserve = new ArrayList<>();
@@ -591,7 +588,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 			return;
 		} else {
 			unreserveResources(resources);
-			List<String> resourceNamesToLock = new ArrayList<String>();
+			List<String> resourceNamesToLock = new ArrayList<>();
 
 			// lock all (old and new resources)
 			for (LockableResource requiredResource : requiredResourceForNextContext) {
@@ -687,7 +684,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 		for (LockableResourcesCandidatesStruct requiredResources : requiredResourcesCandidatesList) {
 			// start with an empty set of selected resources
-			List<LockableResource> selected = new ArrayList<LockableResource>();
+			List<LockableResource> selected = new ArrayList<>();
 
 			// some resources might be already locked, but will be freed.
 			// Determine if these resources can be reused
@@ -786,6 +783,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 				.getDescriptorOrDie(LockableResourcesManager.class);
 	}
 
+	@Override
 	public synchronized void save() {
                 if(BulkChange.contains(this))
                     return;

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -159,7 +159,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 				return FormValidation.error(
 						"Only label, groovy expression, or resources can be defined, not more than one.");
 			} else {
-				List<String> wrongNames = new ArrayList<String>();
+				List<String> wrongNames = new ArrayList<>();
 				for (String name : names.split("\\s+")) {
 					boolean found = false;
 					for (LockableResource r : LockableResourcesManager.get()

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -99,7 +99,7 @@ public class LockableResourcesRootAction implements RootAction {
 			return;
 		}
 
-		List<LockableResource> resources = new ArrayList<LockableResource>();
+		List<LockableResource> resources = new ArrayList<>();
 		resources.add(r);
 		LockableResourcesManager.get().unlock(resources, null);
 
@@ -117,7 +117,7 @@ public class LockableResourcesRootAction implements RootAction {
 			return;
 		}
 
-		List<LockableResource> resources = new ArrayList<LockableResource>();
+		List<LockableResource> resources = new ArrayList<>();
 		resources.add(r);
 		String userName = getUserName();
 		if (userName != null)
@@ -143,7 +143,7 @@ public class LockableResourcesRootAction implements RootAction {
 			throw new AccessDeniedException2(Jenkins.getAuthentication(),
 					RESERVE);
 
-		List<LockableResource> resources = new ArrayList<LockableResource>();
+		List<LockableResource> resources = new ArrayList<>();
 		resources.add(r);
 		LockableResourcesManager.get().unreserve(resources);
 
@@ -161,7 +161,7 @@ public class LockableResourcesRootAction implements RootAction {
 			return;
 		}
 
-		List<LockableResource> resources = new ArrayList<LockableResource>();
+		List<LockableResource> resources = new ArrayList<>();
 		resources.add(r);
 		LockableResourcesManager.get().reset(resources);
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -42,7 +42,7 @@ public class LockedResourcesBuildAction implements Action {
 
 	public static LockedResourcesBuildAction fromResources(
 			Collection<LockableResource> resources) {
-		List<ResourcePOJO> resPojos = new ArrayList<ResourcePOJO>();
+		List<ResourcePOJO> resPojos = new ArrayList<>();
 		for (LockableResource r : resources)
 			resPojos.add(new ResourcePOJO(r));
 		return new LockedResourcesBuildAction(resPojos);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -17,7 +17,6 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.model.StringParameterValue;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,7 +43,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
 		if (build instanceof AbstractBuild) {
 			Job<?, ?> proj = Utils.getProject(build);
-			Set<LockableResource> required = new HashSet<LockableResource>();
+			Set<LockableResource> required = new HashSet<>();
 			if (proj != null) {
 				LockableResourcesStruct resources = Utils.requiredResources(proj);
 
@@ -77,8 +76,6 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 				}
 			}
 		}
-
-		return;
 	}
 
 	@Override
@@ -91,7 +88,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 		// obviously project name cannot be obtained here
 		List<LockableResource> required = LockableResourcesManager.get()
 				.getResourcesFromBuild(build);
-		if (required.size() > 0) {
+		if (!required.isEmpty()) {
 			LockableResourcesManager.get().unlock(required, build);
 			listener.getLogger().printf("%s released lock on %s%n",
 					LOG_PREFIX, required);
@@ -110,7 +107,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
 		List<LockableResource> required = LockableResourcesManager.get()
 				.getResourcesFromBuild(build);
-		if (required.size() > 0) {
+		if (!required.isEmpty()) {
 			LockableResourcesManager.get().unlock(required, build);
 			LOGGER.fine(build.getFullDisplayName() + " released lock on "
 					+ required);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -14,7 +14,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.queue.QueueTaskDispatcher;
@@ -31,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.time.DateUtils;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.kohsuke.accmod.Restricted;
@@ -73,7 +71,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 			" trying to get resources with these details: " + resources);
 
 		if (resourceNumber > 0 || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {
-			Map<String, Object> params = new HashMap<String, Object>();
+			Map<String, Object> params = new HashMap<>();
 
 			// Inject Build Parameters, if possible and applicable to the "item" type
 			try {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -9,9 +9,6 @@
 package org.jenkins.plugins.lockableresources.queue;
 
 import hudson.EnvVars;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +37,7 @@ public class LockableResourcesStruct implements Serializable {
 
 	public LockableResourcesStruct(RequiredResourcesProperty property,
 			EnvVars env) {
-		required = new ArrayList<LockableResource>();
+		required = new ArrayList<>();
 		for (String name : property.getResources()) {
 			LockableResource r = LockableResourcesManager.get().fromName(
 				env.expand(name));
@@ -77,7 +74,7 @@ public class LockableResourcesStruct implements Serializable {
 	}
 
 	public LockableResourcesStruct(@Nullable List<String> resources, @Nullable String label, int quantity) {
-		required = new ArrayList<LockableResource>();
+		required = new ArrayList<>();
 		if (resources != null) {
 			for (String resource : resources) {
 				LockableResource r = LockableResourcesManager.get().fromName(resource);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -12,9 +12,6 @@ import java.io.Serializable;
 import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /*
  * This class is used to queue pipeline contexts

--- a/src/test/java/org/jenkins/plugins/lockableresources/BasicIntegrationTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/BasicIntegrationTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.model.Queue;
 import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -442,7 +442,7 @@ public class LockStepTest {
 				));
 
 				FreeStyleProject f = story.j.createFreeStyleProject("f");
-				f.addProperty(new RequiredResourcesProperty("resource1", null, null, null));
+				f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
 				f.getBuildersList().add(new TestBuilder() {
 
 					@Override
@@ -485,7 +485,7 @@ public class LockStepTest {
 				isPaused(b1, 1, 0);
 
 				FreeStyleProject f = story.j.createFreeStyleProject("f");
-				f.addProperty(new RequiredResourcesProperty("resource1", null, null, null));
+				f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
 
 				f.scheduleBuild2(0);
 
@@ -895,7 +895,7 @@ public class LockStepTest {
 						public void run() {
 							try {
 								barrier.await();
-								WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+								p.scheduleBuild2(0).waitForStart();
 							} catch (Exception e) {
 								System.err.println("Failed to start pipeline job");
 							}

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
@@ -26,7 +26,7 @@ package org.jenkins.plugins.lockableresources;
 import com.gargoylesoftware.htmlunit.AlertHandler;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
@@ -81,11 +81,11 @@ public class LockableResourceRootActionSEC1361Test {
         
         // currently only one button but perhaps in future version of the core/plugin, 
         // other buttons will be added to the layout
-        List<HtmlButton> allButtons = htmlPage.getDocumentElement().getHtmlElementsByTagName("button");
+        List<HtmlElement> allButtons = htmlPage.getDocumentElement().getElementsByTagName("button");
         assertThat(allButtons.size(), greaterThanOrEqualTo(1));
         
-        HtmlButton reserveButton = null;
-        for (HtmlButton b : allButtons) {
+        HtmlElement reserveButton = null;
+        for (HtmlElement b : allButtons) {
             String onClick = b.getAttribute("onClick");
             if (onClick != null && onClick.contains("reserve_resource")) {
                 reserveButton = b;


### PR DESCRIPTION
Update to Jenkins 2.60.3 (released 2017-08-17) and Java 8

Considerations:
- From [Telemetry](http://stats.jenkins.io/pluginversions/lockable-resources.html) we can see, that this only "affects" 553/112545 (0.5%) of users
- If we only consider the last 4 releases (2.1-2.4), this affects 185/111776 (just under 0.2%) of "updating" users

Changes:
- Update plugin parent (replaces FindBugs with SpotBugs)
- Doesn't use the pipeline aggregator anymore, but individual dependencies
- Re-enables SpotBugs (and fix the one place it found)
- Build against recommended Jenkins/JDK versions (not sure if all combinations work, a member of this project needs to push my branch to make Jenkins pick up the Jenkinsfile change)
- Plugin dependencies are updated, but still older then the required Jenkins baseline...