### PR TITLE
Add lock/release message for consistency

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -78,12 +78,14 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 			r = context.get(Run.class);
 			node = context.get(FlowNode.class);
 			context.get(TaskListener.class).getLogger().println("Lock acquired on [" + resourceDescription + "]");
+			context.get(TaskListener.class).getLogger().println("[lockable-resources] acquired lock on " + resourcenames);
 		} catch (Exception e) {
 			context.onFailure(e);
 			return;
 		}
 
 		LOGGER.finest("Lock acquired on [" + resourceDescription + "] by " + r.getExternalizableId());
+		LOGGER.finest("[lockable-resources] acquired lock on " + resourcenames + " by " + r.getExternalizableId());
 		try {
 			PauseAction.endCurrentPause(node);
 			BodyInvoker bodyInvoker = context.newBodyInvoker().
@@ -123,7 +125,9 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 		protected void finished(StepContext context) throws Exception {
 			LockableResourcesManager.get().unlockNames(this.resourceNames, context.get(Run.class), this.variable, this.inversePrecedence);
 			context.get(TaskListener.class).getLogger().println("Lock released on resource [" + resourceDescription + "]");
+			context.get(TaskListener.class).getLogger().println("[lockable-resources] released lock on " + resourceNames);
 			LOGGER.finest("Lock released on [" + resourceDescription + "]");
+			LOGGER.finest("[lockable-resources] released lock on " + resourceNames);
 		}
 
 		private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Log the specific resources locked/released for Pipeline jobs as well.

   Lock acquired on [{Label: SERVER, Quantity: 1},{Label: CLIENT, Quantity: 1},{Label: OTHER, Quantity: 1},]
   [lockable-resources] acquired lock on [server1, client1, other1]
   ...
   Lock released on resource [{Label: SERVER, Quantity: 1},{Label: CLIENT, Quantity: 1},{Label: OTHER, Quantity: 1},]
   [lockable-resources] released lock on [server1, client1, other1]