### PR TITLE
Protecting the LockableResourcesManager from Races

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -28,17 +28,19 @@ public final class BackwardCompatibility {
 	@Initializer(after = InitMilestone.JOB_LOADED)
 	public static void compatibilityMigration() {
 		LOG.log(Level.FINE, "lockable-resource-plugin compatibility migration task run");
-		List<LockableResource> resources = LockableResourcesManager.get().getResources();
-		for (LockableResource resource : resources) {
-			List<StepContext> queuedContexts = resource.getQueuedContexts();
-			if (!queuedContexts.isEmpty()) {
-				for (StepContext queuedContext : queuedContexts) {
-					List<String> resourcesNames = new ArrayList<>();
-					resourcesNames.add(resource.getName());
-					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-					LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName(), null);
+		synchronized(LockableResourcesManager.get()) {
+			List<LockableResource> resources = LockableResourcesManager.get().getResources();
+			for (LockableResource resource : resources) {
+				List<StepContext> queuedContexts = resource.getQueuedContexts();
+				if (!queuedContexts.isEmpty()) {
+					for (StepContext queuedContext : queuedContexts) {
+						List<String> resourcesNames = new ArrayList<>();
+						resourcesNames.add(resource.getName());
+						LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
+						LockableResourcesManager.get().queueContext(queuedContext, Arrays.asList(resourceHolder), resource.getName(), null);
+					}
+					queuedContexts.clear();
 				}
-				queuedContexts.clear();
 			}
 		}
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResources.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResources.java
@@ -26,8 +26,11 @@ public class LockableResources extends Plugin {
 
 	@Exported
 	public List<LockableResource> getResources() {
-		return Collections.unmodifiableList(LockableResourcesManager.get()
+		List<LockableResource> returnList;
+		synchronized(LockableResourcesManager.get()) {
+			returnList = Collections.unmodifiableList(LockableResourcesManager.get()
 				.getResources());
+		}
+		return returnList;
 	}
-
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -103,7 +103,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     this.resources = mergedResources;
   }
 
-  public List<LockableResource> getResourcesFromProject(String fullName) {
+  public synchronized List<LockableResource> getResourcesFromProject(String fullName) {
     List<LockableResource> matching = new ArrayList<>();
     for (LockableResource r : resources) {
       String rName = r.getQueueItemProject();
@@ -114,7 +114,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return matching;
   }
 
-  public List<LockableResource> getResourcesFromBuild(Run<?, ?> build) {
+  public synchronized List<LockableResource> getResourcesFromBuild(Run<?, ?> build) {
     List<LockableResource> matching = new ArrayList<>();
     for (LockableResource r : resources) {
       Run<?, ?> rBuild = r.getBuild();
@@ -125,11 +125,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return matching;
   }
 
-  public Boolean isValidLabel(String label) {
+  public synchronized Boolean isValidLabel(String label) {
     return this.getAllLabels().contains(label);
   }
 
-  public Set<String> getAllLabels() {
+  public synchronized Set<String> getAllLabels() {
     Set<String> labels = new HashSet<>();
     for (LockableResource r : this.resources) {
       String rl = r.getLabels();
@@ -139,7 +139,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return labels;
   }
 
-  public int getFreeResourceAmount(String label) {
+  public synchronized int getFreeResourceAmount(String label) {
     int free = 0;
     for (LockableResource r : this.resources) {
       if (r.isLocked() || r.isQueued() || r.isReserved()) continue;
@@ -148,7 +148,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return free;
   }
 
-  public List<LockableResource> getResourcesWithLabel(String label, Map<String, Object> params) {
+  public synchronized List<LockableResource> getResourcesWithLabel(String label, Map<String, Object> params) {
     List<LockableResource> found = new ArrayList<>();
     for (LockableResource r : this.resources) {
       if (r.isValidLabel(label, params)) found.add(r);
@@ -167,7 +167,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
    * @since TODO
    */
   @Nonnull
-  public List<LockableResource> getResourcesMatchingScript(
+  public synchronized List<LockableResource> getResourcesMatchingScript(
       @Nonnull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
       throws ExecutionException {
     List<LockableResource> found = new ArrayList<>();
@@ -177,7 +177,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return found;
   }
 
-  public LockableResource fromName(String resourceName) {
+  public synchronized LockableResource fromName(String resourceName) {
     if (resourceName != null) {
       for (LockableResource r : resources) {
         if (resourceName.equals(r.getName())) return r;

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -162,11 +162,13 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 				List<String> wrongNames = new ArrayList<>();
 				for (String name : names.split("\\s+")) {
 					boolean found = false;
-					for (LockableResource r : LockableResourcesManager.get()
-							.getResources()) {
-						if (r.getName().equals(name)) {
-							found = true;
-							break;
+					synchronized(LockableResourcesManager.get()) {
+						for (LockableResource r : LockableResourcesManager.get()
+								.getResources()) {
+							if (r.getName().equals(name)) {
+								found = true;
+								break;
+							}
 						}
 					}
 					if (!found)
@@ -206,14 +208,13 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
 		public FormValidation doCheckResourceNumber(@QueryParameter String value,
 				@QueryParameter String resourceNames,
-                @QueryParameter String labelName,
-                @QueryParameter String resourceMatchScript)
-        {
+				@QueryParameter String labelName,
+				@QueryParameter String resourceMatchScript) {
 
 			String number = Util.fixEmptyAndTrim(value);
 			String names = Util.fixEmptyAndTrim(resourceNames);
 			String label = Util.fixEmptyAndTrim(labelName);
-            String script = Util.fixEmptyAndTrim(resourceMatchScript);
+			String script = Util.fixEmptyAndTrim(resourceMatchScript);
 
 			if (number == null || number.equals("") || number.trim().equals("0")) {
 				return FormValidation.ok();
@@ -229,9 +230,9 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			int numResources = 0;
 			if (names != null) {
 				numResources = names.split("\\s+").length;
-            } else if (label != null || script != null) {
-                	numResources = Integer.MAX_VALUE;
-            }
+			} else if (label != null || script != null) {
+				numResources = Integer.MAX_VALUE;
+			}
 
 			if (numResources < numAsInt) {
 				return FormValidation.error(String.format(
@@ -248,9 +249,11 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
 			value = Util.fixEmptyAndTrim(value);
 
-			for (String l : LockableResourcesManager.get().getAllLabels())
-				if (value != null && l.startsWith(value))
-					c.add(l);
+			synchronized(LockableResourcesManager.get()) {
+				for (String l : LockableResourcesManager.get().getAllLabels())
+					if (value != null && l.startsWith(value))
+						c.add(l);
+			}
 
 			return c;
 		}
@@ -262,10 +265,12 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			value = Util.fixEmptyAndTrim(value);
 
 			if (value != null) {
-				for (LockableResource r : LockableResourcesManager.get()
-						.getResources()) {
-					if (r.getName().startsWith(value))
-						c.add(r.getName());
+				synchronized(LockableResourcesManager.get()) {
+					for (LockableResource r : LockableResourcesManager.get()
+							.getResources()) {
+						if (r.getName().startsWith(value))
+							c.add(r.getName());
+					}
 				}
 			}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -93,15 +93,17 @@ public class LockableResourcesRootAction implements RootAction {
 		Jenkins.getInstance().checkPermission(UNLOCK);
 
 		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+		synchronized(LockableResourcesManager.get()) {
+			LockableResource r = LockableResourcesManager.get().fromName(name);
+			if (r == null) {
+				rsp.sendError(404, "Resource not found " + name);
+				return;
+			}
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().unlock(resources, null);
+			List<LockableResource> resources = new ArrayList<>();
+			resources.add(r);
+			LockableResourcesManager.get().unlock(resources, null);
+		}
 
 		rsp.forwardToPreviousPage(req);
 	}
@@ -111,17 +113,19 @@ public class LockableResourcesRootAction implements RootAction {
 		Jenkins.getInstance().checkPermission(RESERVE);
 
 		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+		synchronized(LockableResourcesManager.get()) {
+			LockableResource r = LockableResourcesManager.get().fromName(name);
+			if (r == null) {
+				rsp.sendError(404, "Resource not found " + name);
+				return;
+			}
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		String userName = getUserName();
-		if (userName != null)
-			LockableResourcesManager.get().reserve(resources, userName);
+			List<LockableResource> resources = new ArrayList<>();
+			resources.add(r);
+			String userName = getUserName();
+			if (userName != null)
+				LockableResourcesManager.get().reserve(resources, userName);
+		}
 
 		rsp.forwardToPreviousPage(req);
 	}
@@ -131,21 +135,23 @@ public class LockableResourcesRootAction implements RootAction {
 		Jenkins.getInstance().checkPermission(RESERVE);
 
 		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
+		synchronized(LockableResourcesManager.get()) {
+			LockableResource r = LockableResourcesManager.get().fromName(name);
+			if (r == null) {
+				rsp.sendError(404, "Resource not found " + name);
+				return;
+			}
+
+			String userName = getUserName();
+			if ((userName == null || !userName.equals(r.getReservedBy()))
+					&& !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+				throw new AccessDeniedException2(Jenkins.getAuthentication(),
+						RESERVE);
+
+			List<LockableResource> resources = new ArrayList<>();
+			resources.add(r);
+			LockableResourcesManager.get().unreserve(resources);
 		}
-
-		String userName = getUserName();
-		if ((userName == null || !userName.equals(r.getReservedBy()))
-				&& !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
-			throw new AccessDeniedException2(Jenkins.getAuthentication(),
-					RESERVE);
-
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().unreserve(resources);
 
 		rsp.forwardToPreviousPage(req);
 	}
@@ -155,15 +161,17 @@ public class LockableResourcesRootAction implements RootAction {
 		Jenkins.getInstance().checkPermission(UNLOCK);
 
 		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+		synchronized(LockableResourcesManager.get()) {
+			LockableResource r = LockableResourcesManager.get().fromName(name);
+			if (r == null) {
+				rsp.sendError(404, "Resource not found " + name);
+				return;
+			}
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().reset(resources);
+			List<LockableResource> resources = new ArrayList<>();
+			resources.add(r);
+			LockableResourcesManager.get().reset(resources);
+		}
 
 		rsp.forwardToPreviousPage(req);
 	}

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -43,9 +43,11 @@ public class LockableResourcesStruct implements Serializable {
       if (resourceName == null) {
         continue;
       }
-      resourcesManager.createResource(resourceName);
-      LockableResource r = resourcesManager.fromName(resourceName);
-      this.required.add(r);
+      synchronized(LockableResourcesManager.get()) {
+        resourcesManager.createResource(resourceName);
+        LockableResource r = resourcesManager.fromName(resourceName);
+        this.required.add(r);
+      }
     }
 
     label = env.expand(property.getLabelName());

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourcesManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Aki Asikainen.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class LockableResourcesManagerTest {
+
+  @Rule public JenkinsRule j = new JenkinsRule();
+
+  static final int LOOP_AMOUNT = 1000;
+  static final int THREAD_AMOUNT = 2;
+
+  static LockableResourcesManager manager;
+  static ExecutorService executorService;
+
+  public LockableResourcesManagerTest() {}
+
+  @BeforeClass
+  public static void setUpClass() {
+    executorService = Executors.newFixedThreadPool(4);
+  }
+
+  @AfterClass
+  public static void tearDownClass() {}
+
+  @Before
+  public void setUp() {
+    // BeforeClass is executed before the JenkinsRule, therefore set the manager here
+    manager = LockableResourcesManager.get();
+  }
+
+  @After
+  public void tearDown() {}
+
+  /** Test to simulate a concurrent write (create) and read (lock) on the resources list. */
+  @Test
+  public void testConcurrentCreateAndFetch() {
+    // start multiple thread jobs that create and fetch in parallel
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < LOOP_AMOUNT; i++) {
+      final int k = i;
+      futures.add(executorService.submit(() -> manager.fromName("r" + k)));
+      futures.add(executorService.submit(() -> createLockAndFree("r" + k, "l" + k, true)));
+    }
+    for (int i = 0; i < LOOP_AMOUNT; i++) {
+      manager.fromName("r" + i);
+    }
+
+    // wait until they are finished
+    waitUntilFuturesAreReady(futures);
+
+    // since all locks are ephemeral and unlocked, the amount of free resources must be 0
+    assertEquals(0, manager.getFreeResourceAmount("l"));
+  }
+
+  private void sleep(long ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (Exception e) {
+    }
+  }
+
+  private void createLockAndFree(String name, String label, boolean ephemeral) {
+    // create new resource
+    manager.createResourceWithLabel(name, label + " l");
+
+    // set the created resource to ephemeral
+    LockableResource resource = manager.fromName(name);
+    sleep(20);
+    resource.setEphemeral(ephemeral);
+    assertEquals(name, resource.getName());
+
+    // lock the created resource
+    List<LockableResource> resources = Arrays.asList(resource);
+    manager.lock(new HashSet<>(resources), null, null);
+
+    // unlock and remove the created resource
+    List<String> resourceStrings = Arrays.asList(name);
+    manager.unlockNames(resourceStrings, null, false);
+  }
+
+  private void waitUntilFuturesAreReady(List<Future<?>> futures) {
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (Exception e) {
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey guys,

this PR should protect the `resources` member of the LRM to avoid races (like #149).
Some of the locks might be a little bit overprotective but I think with ephemeral resources
the member will become more volatile and therefore also more vulnerable to races.

The PR is extending the current synchronization by including the scope of returned references.
As `synchronized` should behave reentrant/recursive, no deadlocks should be possible.

If further stuff is required to merge it, please feel free to tell me.
If I find time, I will also attach a test that tries to provoke such an error.

BR,
BB