### PR TITLE
Allow "empty" lock

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -113,8 +113,10 @@ public class LockStep extends AbstractStepImpl implements Serializable {
         builder.append("{" + resource.toString() + "},");
       }
       return builder.toString();
-    } else {
+    } else if (resource != null || label != null) {
       return LockStepResource.toString(resource, label, quantity);
+    } else {
+      return "nothing";
     }
   }
 
@@ -125,7 +127,9 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 
   public List<LockStepResource> getResources() {
     List<LockStepResource> resources = new ArrayList<>();
-    resources.add(new LockStepResource(resource, label, quantity));
+    if (resource != null || label != null) {
+      resources.add(new LockStepResource(resource, label, quantity));
+    }
 
     if (extra != null) {
       resources.addAll(extra);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -1,142 +1,135 @@
 package org.jenkins.plugins.lockableresources;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.model.AutoCompletionCandidates;
+import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import hudson.Extension;
-import hudson.model.AutoCompletionCandidates;
-import hudson.util.FormValidation;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-
 public class LockStep extends AbstractStepImpl implements Serializable {
 
-	@CheckForNull
-	public String resource = null;
+  private static final long serialVersionUID = 1L;
 
-	@CheckForNull
-	public String label = null;
+  @CheckForNull public String resource = null;
 
-	public int quantity = 0;
+  @CheckForNull public String label = null;
 
-	/** name of environment variable to store locked resources in */
-	@CheckForNull
-	public String variable = null;
+  public int quantity = 0;
 
-	public boolean inversePrecedence = false;
+  /** name of environment variable to store locked resources in */
+  @CheckForNull public String variable = null;
 
-	@CheckForNull
-	public List<LockStepResource> extra = null;
+  public boolean inversePrecedence = false;
 
-	// it should be LockStep() - without params. But keeping this for backward compatibility
-	// so `lock('resource1')` still works and `lock(label: 'label1', quantity: 3)` works too (resource is not required)
-	@DataBoundConstructor
-	public LockStep(String resource) {
-		if (resource != null && !resource.isEmpty()) {
-			this.resource = resource;
-		}
-	}
+  @CheckForNull public List<LockStepResource> extra = null;
 
-	@DataBoundSetter
-	public void setInversePrecedence(boolean inversePrecedence) {
-		this.inversePrecedence = inversePrecedence;
-	}
+  // it should be LockStep() - without params. But keeping this for backward compatibility
+  // so `lock('resource1')` still works and `lock(label: 'label1', quantity: 3)` works too (resource
+  // is not required)
+  @DataBoundConstructor
+  public LockStep(String resource) {
+    if (resource != null && !resource.isEmpty()) {
+      this.resource = resource;
+    }
+  }
 
-	@DataBoundSetter
-	public void setLabel(String label) {
-		if (label != null && !label.isEmpty()) {
-			this.label = label;
-		}
-	}
+  @DataBoundSetter
+  public void setInversePrecedence(boolean inversePrecedence) {
+    this.inversePrecedence = inversePrecedence;
+  }
 
-	@DataBoundSetter
-	public void setVariable(String variable) {
-		if (variable != null && !variable.isEmpty()) {
-			this.variable = variable;
-		}
-	}
+  @DataBoundSetter
+  public void setLabel(String label) {
+    if (label != null && !label.isEmpty()) {
+      this.label = label;
+    }
+  }
 
-	@DataBoundSetter
-	public void setQuantity(int quantity) {
-		this.quantity = quantity;
-	}
+  @DataBoundSetter
+  public void setVariable(String variable) {
+    if (variable != null && !variable.isEmpty()) {
+      this.variable = variable;
+    }
+  }
 
-	@DataBoundSetter
-	public void setExtra(List<LockStepResource> extra) {
-		this.extra = extra;
-	}
+  @DataBoundSetter
+  public void setQuantity(int quantity) {
+    this.quantity = quantity;
+  }
 
-	@Extension
-	public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+  @DataBoundSetter
+  public void setExtra(List<LockStepResource> extra) {
+    this.extra = extra;
+  }
 
-		public DescriptorImpl() {
-			super(LockStepExecution.class);
-		}
+  @Extension
+  public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
 
-		@Override
-		public String getFunctionName() {
-			return "lock";
-		}
+    public DescriptorImpl() {
+      super(LockStepExecution.class);
+    }
 
-		@Override
-		public String getDisplayName() {
-			return "Lock shared resource";
-		}
+    @Override
+    public String getFunctionName() {
+      return "lock";
+    }
 
-		@Override
-		public boolean takesImplicitBlockArgument() {
-			return true;
-		}
+    @Override
+    public String getDisplayName() {
+      return "Lock shared resource";
+    }
 
-		public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
-			return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
-		}
+    @Override
+    public boolean takesImplicitBlockArgument() {
+      return true;
+    }
 
-		public static FormValidation doCheckLabel(@QueryParameter String value, @QueryParameter String resource) {
-			return LockStepResource.DescriptorImpl.doCheckLabel(value, resource);
-		}
+    public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
+      return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+    }
 
-		public static FormValidation doCheckResource(@QueryParameter String value, @QueryParameter String label) {
-			return LockStepResource.DescriptorImpl.doCheckLabel(label, value);
-		}
-	}
+    public static FormValidation doCheckLabel(
+        @QueryParameter String value, @QueryParameter String resource) {
+      return LockStepResource.DescriptorImpl.doCheckLabel(value, resource);
+    }
 
