### PR TITLE
tryLock and releaseLock steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.idea/
 /target/
 /work/
+.settings
+.project
+.classpath
+.factorypath

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ them.
 
 Examples:
 
+*Lock a resource*
 ```groovy
 echo 'Starting'
 lock('my-resource-name') {
@@ -54,6 +55,7 @@ lock('my-resource-name') {
 echo 'Finish'
 ```
 
+*Lock a resource using inverse precedence*
 ```groovy
 lock(resource: 'staging-server', inversePrecedence: true) {
     node {
@@ -63,9 +65,61 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 }
 ```
 
+*Lock a resource by label*
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
+}
+```
+
+*Do the locking in its own stage*
+```groovy
+stage("Locking resource") {
+  lock(resource: 'the-resource')
+}
+
+stage("Using resource") {
+  println "Using the resource..."
+}
+
+stage("Releasing resource") {
+  releaseLock(resource: 'the-resource')
+}
+```
+
+*Try to lock the resource*
+```groovy
+if (tryLock(resource: 'staging-server')) {
+  try {
+    println "Resource acquired :)"
+  } finally {
+    releaseLock(resource: 'staging-server')
+  }
+} else {
+    println "Was unable to acquire lock :("
+}
+```
+
+*Release any acquired locks*
+```groovy
+try {
+  if (tryLock(resource: 'staging-server-1') && tryLock(resource: 'staging-server-2')) {
+    println "Resources acquired =)"
+  }
+} finally {
+  // Release any acquired resources
+  releaseLock()
+}
+```
+
+*Check if a resource is locked or not*
+```
+boolean isAvailable(resource) {
+  def isAvailable = tryLock(resource: resource)
+  if (isAvailable) {
+    releaseLock(resource: resource)
+  }
+  return isAvailable
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,17 @@
     <revision>2.8</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <workflow-support.version>2.12</workflow-support.version>
-    <jenkins.version>2.60.3</jenkins.version>
+    <workflow-support.version>3.4</workflow-support.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <configuration-as-code.version>1.25</configuration-as-code.version>
   </properties>
 
   <dependencies>
+  	<dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.18</version>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
@@ -77,7 +82,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.33</version>
+      <version>1.39</version>
     </dependency>
     <dependency>
       <groupId>com.infradna.tool</groupId>
@@ -109,7 +114,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.10</version>
+      <version>2.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockAttributes.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockAttributes.java
@@ -1,0 +1,68 @@
+package org.jenkins.plugins.lockableresources;
+
+import java.util.List;
+
+public class LockAttributes {
+  private List<LockStepResource> extra = null;
+  private String resource = null;
+  private String label = null;
+  private int quantity = 0;
+  private String variable = null;
+  private final boolean inversePrecedence;
+
+  public LockAttributes(
+      final List<LockStepResource> extra,
+      final String resource,
+      final String label,
+      final int quantity,
+      final String variable,
+      final boolean inversePrecedence) {
+    this.extra = extra;
+    this.resource = resource;
+    this.label = label;
+    this.quantity = quantity;
+    this.variable = variable;
+    this.inversePrecedence = inversePrecedence;
+  }
+
+  public List<LockStepResource> getExtra() {
+    return extra;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+
+  public String getVariable() {
+    return variable;
+  }
+
+  public boolean getInversePrecedence() {
+    return inversePrecedence;
+  }
+
+  @Override
+  public String toString() {
+    return "LockAttributes [extra="
+        + extra
+        + ", resource="
+        + resource
+        + ", label="
+        + label
+        + ", quantity="
+        + quantity
+        + ", variable="
+        + variable
+        + ", inversePrecedence="
+        + inversePrecedence
+        + "]";
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockHelper.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockHelper.java
@@ -1,0 +1,127 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
+
+public class LockHelper {
+
+  public static Collection<LockStepResource> getResources(final LockAttributes lockAttributes) {
+
+    final List<LockStepResource> resources = new ArrayList<>();
+    if (lockAttributes.getResource() != null || lockAttributes.getLabel() != null) {
+      resources.add(
+          new LockStepResource(
+              lockAttributes.getResource(),
+              lockAttributes.getLabel(),
+              lockAttributes.getQuantity()));
+    }
+
+    if (lockAttributes.getExtra() != null) {
+      resources.addAll(lockAttributes.getExtra());
+    }
+    return resources;
+  }
+
+  public static String toString(final LockAttributes lockAttributes) {
+    if (lockAttributes.getExtra() != null && !lockAttributes.getExtra().isEmpty()) {
+      return LockHelper.getResources(lockAttributes).stream()
+          .map(resource -> "{" + resource.toString() + "}")
+          .collect(Collectors.joining(","));
+    } else if (lockAttributes.getResource() != null || lockAttributes.getLabel() != null) {
+      return LockStepResource.toString(
+          lockAttributes.getResource(), lockAttributes.getLabel(), lockAttributes.getQuantity());
+    } else {
+      return "nothing";
+    }
+  }
+
+  public static boolean start(
+      final boolean queIfLocked, final LockAttributes lockAttributes, final StepContext stepContext)
+      throws Exception {
+    LockStepResource.validate(
+        lockAttributes.getResource(), lockAttributes.getLabel(), lockAttributes.getQuantity());
+    stepContext.get(FlowNode.class).addAction(new PauseAction("Lock"));
+    final Run<?, ?> run = stepContext.get(Run.class);
+    final TaskListener listener = stepContext.get(TaskListener.class);
+
+    listener
+        .getLogger()
+        .println("Trying to acquire lock on [" + LockHelper.toString(lockAttributes) + "]");
+
+    final List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
+
+    for (final LockStepResource resource : LockHelper.getResources(lockAttributes)) {
+      final List<String> resources = new ArrayList<>();
+      if (resource.resource != null) {
+        if (LockableResourcesManager.get().createResource(resource.resource)) {
+          listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
+        }
+        resources.add(resource.resource);
+      }
+      resourceHolderList.add(
+          new LockableResourcesStruct(resources, resource.label, resource.quantity));
+    }
+
+    // determine if there are enough resources available to proceed
+    final Set<LockableResource> available =
+        LockableResourcesManager.get()
+            .checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
+    final boolean lockWasNotAvailabel =
+        available == null
+            || !LockableResourcesManager.get()
+                .lock(
+                    available,
+                    run,
+                    stepContext,
+                    LockHelper.toString(lockAttributes),
+                    lockAttributes.getVariable(),
+                    lockAttributes.getInversePrecedence());
+    if (lockWasNotAvailabel) {
+      // if the resource is known, we could output the active/blocking job/build
+      final LockableResource resource =
+          LockableResourcesManager.get().fromName(lockAttributes.getResource());
+      if (queIfLocked && resource != null && resource.getBuildName() != null) {
+        listener
+            .getLogger()
+            .println(
+                "["
+                    + LockHelper.toString(lockAttributes)
+                    + "] is locked by "
+                    + resource.getBuildName()
+                    + ", waiting...");
+
+      } else if (queIfLocked) {
+        listener
+            .getLogger()
+            .println("[" + LockHelper.toString(lockAttributes) + "] is locked, waiting...");
+      }
+      if (queIfLocked) {
+        // proceed is called inside lock if execution is possible
+        LockableResourcesManager.get()
+            .queueContext(
+                stepContext,
+                resourceHolderList,
+                LockHelper.toString(lockAttributes),
+                lockAttributes.getVariable());
+      } else {
+        listener
+            .getLogger()
+            .println("[" + LockHelper.toString(lockAttributes) + "] was not available");
+        return false;
+      }
+      return true;
+    } else {
+      listener.getLogger().println("[" + LockHelper.toString(lockAttributes) + "] was available");
+      return true;
+    }
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -108,31 +108,10 @@ public class LockStep extends AbstractStepImpl implements Serializable {
   }
 
   public String toString() {
-    if (extra != null && !extra.isEmpty()) {
-      return getResources().stream()
-          .map(resource -> "{" + resource.toString() + "}")
-          .collect(Collectors.joining(","));
-    } else if (resource != null || label != null) {
-      return LockStepResource.toString(resource, label, quantity);
-    } else {
-      return "nothing";
-    }
+    return LockHelper.toString(toLockAttributes());
   }
-
-  /** Label and resource are mutual exclusive. */
-  public void validate() throws Exception {
-    LockStepResource.validate(resource, label, quantity);
-  }
-
-  public List<LockStepResource> getResources() {
-    List<LockStepResource> resources = new ArrayList<>();
-    if (resource != null || label != null) {
-      resources.add(new LockStepResource(resource, label, quantity));
-    }
-
-    if (extra != null) {
-      resources.addAll(extra);
-    }
-    return resources;
+  
+  public LockAttributes toLockAttributes() {
+	  return new LockAttributes(extra, resource, label, quantity, variable,inversePrecedence);
   }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -3,22 +3,19 @@ package org.jenkins.plugins.lockableresources;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import hudson.EnvVars;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 
 public class LockStepExecution extends AbstractStepExecutionImpl {
@@ -28,62 +25,18 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
   @Inject(optional = true)
   private LockStep step;
 
-  @StepContextParameter private transient Run<?, ?> run;
-
-  @StepContextParameter private transient TaskListener listener;
-
-  @StepContextParameter private transient FlowNode node;
-
   private static final Logger LOGGER = Logger.getLogger(LockStepExecution.class.getName());
 
   @Override
   public boolean start() throws Exception {
-    step.validate();
-
-    node.addAction(new PauseAction("Lock"));
-    listener.getLogger().println("Trying to acquire lock on [" + step + "]");
-
-    List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
-
-    for (LockStepResource resource : step.getResources()) {
-      List<String> resources = new ArrayList<>();
-      if (resource.resource != null) {
-        if (LockableResourcesManager.get().createResource(resource.resource)) {
-          listener.getLogger().println("Resource [" + resource + "] did not exist. Created.");
-        }
-        resources.add(resource.resource);
-      }
-      resourceHolderList.add(
-          new LockableResourcesStruct(resources, resource.label, resource.quantity));
+    boolean queIfLocked = true;
+    boolean lockWasAcquired = LockHelper.start(queIfLocked, step.toLockAttributes(), getContext());
+    boolean hasNoBodyToExecute = !getContext().hasBody();
+    boolean hasSynchronouslyFinished = lockWasAcquired && hasNoBodyToExecute;
+    if (hasSynchronouslyFinished) {
+      getContext().onSuccess(Result.SUCCESS);
     }
-
-    // determine if there are enough resources available to proceed
-    Set<LockableResource> available =
-        LockableResourcesManager.get()
-            .checkResourcesAvailability(resourceHolderList, listener.getLogger(), null);
-    if (available == null
-        || !LockableResourcesManager.get()
-            .lock(
-                available,
-                run,
-                getContext(),
-                step.toString(),
-                step.variable,
-                step.inversePrecedence)) {
-      // if the resource is known, we could output the active/blocking job/build
-      LockableResource resource = LockableResourcesManager.get().fromName(step.resource);
-      if (resource != null && resource.getBuildName() != null) {
-        listener
-            .getLogger()
-            .println("[" + step + "] is locked by " + resource.getBuildName() + ", waiting...");
-
-      } else {
-        listener.getLogger().println("[" + step + "] is locked, waiting...");
-      }
-      LockableResourcesManager.get()
-          .queueContext(getContext(), resourceHolderList, step.toString(), step.variable);
-    } // proceed is called inside lock if execution is possible
-    return false;
+    return hasSynchronouslyFinished;
   }
 
   public static void proceed(
@@ -109,34 +62,45 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
     LOGGER.finest("Lock acquired on [" + resourceDescription + "] by " + r.getExternalizableId());
     try {
       PauseAction.endCurrentPause(node);
-      BodyInvoker bodyInvoker =
-          context
-              .newBodyInvoker()
-              .withCallback(
-                  new Callback(resourcenames, resourceDescription, inversePrecedence));
-      if (variable != null && variable.length() > 0)
-        // set the variable for the duration of the block
-        bodyInvoker.withContext(
-            EnvironmentExpander.merge(
-                context.get(EnvironmentExpander.class),
-                new EnvironmentExpander() {
-                  @Override
-                  public void expand(EnvVars env) throws IOException, InterruptedException {
-                    final String resources = COMMA_JOINER.join(resourcenames);
-                    LOGGER.finest(
-                        "Setting ["
-                            + variable
-                            + "] to ["
-                            + resources
-                            + "] for the duration of the block");
-
-                    env.override(variable, resources);
-                  }
-                }));
-      bodyInvoker.start();
+      if (context.hasBody()) {
+        invokeBody(resourcenames, context, resourceDescription, variable, inversePrecedence);
+      }
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static void invokeBody(
+      final List<String> resourcenames,
+      StepContext context,
+      String resourceDescription,
+      final String variable,
+      boolean inversePrecedence)
+      throws IOException, InterruptedException {
+    BodyInvoker bodyInvoker =
+        context
+            .newBodyInvoker()
+            .withCallback(new Callback(resourcenames, resourceDescription, inversePrecedence));
+    if (variable != null && variable.length() > 0)
+      // set the variable for the duration of the block
+      bodyInvoker.withContext(
+          EnvironmentExpander.merge(
+              context.get(EnvironmentExpander.class),
+              new EnvironmentExpander() {
+                @Override
+                public void expand(EnvVars env) throws IOException, InterruptedException {
+                  final String resources = COMMA_JOINER.join(resourcenames);
+                  LOGGER.finest(
+                      "Setting ["
+                          + variable
+                          + "] to ["
+                          + resources
+                          + "] for the duration of the block");
+
+                  env.override(variable, resources);
+                }
+              }));
+    bodyInvoker.start();
   }
 
   private static final class Callback extends BodyExecutionCallback.TailCall {
@@ -145,10 +109,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
     private final String resourceDescription;
     private final boolean inversePrecedence;
 
-    Callback(
-        List<String> resourceNames,
-        String resourceDescription,
-        boolean inversePrecedence) {
+    Callback(List<String> resourceNames, String resourceDescription, boolean inversePrecedence) {
       this.resourceNames = resourceNames;
       this.resourceDescription = resourceDescription;
       this.inversePrecedence = inversePrecedence;
@@ -156,8 +117,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 
     protected void finished(StepContext context) throws Exception {
       LockableResourcesManager.get()
-          .unlockNames(
-              this.resourceNames, context.get(Run.class), this.inversePrecedence);
+          .unlockNames(this.resourceNames, context.get(Run.class), this.inversePrecedence);
       context
           .get(TaskListener.class)
           .getLogger()
@@ -170,13 +130,16 @@ public class LockStepExecution extends AbstractStepExecutionImpl {
 
   @Override
   public void stop(Throwable cause) throws Exception {
-    boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
-    if (!cleaned) {
-      LOGGER.log(
-          Level.WARNING,
-          "Cannot remove context from lockable resource waiting list. The context is not in the waiting list.");
+    StepContext context = getContext();
+    if (context.hasBody()) {
+      boolean cleaned = LockableResourcesManager.get().unqueueContext(context);
+      if (!cleaned) {
+        LOGGER.log(
+            Level.WARNING,
+            "Cannot remove context from lockable resource waiting list. The context is not in the waiting list.");
+      }
+      getContext().onFailure(cause);
     }
-    getContext().onFailure(cause);
   }
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/ReleaseLockStep.java
@@ -1,0 +1,118 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.Extension;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+public class ReleaseLockStep extends Step implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger LOGGER = Logger.getLogger(ReleaseLockStep.class.getName());
+
+  public String resource = null;
+
+  @DataBoundConstructor
+  public ReleaseLockStep() {}
+
+  @DataBoundSetter
+  public void setResource(final String resource) {
+    this.resource = resource;
+  }
+
+  @Extension
+  public static final class DescriptorImpl extends StepDescriptor {
+
+    @Override
+    public String getFunctionName() {
+      return "releaseLock";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "Release lock shared resource";
+    }
+
+    @Override
+    public boolean takesImplicitBlockArgument() {
+      return false;
+    }
+
+    public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter final String value) {
+      return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+    }
+
+    public static FormValidation doCheckResource(
+        @QueryParameter final String value, @QueryParameter final String resource) {
+      if (resource == null || resource.isEmpty()) {
+        // Will release any acquired locks
+        return FormValidation.ok();
+      }
+      return LockStepResource.DescriptorImpl.doCheckResource(resource, null);
+    }
+
+    @Override
+    public Set<Class<?>> getRequiredContext() {
+      return Collections.singleton(TaskListener.class);
+    }
+  }
+
+  @Override
+  public StepExecution start(final StepContext context) {
+    return new SynchronousNonBlockingStepExecution<Object>(context) {
+
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      protected Object run() throws Exception {
+        final Run<?, ?> build = context.get(Run.class);
+        final PrintStream logger = context.get(TaskListener.class).getLogger();
+        // obviously project name cannot be obtained here
+        final List<LockableResource> acquiredByJob =
+            LockableResourcesManager.get().getResourcesFromBuild(build);
+
+        if (acquiredByJob.isEmpty()) {
+          logger.println("Cannot release any locks as none are acquired");
+          return null;
+        }
+
+        List<LockableResource> toRelease = acquiredByJob;
+        if (ReleaseLockStep.this.resource != null) {
+          toRelease =
+              acquiredByJob.stream()
+                  .filter(t -> t.getName().equals(ReleaseLockStep.this.resource))
+                  .collect(Collectors.toList());
+          if (toRelease.isEmpty()) {
+            logger.println(
+                "Cannot release lock "
+                    + ReleaseLockStep.this.resource
+                    + " as it was not acquired by the build: "
+                    + acquiredByJob);
+            return null;
+          }
+        }
+
+        LockableResourcesManager.get().unlock(toRelease, build);
+        logger.println("Lock released on [" + toRelease + "]");
+        return null;
+      }
+    };
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/TryLockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/TryLockStep.java
@@ -1,0 +1,94 @@
+package org.jenkins.plugins.lockableresources;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+public class TryLockStep extends Step implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @CheckForNull public String resource = null;
+
+  @DataBoundConstructor
+  public TryLockStep() {}
+
+  @DataBoundSetter
+  public void setResource(final String resource) {
+    this.resource = resource;
+  }
+
+  @Extension
+  public static final class DescriptorImpl extends StepDescriptor {
+
+    @Override
+    public String getFunctionName() {
+      return "tryLock";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "Try to lock shared resource";
+    }
+
+    @Override
+    public boolean takesImplicitBlockArgument() {
+      return false;
+    }
+
+    public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter final String value) {
+      return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+    }
+
+    public static FormValidation doCheckResource(
+        @QueryParameter final String value, @QueryParameter final String resource) {
+      return LockStepResource.DescriptorImpl.doCheckResource(resource, null);
+    }
+
+    @Override
+    public Set<Class<?>> getRequiredContext() {
+      return Collections.singleton(TaskListener.class);
+    }
+  }
+
+  public LockAttributes toLockAttributes() {
+    final boolean inversePrecedence = false;
+    final List<LockStepResource> extra = new ArrayList<>();
+    final String label = null;
+    final int quantity = 1;
+    final String variable = null;
+    return new LockAttributes(extra, resource, label, quantity, variable, inversePrecedence);
+  }
+
+  @Override
+  public StepExecution start(final StepContext context) {
+    return new SynchronousNonBlockingStepExecution<Object>(context) {
+
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      protected Object run() throws Exception {
+        getContext().get(FlowNode.class).addAction(new PauseAction("TryLock"));
+        final boolean queIfLocked = false;
+        return LockHelper.start(queIfLocked, toLockAttributes(), getContext());
+      }
+    };
+  }
+}

--- a/src/main/resources/org/jenkins/plugins/lockableresources/ReleaseLockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/ReleaseLockStep/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="${%Resource}" field="resource">
+		<f:textbox/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/ReleaseLockStep/help-resource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/ReleaseLockStep/help-resource.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		Optional resource name to release. If empty, any acquired locks will be released. 
+		It should have been acquired earlier with the tryLock step.
+	</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/TryLockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/TryLockStep/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="${%Resource}" field="resource">
+		<f:textbox/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/TryLockStep/help-resource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/TryLockStep/help-resource.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		The resource name to try to lock as defined in Global settings.
+		The step will return true if lock was acquired, or false if not.
+		If the resource does not exist in Global Settings it will be automatically created on build execution.
+	</p>
+</div>

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -44,6 +44,20 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  public void noBodyRequired() throws Exception {
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "lock(resource: 'resource1')\n"
+            + "echo 'Resource locked'\n"
+            + "releaseLock(resource: 'resource1')\n"
+            + "echo 'Finish'"));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+    j.assertBuildStatus(Result.SUCCESS, b1);
+  }
+
+  @Test
   public void autoCreateResourceFreeStyle() throws IOException, InterruptedException {
     FreeStyleProject f = j.createFreeStyleProject("f");
     f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));

--- a/src/test/java/org/jenkins/plugins/lockableresources/ReleaseLockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ReleaseLockStepTest.java
@@ -1,0 +1,105 @@
+package org.jenkins.plugins.lockableresources;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ReleaseLockStepTest extends LockStepTestBase {
+
+  private static final String SCRIPT_LOCK_AND_RELEASE_WITHOUT_RESOURCE =
+      "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'acquired first lock'\n"
+          + "  releaseLock()\n"
+          + "}\n\n"
+          + "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'acquired second lock'\n"
+          + "  releaseLock()\n"
+          + "}";
+
+  private static final String SCRIPT_LOCK_AND_RELEASE_WITH_RESOURCE =
+      "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'acquired first lock'\n"
+          + "  releaseLock(resource: 'resource1')\n"
+          + "}\n\n"
+          + "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'acquired second lock'\n"
+          + "  releaseLock(resource: 'resource1')\n"
+          + "}";
+
+  private static final String SCRIPT_LOCK_AND_RELEASE_NOT_LOCKED_RESOURCE =
+      "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'acquired first lock'\n"
+          + "  releaseLock(resource: 'resource2')\n"
+          + "}\n";
+
+  private static final String SCRIPT_RELEASE_NOT_LOCKED_RESOURCE =
+      "releaseLock(resource: 'resource1')";
+
+  @Rule public JenkinsRule j = new JenkinsRule();
+
+  @Test
+  public void releaseLockWithoutSpecifyingTheName() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_LOCK_AND_RELEASE_WITHOUT_RESOURCE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("acquired first lock", b1);
+    j.assertLogContains("acquired second lock", b1);
+  }
+
+  @Test
+  public void releaseLockBySpecifyingTheName() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_LOCK_AND_RELEASE_WITH_RESOURCE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("acquired first lock", b1);
+    j.assertLogContains("acquired second lock", b1);
+  }
+
+  @Test
+  public void lockAndReleaseNotLockedResource() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_LOCK_AND_RELEASE_NOT_LOCKED_RESOURCE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains(
+        "Cannot release lock resource2 as it was not acquired by the build: [resource1]", b1);
+  }
+
+  @Test
+  public void releaseNotLockedResource() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_RELEASE_NOT_LOCKED_RESOURCE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("Cannot release any locks as none are acquired", b1);
+  }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/TryLockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/TryLockStepTest.java
@@ -1,0 +1,78 @@
+package org.jenkins.plugins.lockableresources;
+
+import java.util.Arrays;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TryLockStepTest extends LockStepTestBase {
+
+  private static final String SCRIPT_TRY_DONT_RELEASE =
+      "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'Returned True'\n"
+          + "} else {\n"
+          + "  echo 'Returned False'\n"
+          + "}";
+
+  private static final String SCRIPT_TRY_AND_RELEASE =
+      "if (tryLock(resource: 'resource1')) {\n"
+          + "  echo 'Returned True'\n"
+          + "  releaseLock(resource: 'resource1')\n"
+          + "} else {"
+          + "  echo 'Returned False'\n"
+          + "}";
+  @Rule public JenkinsRule j = new JenkinsRule();
+
+  @Test
+  public void reserveAvailableResource() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_TRY_DONT_RELEASE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("Returned True", b1);
+    // This comes from LockRunListener
+    j.assertLogContains("[lockable-resources] released lock on [resource1]", b1);
+  }
+
+  @Test
+  public void reserveUnavailableResource() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+    lm.reserve(Arrays.asList(lm.fromName("resource1")), "test");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_TRY_DONT_RELEASE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("Returned False", b1);
+  }
+
+  @Test
+  public void reserveAndReleaseAvailableResource() throws Exception {
+    final LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "label1");
+
+    final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition(SCRIPT_TRY_AND_RELEASE));
+
+    final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+
+    j.assertLogContains("Returned True", b1);
+    j.assertLogContains("Lock released on [[resource1]]", b1);
+  }
+}


### PR DESCRIPTION
This adds the `tryLock` and `releaseLock` steps. It also enables using `lock` without a body.

The `tryLock` can be used like this:

```groovy
if (tryLock(resource: 'staging-server')) {
  try {
    println "Resource was acquired :)"
  } finally {
    releaseLock(resource: 'staging-server')
  }
} else {
    println "Resource was not acquired :("
}
```

fixes #164 and JENKINS-43336

# Searching for available resource

Sometimes we have many resources, perhaps 1000. We have no need for the queue feature in this plugin, we only need to make sure we have exclusive access to a resource. We know there are free resources, it is just a matter of finding one. We may need to find a port to use when starting a server. Then we can do:

```groovy
node {
  // Find a free resource
  def port = -1
  stage("Find port") {
    for (int i = 0; i < 1000; i++) {
      port = i
      if (tryLock(resource: 'staging-server-' + i)) {
        break;
      }
    }
  }
    
  stage("Use port") {
    try {
      // Start server on port
    } finally {
      releaseLock()
    }
  }
}
```

Also one can implement an `isAvailable` method by doing:

```groovy
boolean isAvailable(resource) {
  def isAvailable = tryLock(resource: resource)
  if (isAvailable) {
    releaseLock(resource: resource)
  }
  return isAvailable
}
```

# Visualize the locking in its own stage

By not requiering `lock` to have a body, we can put the `lock`-part in a `stage` and explicitly release it later. Visualizing how much time we spend on waiting for an available resource.

```groovy
node {
  stage("Waiting for resource") {
    lock(resource: 'myResource')
  }

  stage("Using resource") {
    try {
      println "Using the resource here..."
    } finally {
      println "Now releasing the resource..."
      releaseLock()
    }
  }
}
```