### PR TITLE
Avoid "Waiting for resources []" queue notice when a script is used

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -22,6 +22,9 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 
 public class LockableResourcesStruct implements Serializable {
 
+  // Note to developers: if the set of selection criteria variables evolves,
+  // do not forget to update LockableResourcesQueueTaskDispatcher.java with
+  // class BecauseResourcesLocked method getShortDescription() for user info.
   public List<LockableResource> required;
   public String label;
   public String requiredVar;


### PR DESCRIPTION
Try to classify better what is the real cause of waiting for a resource, now that we have several reasons to choose from.