-	public String toString() {
-		if (extra != null && !extra.isEmpty()) {
-			StringBuilder builder = new StringBuilder();
-			for (LockStepResource resource : getResources()) {
-				builder.append("{" + resource.toString() + "},");
-			}
-			return builder.toString();
-		} else {
-			return LockStepResource.toString(resource, label, quantity);
-		}
-	}
+    public static FormValidation doCheckResource(
+        @QueryParameter String value, @QueryParameter String label) {
+      return LockStepResource.DescriptorImpl.doCheckLabel(label, value);
+    }
+  }
 
-	/**
-	 * Label and resource are mutual exclusive.
-	 */
-	public void validate() throws Exception {
-		LockStepResource.validate(resource, label, quantity);
-	}
+  public String toString() {
+    if (extra != null && !extra.isEmpty()) {
+      StringBuilder builder = new StringBuilder();
+      for (LockStepResource resource : getResources()) {
+        builder.append("{" + resource.toString() + "},");
+      }
+      return builder.toString();
+    } else {
+      return LockStepResource.toString(resource, label, quantity);
+    }
+  }
 
-	public List<LockStepResource> getResources() {
-		List<LockStepResource> resources = new ArrayList<>();
-		resources.add(new LockStepResource(resource, label, quantity));
+  /** Label and resource are mutual exclusive. */
+  public void validate() throws Exception {
+    LockStepResource.validate(resource, label, quantity);
+  }
 
-		if (extra != null) {
-			resources.addAll(extra);
-		}
-		return resources;
-	}
+  public List<LockStepResource> getResources() {
+    List<LockStepResource> resources = new ArrayList<>();
+    resources.add(new LockStepResource(resource, label, quantity));
 
-	private static final long serialVersionUID = 1L;
-
+    if (extra != null) {
+      resources.addAll(extra);
+    }
+    return resources;
+  }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -7,6 +7,7 @@ import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -108,11 +109,9 @@ public class LockStep extends AbstractStepImpl implements Serializable {
 
   public String toString() {
     if (extra != null && !extra.isEmpty()) {
-      StringBuilder builder = new StringBuilder();
-      for (LockStepResource resource : getResources()) {
-        builder.append("{" + resource.toString() + "},");
-      }
-      return builder.toString();
+      return getResources().stream()
+          .map(resource -> "{" + resource.toString() + "}")
+          .collect(Collectors.joining(","));
     } else if (resource != null || label != null) {
       return LockStepResource.toString(resource, label, quantity);
     } else {

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -67,6 +67,18 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  public void lockNothing() throws Exception {
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "lock() {\n" + "  echo 'Nothing locked.'\n" + "}\n" + "echo 'Finish'"));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+    j.assertBuildStatus(Result.SUCCESS, b1);
+    j.assertLogContains("Lock acquired on [nothing]", b1);
+  }
+
+  @Test
   public void lockWithLabel() throws Exception {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
@@ -761,11 +773,11 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
         new CpsFlowDefinition(
-            "lock(resource: 'resource4', variable: 'var', extra: [[resource: 'resource2'], [label: 'label1', quantity: 2]]) {\n"
-                + "	def lockedResources = env.var.split(',')\n"
-                + "	Arrays.sort(lockedResources)\n"
-                + "	echo \"Resources locked: ${lockedResources}\"\n"
-                + "	semaphore 'wait-inside'\n"
+            "lock(variable: 'var', extra: [[resource: 'resource4'], [resource: 'resource2'], [label: 'label1', quantity: 2]]) {\n"
+                + "  def lockedResources = env.var.split(',')\n"
+                + "  Arrays.sort(lockedResources)\n"
+                + "  echo \"Resources locked: ${lockedResources}\"\n"
+                + "  semaphore 'wait-inside'\n"
                 + "}\n"
                 + "echo 'Finish'"));
     // #1 should lock as few resources as possible

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -644,7 +644,7 @@ public class LockStepTest extends LockStepTestBase {
 
     // Unlock resources
     SemaphoreStep.success("wait-inside/1", null);
-    j.waitForMessage("Lock released on resource [{resource1},{resource2},]", b1);
+    j.waitForMessage("Lock released on resource [{resource1},{resource2}]", b1);
     isPaused(b1, 1, 0);
 
     // Both get their lock
@@ -695,7 +695,7 @@ public class LockStepTest extends LockStepTestBase {
 
     // Unlock resources
     SemaphoreStep.success("wait-inside/1", null);
-    j.waitForMessage("Lock released on resource [{Label: label1},{resource1},]", b1);
+    j.waitForMessage("Lock released on resource [{Label: label1},{resource1}]", b1);
     isPaused(b2, 1, 0);
 
     // Both get their lock
@@ -746,7 +746,7 @@ public class LockStepTest extends LockStepTestBase {
 
     // Unlock resources
     SemaphoreStep.success("wait-inside/1", null);
-    j.waitForMessage("Lock released on resource [{Label: label1},{resource1},]", b1);
+    j.waitForMessage("Lock released on resource [{Label: label1},{resource1}]", b1);
     isPaused(b1, 1, 0);
 
     // #2 gets the lock before #3 (in the order as they requested the lock)
@@ -821,7 +821,7 @@ public class LockStepTest extends LockStepTestBase {
     // Unlock resources
     SemaphoreStep.success("wait-inside/1", null);
     j.waitForMessage(
-        "Lock released on resource [{resource4},{resource2},{Label: label1, Quantity: 2},]", b1);
+        "Lock released on resource [{resource4},{resource2},{Label: label1, Quantity: 2}]", b1);
     j.assertLogContains("Resources locked: [resource2, resource4]", b1);
     isPaused(b1, 1, 0);
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -337,7 +337,8 @@ public class LockStepTest extends LockStepTestBase {
     // both messages are in the log because branch b acquired the lock and branch a is waiting to
     // lock
     j.waitForMessage("[b] Lock acquired on [resource1]", b1);
-    j.waitForMessage("[a] [resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b1);
+    j.waitForMessage(
+        "[a] [resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b1);
     isPaused(b1, 2, 1);
 
     SemaphoreStep.success("wait-b/1", null);
@@ -454,7 +455,8 @@ public class LockStepTest extends LockStepTestBase {
     for (int i = 0; i < 3; i++) {
       WorkflowRun rNext = p.scheduleBuild2(0).waitForStart();
       if (prevBuild != null) {
-        j.waitForMessage("[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
+        j.waitForMessage(
+            "[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         wc.goTo("lockable-resources/unlock?resource=resource1");
       }
@@ -496,7 +498,8 @@ public class LockStepTest extends LockStepTestBase {
     for (int i = 0; i < 5; i++) {
       WorkflowRun rNext = job.scheduleBuild2(0).waitForStart();
       if (toUnlock != null) {
-        j.waitForMessage("[resource1] is locked by " + toUnlock.getFullDisplayName() + ", waiting...", rNext);
+        j.waitForMessage(
+            "[resource1] is locked by " + toUnlock.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         SemaphoreStep.success("wait-inside-1/" + i, null);
       }
@@ -829,11 +832,11 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-      new CpsFlowDefinition(
-        "lock(label: 'invalidLabel', variable: 'var', quantity: 1) {\n" +
-          "	echo \"Resource locked: ${env.var}\"\n" +
-          "}\n" +
-          "echo 'Finish'"));
+        new CpsFlowDefinition(
+            "lock(label: 'invalidLabel', variable: 'var', quantity: 1) {\n"
+                + "	echo \"Resource locked: ${env.var}\"\n"
+                + "}\n"
+                + "echo 'Finish'"));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.FAILURE, b1);


### PR DESCRIPTION
This should make it easier to dynamically build a list of lockable resources in a pipeline: It was possible before, but the log output suggested the user was something wrong - So we just make it explicit.