### PR TITLE
Create implicit locks as ephemeral

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -59,6 +59,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	private String description = "";
 	private String labels = "";
 	private String reservedBy = null;
+  private boolean ephemeral;
 
 	private long queueItemId = NOT_QUEUED;
 	private String queueItemProject = null;
@@ -125,6 +126,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 	public String getLabels() {
 		return labels;
 	}
+
+  @DataBoundSetter
+  public void setEphemeral(boolean ephemeral) {
+    this.ephemeral = ephemeral;
+  }
+
+  @Exported
+  public boolean isEphemeral() {
+    return ephemeral;
+  }
 
 	public boolean isValidLabel(String candidate, Map<String, Object> params) {
 		return labelsContain(candidate);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -329,12 +329,23 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
 	private synchronized void freeResources(List<String> unlockResourceNames, @Nullable Run<?, ?> build) {
 		for (String unlockResourceName : unlockResourceNames) {
-			for (LockableResource resource : this.resources) {
-				if (resource != null && resource.getName() != null && resource.getName().equals(unlockResourceName)) {
-					if (build == null || (resource.getBuild() != null && build.getExternalizableId().equals(resource.getBuild().getExternalizableId()))) {
+      Iterator<LockableResource> resourceIterator = this.resources.iterator();
+      while (resourceIterator.hasNext()) {
+        LockableResource resource = resourceIterator.next();
+        if (resource != null
+          && resource.getName() != null
+          && resource.getName().equals(unlockResourceName)) {
+          if (build == null
+            || (resource.getBuild() != null
+            && build
+            .getExternalizableId()
+            .equals(resource.getBuild().getExternalizableId()))) {
 						// No more contexts, unlock resource
 						resource.unqueue();
 						resource.setBuild(null);
+            if (resource.isEphemeral()) {
+              resourceIterator.remove();
+            }
 					}
 				}
 			}
@@ -493,7 +504,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 		if (name != null) {
 			LockableResource existent = fromName(name);
 			if (existent == null) {
-				getResources().add(new LockableResource(name));
+        LockableResource resource = new LockableResource(name);
+        resource.setEphemeral(true);
+        getResources().add(resource);
 				save();
 				return true;
 			}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -15,6 +15,7 @@ import hudson.model.Run;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -67,6 +68,20 @@ public class LockableResourcesManager extends GlobalConfiguration {
 	public List<LockableResource> getResources() {
 		return resources;
 	}
+
+  public List<LockableResource> getDeclaredResources() {
+    ArrayList<LockableResource> declaredResources = new ArrayList<>();
+    for (LockableResource r : resources) {
+      if (!r.isEphemeral()) {
+        declaredResources.add(r);
+      }
+    }
+    return declaredResources;
+  }
+
+  public void setDeclaredResources(List<LockableResource> resources) {
+    this.resources = resources;
+  }
 
 	public List<LockableResource> getResourcesFromProject(String fullName) {
 		List<LockableResource> matching = new ArrayList<>();

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
@@ -13,7 +13,7 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:section title="${%Lockable Resources Manager}">
 		<f:entry title="${%Lockable Resources}">
-			<f:repeatable field="resources" header="${%Resource}" minimum="0" add="${%Add Lockable Resource}">
+			<f:repeatable field="declaredResources" header="${%Resource}" minimum="0" add="${%Add Lockable Resource}">
 				<table width="100%">
 					<st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockableResource"/>
 					<f:entry title="">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -29,6 +29,7 @@
             <td class="pane-header">Resource</td>
             <td class="pane-header">Status</td>
             <td class="pane-header">Labels</td>
+            <td class="pane-header">Ephemeral</td>
             <td class="pane-header">Action</td>
           </tr>
           <j:forEach var="resource" items="${it.resources}" indexVar="i">
@@ -49,6 +50,7 @@
                   </a>
                 </td>
                 <td class="pane">${resource.labels}</td>
+                <td class="pane">${resource.ephemeral}</td>
                 <td class="pane">
                   <j:if test="${h.hasPermission(it.UNLOCK)}">
                     <button onClick="resource_action(this, 'unlock');">Unlock</button>
@@ -63,6 +65,7 @@
                     <strong>${resource.reservedBy}</strong>
                   </td>
                   <td class="pane">${resource.labels}</td>
+                  <td class="pane">${resource.ephemeral}</td>
                   <td class="pane">
                     <j:if test="${h.hasPermission(it.RESERVE)}">
                       <j:if
@@ -78,6 +81,7 @@
                       QUEUED by "${resource.queueItemProject} ${resource.queueItemId}"
                     </td>
                     <td class="pane">${resource.labels}</td>
+                    <td class="pane">${resource.ephemeral}</td>
                     <td class="pane">
                       <j:if test="${h.hasPermission(it.UNLOCK)}">
                         <button onClick="resource_action(this, 'reset');">ResetResource</button>
@@ -89,6 +93,7 @@
                       <strong>FREE</strong>
                     </td>
                     <td class="pane">${resource.labels}</td>
+                    <td class="pane">${resource.ephemeral}</td>
                     <td class="pane">
                       <j:if test="${h.hasPermission(it.RESERVE) and it.UserName != null}">
                         <button onClick="resource_action(this, 'reserve');">Reserve</button>

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -1,6 +1,7 @@
 package org.jenkins.plugins.lockableresources;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
@@ -37,6 +38,8 @@ public class LockStepTest extends LockStepTestBase {
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.SUCCESS, b1);
     j.assertLogContains("Resource [resource1] did not exist. Created.", b1);
+
+    assertNull(LockableResourcesManager.get().fromName("resource1"));
   }
 
   @Test
@@ -58,6 +61,9 @@ public class LockStepTest extends LockStepTestBase {
     }
 
     j.waitForMessage("acquired lock on [resource1]", fb1);
+    j.waitForCompletion(fb1);
+
+    assertNull(LockableResourcesManager.get().fromName("resource1"));
   }
 
   @Test
@@ -76,6 +82,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Lock released on resource [Label: label1]", b1);
     j.assertLogContains("Resource locked: resource1", b1);
     isPaused(b1, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
   }
 
   @Test
@@ -118,6 +126,10 @@ public class LockStepTest extends LockStepTestBase {
     SemaphoreStep.success("wait-inside/3", null);
     j.waitForMessage("Finish", b3);
     isPaused(b3, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource3"));
   }
 
   @Test
@@ -166,6 +178,10 @@ public class LockStepTest extends LockStepTestBase {
     SemaphoreStep.success("wait-inside/2", null);
     j.waitForMessage("Finish", b2);
     isPaused(b2, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource3"));
   }
 
   @Test
@@ -220,6 +236,10 @@ public class LockStepTest extends LockStepTestBase {
     j.waitForMessage("Finish", b3);
     isPaused(b2, 1, 0);
     isPaused(b3, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource3"));
   }
 
   @Test
@@ -324,6 +344,8 @@ public class LockStepTest extends LockStepTestBase {
 
     j.waitForMessage("[a] Lock acquired on [resource1]", b1);
     isPaused(b1, 2, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
   }
 
   @Test
@@ -721,6 +743,10 @@ public class LockStepTest extends LockStepTestBase {
     SemaphoreStep.success("wait-inside-p3/1", null);
     j.waitForMessage("Finish", b3);
     isPaused(b3, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource3"));
   }
 
   @Test
@@ -791,5 +817,10 @@ public class LockStepTest extends LockStepTestBase {
     // Could be any 3 resources, so just check the beginning of the message
     j.assertLogContains("Resources locked: [resource", b2);
     isPaused(b2, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource3"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource4"));
   }
 }


### PR DESCRIPTION
Motivation: I want to use the commit identifier in the lock, but do not kill Jenkins with garbage locks.

The basic idea: automatically remove locks if they were not explicitly declared in the config.

Changes:
- If lock was not created manually by `Configure System`, it became ephemeral and would removed after free (`isEphemeral` flag are preset in `Lockable Resources` page);
- Ephemeral locks is not present in `Manage Jenkins` > `Configure System` page;
- Ephemeral locks became non-ephemeral on declaring lock in `Configure System` page;
- Non-ephemeral locks became ephemeral on delete locked resource from `Configure System` page.

Also I found a minor bug on autocreation lock resources from `Free Style` jobs (see: #139).