### PR TITLE
Reset resources on configuration update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ unclassified:
 * See the [plugin's Wiki page](https://wiki.jenkins.io/display/JENKINS/Lockable+Resources+Plugin#LockableResourcesPlugin-Changelog)
   for versions 2.5 and older
 
+## Configuration as Code
+This plugin can be configured via [Configuration-as-Code](https://github.com/jenkinsci/configuration-as-code-plugin).
+
+### Example configuration
+```
+unclassified:
+  lockableResourcesManager:
+    declaredResources:
+      - name: "Resource_A"
+        description: "Description_A"
+        labels: "Label_A"
+        reservedBy: "Reserved_A"
+```
+
 ## Contributing
 
 If you want to contribute to this plugin, you probably will need a Jenkins plugin development

--- a/README.md
+++ b/README.md
@@ -93,20 +93,6 @@ unclassified:
 * See the [plugin's Wiki page](https://wiki.jenkins.io/display/JENKINS/Lockable+Resources+Plugin#LockableResourcesPlugin-Changelog)
   for versions 2.5 and older
 
-## Configuration as Code
-This plugin can be configured via [Configuration-as-Code](https://github.com/jenkinsci/configuration-as-code-plugin).
-
-### Example configuration
-```
-unclassified:
-  lockableResourcesManager:
-    declaredResources:
-      - name: "Resource_A"
-        description: "Description_A"
-        labels: "Label_A"
-        reservedBy: "Reserved_A"
-```
-
 ## Contributing
 
 If you want to contribute to this plugin, you probably will need a Jenkins plugin development

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -721,6 +721,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
   public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
     BulkChange bc = new BulkChange(this);
     try {
+      // reset resources to default before data-binding
+      this.resources = new ArrayList<>();
       req.bindJSON(this, json);
       bc.commit();
     } catch (IOException exception) {


### PR DESCRIPTION
I created a fix for the issue and tested it manually.

I would like to create a unit test for it but i have no experience in developing or testing jenkins plugins. So maybe @TobiX you can help me with that.

Basically i want to create a unit test for the `LockableResourceManager.configure()` method.
Therefore, i tried to perform a system config (global config) update and add/remove LockableResources. 

I saw similar approaches in other plugins where they are mocking the `StaplerRequest` in order to execute the `r.jenkins.reconfigure(...)` or `r.jenkins.doConfigSubmit(...)` method.

But i want to perform a regular config update without using mocks.
Do you have any idea how to achieve that?

