### PR TITLE
Log Blocking Build

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -65,7 +65,16 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		// determine if there are enough resources available to proceed
 		Set<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
 		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.variable, step.inversePrecedence)) {
-			listener.getLogger().println("[" + step + "] is locked, waiting...");
+      // if the resource is known, we could output the active/blocking job/build
+      LockableResource resource = LockableResourcesManager.get().fromName(step.resource);
+      if (resource != null && resource.getBuildName() != null) {
+        listener
+            .getLogger()
+            .println("[" + step + "] is locked by " + resource.getBuildName() + ", waiting...");
+
+      } else {
+        listener.getLogger().println("[" + step + "] is locked, waiting...");
+      }
 			LockableResourcesManager.get().queueContext(getContext(), resourceHolderList, step.toString());
 		} // proceed is called inside lock if execution is possible
 		return false;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -1,12 +1,16 @@
 package org.jenkins.plugins.lockableresources;
 
+import com.google.common.base.Joiner;
+import com.google.inject.Inject;
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -15,56 +19,57 @@ import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
-
-import com.google.common.base.Joiner;
-import com.google.inject.Inject;
-
-import hudson.EnvVars;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 
 public class LockStepExecution extends AbstractStepExecutionImpl {
 
-	private static final Joiner COMMA_JOINER = Joiner.on(',');
+  private static final Joiner COMMA_JOINER = Joiner.on(',');
 
-    @Inject(optional = true)
-	private LockStep step;
+  @Inject(optional = true)
+  private LockStep step;
 
-	@StepContextParameter
-	private transient Run<?, ?> run;
+  @StepContextParameter private transient Run<?, ?> run;
 
-	@StepContextParameter
-	private transient TaskListener listener;
+  @StepContextParameter private transient TaskListener listener;
 
-	@StepContextParameter
-	private transient FlowNode node;
+  @StepContextParameter private transient FlowNode node;
 
-	private static final Logger LOGGER = Logger.getLogger(LockStepExecution.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(LockStepExecution.class.getName());
 
-	@Override
-	public boolean start() throws Exception {
-		step.validate();
+  @Override
+  public boolean start() throws Exception {
+    step.validate();
 
-		node.addAction(new PauseAction("Lock"));
-		listener.getLogger().println("Trying to acquire lock on [" + step + "]");
+    node.addAction(new PauseAction("Lock"));
+    listener.getLogger().println("Trying to acquire lock on [" + step + "]");
 
-		List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
+    List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
 
-		for (LockStepResource resource : step.getResources()) {
-			List<String> resources = new ArrayList<>();
-			if (resource.resource != null) {
-				if (LockableResourcesManager.get().createResource(resource.resource)) {
-					listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
-				}
-				resources.add(resource.resource);
-			}
-			resourceHolderList.add(new LockableResourcesStruct(resources, resource.label, resource.quantity));
-		}
+    for (LockStepResource resource : step.getResources()) {
+      List<String> resources = new ArrayList<>();
+      if (resource.resource != null) {
+        if (LockableResourcesManager.get().createResource(resource.resource)) {
+          listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
+        }
+        resources.add(resource.resource);
+      }
+      resourceHolderList.add(
+          new LockableResourcesStruct(resources, resource.label, resource.quantity));
+    }
 
-		// determine if there are enough resources available to proceed
-		Set<LockableResource> available = LockableResourcesManager.get().checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
-		if (available == null || !LockableResourcesManager.get().lock(available, run, getContext(), step.toString(), step.variable, step.inversePrecedence)) {
+    // determine if there are enough resources available to proceed
+    Set<LockableResource> available =
+        LockableResourcesManager.get()
+            .checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
+    if (available == null
+        || !LockableResourcesManager.get()
+            .lock(
+                available,
+                run,
+                getContext(),
+                step.toString(),
+                step.variable,
+                step.inversePrecedence)) {
       // if the resource is known, we could output the active/blocking job/build
       LockableResource resource = LockableResourcesManager.get().fromName(step.resource);
       if (resource != null && resource.getBuildName() != null) {
@@ -75,79 +80,107 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
       } else {
         listener.getLogger().println("[" + step + "] is locked, waiting...");
       }
-			LockableResourcesManager.get().queueContext(getContext(), resourceHolderList, step.toString());
-		} // proceed is called inside lock if execution is possible
-		return false;
-	}
+      LockableResourcesManager.get()
+          .queueContext(getContext(), resourceHolderList, step.toString());
+    } // proceed is called inside lock if execution is possible
+    return false;
+  }
 
-	public static void proceed(final List<String> resourcenames, StepContext context, String resourceDescription, final String variable, boolean inversePrecedence) {
-		Run<?, ?> r = null;
-		FlowNode node = null;
-		try {
-			r = context.get(Run.class);
-			node = context.get(FlowNode.class);
-			context.get(TaskListener.class).getLogger().println("Lock acquired on [" + resourceDescription + "]");
-		} catch (Exception e) {
-			context.onFailure(e);
-			return;
-		}
+  public static void proceed(
+      final List<String> resourcenames,
+      StepContext context,
+      String resourceDescription,
+      final String variable,
+      boolean inversePrecedence) {
+    Run<?, ?> r = null;
+    FlowNode node = null;
+    try {
+      r = context.get(Run.class);
+      node = context.get(FlowNode.class);
+      context
+          .get(TaskListener.class)
+          .getLogger()
+          .println("Lock acquired on [" + resourceDescription + "]");
+    } catch (Exception e) {
+      context.onFailure(e);
+      return;
+    }
 
-		LOGGER.finest("Lock acquired on [" + resourceDescription + "] by " + r.getExternalizableId());
-		try {
-			PauseAction.endCurrentPause(node);
-			BodyInvoker bodyInvoker = context.newBodyInvoker().
-				withCallback(new Callback(resourcenames, resourceDescription, variable, inversePrecedence));
-			if(variable != null && variable.length()>0)
-				// set the variable for the duration of the block
-				bodyInvoker.withContext(EnvironmentExpander.merge(context.get(EnvironmentExpander.class), new EnvironmentExpander() {
-					@Override
-					public void expand(EnvVars env) throws IOException, InterruptedException {
-						final String resources = COMMA_JOINER.join(resourcenames);
-								LOGGER.finest("Setting [" + variable + "] to [" + resources
-										+ "] for the duration of the block");
+    LOGGER.finest("Lock acquired on [" + resourceDescription + "] by " + r.getExternalizableId());
+    try {
+      PauseAction.endCurrentPause(node);
+      BodyInvoker bodyInvoker =
+          context
+              .newBodyInvoker()
+              .withCallback(
+                  new Callback(resourcenames, resourceDescription, variable, inversePrecedence));
+      if (variable != null && variable.length() > 0)
+        // set the variable for the duration of the block
+        bodyInvoker.withContext(
+            EnvironmentExpander.merge(
+                context.get(EnvironmentExpander.class),
+                new EnvironmentExpander() {
+                  @Override
+                  public void expand(EnvVars env) throws IOException, InterruptedException {
+                    final String resources = COMMA_JOINER.join(resourcenames);
+                    LOGGER.finest(
+                        "Setting ["
+                            + variable
+                            + "] to ["
+                            + resources
+                            + "] for the duration of the block");
 
-						env.override(variable, resources);
-					}
-				}));
-			bodyInvoker.start();
-		} catch (IOException | InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-	}
+                    env.override(variable, resources);
+                  }
+                }));
+      bodyInvoker.start();
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-	private static final class Callback extends BodyExecutionCallback.TailCall {
+  private static final class Callback extends BodyExecutionCallback.TailCall {
 
-		private final List<String> resourceNames;
-		private final String resourceDescription;
-		private final String variable;
-		private final boolean inversePrecedence;
+    private final List<String> resourceNames;
+    private final String resourceDescription;
+    private final String variable;
+    private final boolean inversePrecedence;
 
-		Callback(List<String> resourceNames, String resourceDescription, String variable, boolean inversePrecedence) {
-			this.resourceNames = resourceNames;
-			this.resourceDescription = resourceDescription;
-			this.variable = variable;
-			this.inversePrecedence = inversePrecedence;
-		}
+    Callback(
+        List<String> resourceNames,
+        String resourceDescription,
+        String variable,
+        boolean inversePrecedence) {
+      this.resourceNames = resourceNames;
+      this.resourceDescription = resourceDescription;
+      this.variable = variable;
+      this.inversePrecedence = inversePrecedence;
+    }
 
-		protected void finished(StepContext context) throws Exception {
-			LockableResourcesManager.get().unlockNames(this.resourceNames, context.get(Run.class), this.variable, this.inversePrecedence);
-			context.get(TaskListener.class).getLogger().println("Lock released on resource [" + resourceDescription + "]");
-			LOGGER.finest("Lock released on [" + resourceDescription + "]");
-		}
+    protected void finished(StepContext context) throws Exception {
+      LockableResourcesManager.get()
+          .unlockNames(
+              this.resourceNames, context.get(Run.class), this.variable, this.inversePrecedence);
+      context
+          .get(TaskListener.class)
+          .getLogger()
+          .println("Lock released on resource [" + resourceDescription + "]");
+      LOGGER.finest("Lock released on [" + resourceDescription + "]");
+    }
 
-		private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+  }
 
-	}
+  @Override
+  public void stop(Throwable cause) throws Exception {
+    boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
+    if (!cleaned) {
+      LOGGER.log(
+          Level.WARNING,
+          "Cannot remove context from lockable resource witing list. The context is not in the waiting list.");
+    }
+    getContext().onFailure(cause);
+  }
 
-	@Override
-	public void stop(Throwable cause) throws Exception {
-		boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
-		if (!cleaned) {
-			LOGGER.log(Level.WARNING, "Cannot remove context from lockable resource witing list. The context is not in the waiting list.");
-		}
-		getContext().onFailure(cause);
-	}
-
-	private static final long serialVersionUID = 1L;
-
+  private static final long serialVersionUID = 1L;
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepHardKillTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepHardKillTest.java
@@ -35,7 +35,7 @@ public class LockStepHardKillTest extends LockStepTestBase {
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 
     // Make sure that b2 is blocked on b1's lock.
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     // Now b2 is still sitting waiting for a lock. Create b3 and launch it to clear the
@@ -44,7 +44,7 @@ public class LockStepHardKillTest extends LockStepTestBase {
     p3.setDefinition(
         new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}"));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource1] is locked, waiting...", b3);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
 
     // Kill b1 hard.
@@ -86,7 +86,7 @@ public class LockStepHardKillTest extends LockStepTestBase {
     for (int i = 0; i < 3; i++) {
       WorkflowRun rNext = p.scheduleBuild2(0).waitForStart();
       if (prevBuild != null) {
-        j.waitForMessage("[resource1] is locked, waiting...", rNext);
+        j.waitForMessage("[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         interruptTermKill(prevBuild);
       }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -254,12 +254,12 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
     // Ensure that b2 reaches the lock before b3
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
     WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
     // Both 2 and 3 are waiting for locking resource1
 
-    j.waitForMessage("[resource1] is locked, waiting...", b3);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
 
     // Unlock resource1
@@ -292,12 +292,12 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
     // Ensure that b2 reaches the lock before b3
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
     WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
     // Both 2 and 3 are waiting for locking resource1
 
-    j.waitForMessage("[resource1] is locked, waiting...", b3);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
 
     // Unlock resource1
@@ -337,7 +337,7 @@ public class LockStepTest extends LockStepTestBase {
     // both messages are in the log because branch b acquired the lock and branch a is waiting to
     // lock
     j.waitForMessage("[b] Lock acquired on [resource1]", b1);
-    j.waitForMessage("[a] [resource1] is locked, waiting...", b1);
+    j.waitForMessage("[a] [resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b1);
     isPaused(b1, 2, 1);
 
     SemaphoreStep.success("wait-b/1", null);
@@ -372,10 +372,10 @@ public class LockStepTest extends LockStepTestBase {
               }
             });
     semaphore.acquire();
-    f.scheduleBuild2(0).waitForStart();
+    FreeStyleBuild f1 = f.scheduleBuild2(0).waitForStart();
 
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource1] is locked, waiting...", b1);
+    j.waitForMessage("[resource1] is locked by " + f1.getFullDisplayName() + ", waiting...", b1);
     isPaused(b1, 1, 1);
     semaphore.release();
 
@@ -413,9 +413,9 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 
     // Make sure that b2 is blocked on b1's lock.
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
-    j.waitForMessage("[resource1] is locked, waiting...", b3);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
 
     b1.delete();
@@ -454,7 +454,7 @@ public class LockStepTest extends LockStepTestBase {
     for (int i = 0; i < 3; i++) {
       WorkflowRun rNext = p.scheduleBuild2(0).waitForStart();
       if (prevBuild != null) {
-        j.waitForMessage("[resource1] is locked, waiting...", rNext);
+        j.waitForMessage("[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         wc.goTo("lockable-resources/unlock?resource=resource1");
       }
@@ -496,7 +496,7 @@ public class LockStepTest extends LockStepTestBase {
     for (int i = 0; i < 5; i++) {
       WorkflowRun rNext = job.scheduleBuild2(0).waitForStart();
       if (toUnlock != null) {
-        j.waitForMessage("[resource1] is locked, waiting...", rNext);
+        j.waitForMessage("[resource1] is locked by " + toUnlock.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         SemaphoreStep.success("wait-inside-1/" + i, null);
       }
@@ -616,7 +616,7 @@ public class LockStepTest extends LockStepTestBase {
         new CpsFlowDefinition(
             "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'"));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
@@ -624,7 +624,7 @@ public class LockStepTest extends LockStepTestBase {
         new CpsFlowDefinition(
             "lock('resource2') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'"));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource2] is locked, waiting...", b3);
+    j.waitForMessage("[resource2] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
 
     // Unlock resources
@@ -664,7 +664,7 @@ public class LockStepTest extends LockStepTestBase {
         new CpsFlowDefinition(
             "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'"));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
@@ -715,7 +715,7 @@ public class LockStepTest extends LockStepTestBase {
         new CpsFlowDefinition(
             "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'"));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
-    j.waitForMessage("[resource1] is locked, waiting...", b2);
+    j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
@@ -41,12 +41,12 @@ public class LockStepWithRestartTest extends LockStepTestBase {
           SemaphoreStep.waitForStart("wait-inside/1", b1);
           WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
           // Ensure that b2 reaches the lock before b3
-          j.waitForMessage("[resource1] is locked, waiting...", b2);
+          j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
           isPaused(b2, 1, 1);
           WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
           // Both 2 and 3 are waiting for locking resource1
 
-          j.waitForMessage("[resource1] is locked, waiting...", b3);
+          j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
           isPaused(b3, 1, 1);
         });
 
@@ -64,7 +64,7 @@ public class LockStepWithRestartTest extends LockStepTestBase {
 
           j.waitForMessage("Lock acquired on [resource1]", b2);
           isPaused(b2, 1, 0);
-          j.assertLogContains("[resource1] is locked, waiting...", b3);
+          j.assertLogContains("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
           isPaused(b3, 1, 1);
           SemaphoreStep.success("wait-inside/2", null);
           SemaphoreStep.waitForStart("wait-inside/3", b3);


### PR DESCRIPTION
Hey,

targeting #148. Notice that this just works when a resource **name** is specified.

**Example Pipeline:**
```
 pipeline {
    agent any
    stages {
        stage('Test') {
            options {
                lock resource: "New Lock"
            }
            steps {
                sh 'sleep 60'
            }
        }
    }
 }
 
```
**Result:**
Running it two times, so that it runs concurrently:
```
Trying to acquire lock on [New Lock]
Resource [New Lock] did not exist. Created.
Lock acquired on [New Lock]
```
```
Trying to acquire lock on [New Lock]
Found 0 available resource(s). Waiting for correct amount: 1.
[New Lock] is locked by Temp #1, waiting...
```