### PR TITLE
Proposal for issue #128: Ephemeral labels

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/InternalException.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/InternalException.java
@@ -1,0 +1,7 @@
+package org.jenkins.plugins.lockableresources;
+
+public class InternalException extends Exception {
+  public InternalException(String message) {
+    super("An internal exception occurred in the LockableResourcesPlugin: "  + message);
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -27,6 +27,8 @@ public class LockStep extends Step implements Serializable {
 
   @CheckForNull public String label = null;
 
+  public int createLabelWithQuantity = 0;
+
   public int quantity = 0;
 
   /** name of environment variable to store locked resources in */
@@ -75,6 +77,11 @@ public class LockStep extends Step implements Serializable {
   @DataBoundSetter
   public void setQuantity(int quantity) {
     this.quantity = quantity;
+  }
+
+  @DataBoundSetter
+  public void setCreateLabelWithQuantity(int createLabelWithQuantity) {
+    this.createLabelWithQuantity = createLabelWithQuantity;
   }
 
   @DataBoundSetter
@@ -127,7 +134,7 @@ public class LockStep extends Step implements Serializable {
           .map(res -> "{" + res.toString() + "}")
           .collect(Collectors.joining(","));
     } else if (resource != null || label != null) {
-      return LockStepResource.toString(resource, label, quantity);
+      return LockStepResource.toString(resource, label, quantity, createLabelWithQuantity);
     } else {
       return "nothing";
     }
@@ -135,13 +142,13 @@ public class LockStep extends Step implements Serializable {
 
   /** Label and resource are mutual exclusive. */
   public void validate() throws Exception {
-    LockStepResource.validate(resource, label, quantity);
+    LockStepResource.validate(resource, label, quantity, createLabelWithQuantity);
   }
 
   public List<LockStepResource> getResources() {
     List<LockStepResource> resources = new ArrayList<>();
     if (resource != null || label != null) {
-      resources.add(new LockStepResource(resource, label, quantity));
+      resources.add(new LockStepResource(resource, label, quantity, createLabelWithQuantity));
     }
 
     if (extra != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -45,11 +45,20 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
 
     for (LockStepResource resource : step.getResources()) {
       List<String> resources = new ArrayList<>();
+
       if (resource.resource != null) {
-        if (LockableResourcesManager.get().createResource(resource.resource)) {
+        if (LockableResourcesManager.get().createResource(resource.resource, true)) {
           logger.println("Resource [" + resource + "] did not exist. Created.");
         }
         resources.add(resource.resource);
+      }
+
+      if (resource.label != null && resource.createLabelWithQuantity > 0) {
+        boolean ephemeralLabelCreated = LockableResourcesManager.get().createEphemeralLabel(
+          resource.label, resource.createLabelWithQuantity);
+        if (ephemeralLabelCreated) {
+          logger.println("Label [" + resource.label + "] did not exist. An ephemeral label was created.");
+        }
       }
       resourceHolderList.add(
           new LockableResourcesStruct(resources, resource.label, resource.quantity));

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -25,10 +25,13 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 
 	public int quantity = 0;
 
-	LockStepResource(String resource, String label, int quantity) {
+	public int createLabelWithQuantity = 0;
+
+	LockStepResource(String resource, String label, int quantity, int createLabelWithQuantity) {
 		this.resource = resource;
 		this.label = label;
 		this.quantity = quantity;
+		this.createLabelWithQuantity = createLabelWithQuantity;
 	}
 
 	@DataBoundConstructor
@@ -50,17 +53,27 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 		this.quantity = quantity;
 	}
 
-	public String toString() {
-		return toString(resource, label, quantity);
+  @DataBoundSetter
+  public void setCreateLabelWithQuantity(int quantity) {
+    this.createLabelWithQuantity = quantity;
+  }
+
+  public String toString() {
+		return toString(resource, label, quantity, createLabelWithQuantity);
 	}
-	
-	public static String toString(String resource, String label, int quantity) {
+
+	public static String toString(String resource, String label, int quantity, int createLabelWithQuantity) {
 		// a label takes always priority
 		if (label != null) {
-			if (quantity > 0) {
-				return "Label: " + label + ", Quantity: " + quantity;
-			}
-			return "Label: " + label;
+		  String result = "";
+			result += "Label: " + label;
+      if (quantity > 0) {
+        result += ", Quantity: " + quantity;
+      }
+      if (createLabelWithQuantity > 0) {
+        result += ", CreateLabelWithQuantity: " + createLabelWithQuantity;
+      }
+      return result;
 		}
 		// make sure there is an actual resource specified
 		if (resource != null) {
@@ -73,20 +86,23 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 	 * Label and resource are mutual exclusive.
 	 */
 	public void validate() throws Exception {
-		validate(resource, label, quantity);
+		validate(resource, label, quantity, createLabelWithQuantity);
 	}
 
 	/**
 	 * Label and resource are mutual exclusive.
 	 * The label, if provided, must be configured (at least one resource must have this label).
 	 */
-	public static void validate(String resource, String label, int quantity) throws Exception {
+	public static void validate(String resource, String label, int quantity, int createLabelWithQuantity) throws Exception {
 		if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
 			throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
 		}
-		if (label != null && !LockableResourcesManager.get().isValidLabel( label ) ) {
-			throw new IllegalArgumentException("The label does not exist: " + label);
+		if (label != null && !LockableResourcesManager.get().isValidLabel( label ) && (createLabelWithQuantity == 0)) {
+			throw new IllegalArgumentException("The label does not exist, and createLabelWithQuantity is 0: " + label);
 		}
+    if (label == null && (createLabelWithQuantity > 0)) {
+      throw new IllegalArgumentException("createLabelWithQuantity cannot be used without a label name.");
+    }
 	}
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -139,10 +139,10 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   private boolean labelsContain(String candidate) {
-    return makeLabelsList().contains(candidate);
+    return getLabelsAsList().contains(candidate);
   }
 
-  private List<String> makeLabelsList() {
+  public List<String> getLabelsAsList() {
     return Arrays.asList(labels.split("\\s+"));
   }
 
@@ -162,7 +162,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     Binding binding = new Binding(params);
     binding.setVariable("resourceName", name);
     binding.setVariable("resourceDescription", description);
-    binding.setVariable("resourceLabels", makeLabelsList());
+    binding.setVariable("resourceLabels", getLabelsAsList());
     try {
       Object result = script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding);
       if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -8,7 +8,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources;
 
-import com.iwombat.util.GUIDUtil;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.BulkChange;

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -43,7 +43,7 @@ public class LockableResourcesStruct implements Serializable {
       if (resourceName == null) {
         continue;
       }
-      resourcesManager.createResource(resourceName);
+      resourcesManager.createResource(resourceName, true);
       LockableResource r = resourcesManager.fromName(resourceName);
       this.required.add(r);
     }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -10,6 +10,9 @@
 	<f:entry title="${%Quantity}" field="quantity">
 		<f:number/>
 	</f:entry>
+	<f:entry title="${%CreateLabelWithQuantity}" field="createLabelWithQuantity">
+		<f:number/>
+	</f:entry>
 	<f:entry title="${%Result variable}" field="variable">
 		<f:textbox/>
 	</f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-createLabelWithQuantity.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-createLabelWithQuantity.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+    Set this optional parameter in your pipeline if you want to create an ephemeral label with the
+    specified amount of ephemeral resources automatically if it does not exist already. If you leave
+    this attribute empty or if you specify 0, labels are not created automatically and an error occurs
+    unless the label has already been defined at the system / Jenkins level.
+	</p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
@@ -10,4 +10,7 @@
 	<f:entry title="${%Quantity}" field="quantity">
 		<f:number/>
 	</f:entry>
+	<f:entry title="${%CreateLabelWithQuantity}" field="createLabelWithQuantity">
+		<f:number/>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-createLabelWithQuantity.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-createLabelWithQuantity.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+    Set this optional parameter in your pipeline if you want to create an ephemeral label with the
+    specified amount of ephemeral resources automatically if it does not exist already. If you leave
+    this attribute empty or if you specify 0, labels are not created automatically and an error occurs
+    unless the label has already been defined at the system / Jenkins level.
+	</p>
+</div>

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -2,9 +2,7 @@ package org.jenkins.plugins.lockableresources;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 import hudson.Functions;
@@ -13,7 +11,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
+
 import net.sf.json.JSONObject;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.WithPlugin;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 public class LockStepTest extends LockStepTestBase {
 
@@ -73,6 +75,27 @@ public class LockStepTest extends LockStepTestBase {
     isPaused(b1, 1, 0);
 
     assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+  }
+
+  @Test
+  public void lockWithNonExistentLabel() throws Exception {
+    // Should fail because createLabelWithQuantity needs to be specified in order to create
+    // resources automatically by label
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var') {\n"
+          + "	echo \"Resource locked: ${env.var}\"\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+    j.assertBuildStatus(Result.FAILURE, b1);
+    j.assertLogContains("The label does not exist, and createLabelWithQuantity is 0: label1", b1);
+    isPaused(b1, 0, 0);
+
+    assertFalse(LockableResourcesManager.get().isValidLabel("label1"));
   }
 
   @Test
@@ -549,8 +572,13 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  @WithTimeout(180)
   @WithPlugin("jobConfigHistory.hpi")
   public void lockWithLabelConcurrent() throws Exception {
+    /* This test does not work on Windows, due to similar problems as described in deleteRunningBuildNewBuildClearsLock. */
+    assumeFalse(Functions.isWindows());
+
+    final int numberOfThreads = 50;
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
@@ -559,19 +587,24 @@ public class LockStepTest extends LockStepTestBase {
                 + "Random random = new Random(0);\n"
                 + "lock(label: 'label1') {\n"
                 + "  echo 'Resource locked'\n"
-                + "  sleep random.nextInt(10)*100\n"
+                + "  sleep time: 1000+random.nextInt(2000), unit: 'MILLISECONDS'\n"
                 + "}\n"
                 + "echo 'Finish'",
             true));
-    final CyclicBarrier barrier = new CyclicBarrier(51);
-    for (int i = 0; i < 50; i++) {
+    final CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      System.out.println(String.format("Starting build #%d", i));
       Thread thread =
           new Thread() {
             @Override
             public void run() {
+              final ThreadLocal<WorkflowRun> r;
               try {
                 barrier.await();
                 p.scheduleBuild2(0).waitForStart();
+
+                //j.assertBuildStatusSuccess(j.waitForCompletion(r));
               } catch (Exception e) {
                 System.err.println("Failed to start pipeline job");
               }
@@ -580,7 +613,6 @@ public class LockStepTest extends LockStepTestBase {
       thread.start();
     }
     barrier.await();
-    j.waitUntilNoActivity();
   }
 
   @Test
@@ -854,6 +886,102 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  public void lockWithEphemeralLabelAndResourceQuantity() throws Exception {
+    LockableResourcesManager.get().createResourceWithLabel("resource1", "someOtherLabel");
+    LockableResourcesManager.get().createResourceWithLabel("resource2", "someOtherLabel");
+
+    WorkflowJob p1 = j.jenkins.createProject(WorkflowJob.class, "p1");
+    p1.setDefinition(
+      new CpsFlowDefinition(
+        "lock(variable: 'var', label: 'label2', createLabelWithQuantity: '2', extra: [[resource: 'resource4'], [resource: 'resource2'], [label: 'label1', quantity: 2, createLabelWithQuantity: 4]]) {\n"
+          + "  def lockedResources = env.var.split(',').sort()\n"
+          + "  echo \"Resources locked: ${lockedResources}\"\n"
+          + "  semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+    // #1 should lock as few resources as possible
+    WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
+    SemaphoreStep.waitForStart("wait-inside/1", b1);
+
+    WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
+    p2.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var', quantity: 3, createLabelWithQuantity: 14) {\n"
+          + "	def lockedResources = env.var.split(',').sort()\n"
+          + "	echo \"Resources locked: ${lockedResources}\"\n"
+          + "	semaphore 'wait-inside-quantity3'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+    WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+    j.waitForMessage("[Label: label1, Quantity: 3, CreateLabelWithQuantity: 14] is locked, waiting...", b2);
+    j.waitForMessage("Found 2 available resource(s). Waiting for correct amount: 3.", b2);
+    isPaused(b2, 1, 1);
+
+    WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
+    p3.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var', quantity: 2) {\n"
+          + "	def lockedResources = env.var.split(',').sort()\n"
+          + "	echo \"Resources locked: ${lockedResources}\"\n"
+          + "	semaphore 'wait-inside-quantity2'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+    WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+
+    // Build 4 is for testing that ephemeral labels created in the main clause (not in the extras clause)
+    // also work.
+    WorkflowJob p4 = j.jenkins.createProject(WorkflowJob.class, "p4");
+    p4.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label2', variable: 'var', quantity: 2, createLabelWithQuantity: 3) {\n"
+          + "	def lockedResources = env.var.split(',').sort()\n"
+          + "	echo \"Resources locked: ${lockedResources}\"\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+     WorkflowRun b4 = p4.scheduleBuild2(0).waitForStart();
+
+    // While 2 continues waiting, 3&4 can continue directly
+    SemaphoreStep.waitForStart("wait-inside-quantity2/1", b3);
+    SemaphoreStep.success("wait-inside-quantity2/1", null);
+    j.waitForMessage("Finish", b3);
+    j.assertLogContains("Resources locked: [", b3);
+    isPaused(b3, 1, 0);
+
+    // Unlock resources
+    SemaphoreStep.success("wait-inside/1", null);
+    j.waitForMessage(
+      "Lock released on resource [{Label: label2, CreateLabelWithQuantity: 2},{resource4},{resource2},{Label: label1, Quantity: 2, CreateLabelWithQuantity: 4}]", b1);
+    j.assertLogContains("Resources locked: [", b1);
+    isPaused(b1, 1, 0);
+
+    // #2 gets the lock
+    j.waitForMessage("Lock acquired on [Label: label1, Quantity: 3, CreateLabelWithQuantity: 14]", b2);
+    SemaphoreStep.success("wait-inside-quantity3/1", null);
+    j.waitForMessage("Finish", b2);
+
+    // Could be any 3 resources, so just check the beginning of the message
+    j.assertLogContains("Resources locked: [label1-", b2);
+    isPaused(b2, 1, 0);
+
+    // Let 4 finish
+    j.waitForMessage("Finish", b4);
+    j.assertLogContains("Resources locked: [label2", b4);
+    isPaused(b4, 1, 0);
+
+    assertNotNull(LockableResourcesManager.get().fromName("resource1"));
+    assertNotNull(LockableResourcesManager.get().fromName("resource2"));
+    assertNull(LockableResourcesManager.get().fromName("resource4"));
+
+    assertFalse(LockableResourcesManager.get().isValidLabel("label1"));
+    assertFalse(LockableResourcesManager.get().isValidLabel("label2"));
+
+  }
+
+  @Test
   @Issue("JENKINS-50176")
   public void parallelLockWithLabelFillsVariable() throws Exception {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
@@ -927,7 +1055,7 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.FAILURE, b1);
-    j.assertLogContains("The label does not exist: invalidLabel", b1);
+    j.assertLogContains("The label does not exist, and createLabelWithQuantity is 0: invalidLabel", b1);
     isPaused(b1, 0, 0);
   }
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTestBase.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTestBase.java
@@ -25,5 +25,6 @@ public class LockStepTestBase {
     }
     assertEquals(count, pauseActions);
     assertEquals(effectivePauses, pausedActions);
+
   }
 }


### PR DESCRIPTION
The original motivation for this PR was that I needed fine-grained control over the parallelism in my declarative pipeline. For instance, I needed the ability to allow two parallel jobs within the same Kubernetes build pod, but not three (since that would need too much RAM and CPU, thus crashing my pod). 

Since lockable-resources-plugin already makes this possible in the case where I can define the labels beforehand, I extended the functionality of auto-generating resources to auto-generating labels with a given quantity of resources. The resource names will be auto-generated in the form "LABEL-0000-some-UUID-0000" in order to avoid conflicts with other resources. 

Another motivation was that I wanted to change as few code lines as possible and not break existing behaviour. This is why a user of ephemeral labels must explicitly ask for auto-creation. This is different from single resources, but it should prevent breaking existing pipelines that use lockable-resources.

- Introduce a new lockStep-Parameter "createLabelWithQuantity".
- Make test lockWithLabelConcurrent quicker and ensure that all spawned jobs are checked for success
- Mark test lockWithLabelConcurrent as not working on Windows (seems to work fine on Unix)
- Splits the code for unlocking/freeing resources and deleting obsolete ephemeral resources into two methods
  (see the comment in unlockNames() for details()
- Be more specific inside the code on when createResource() is allowed to auto-create ephemeral resources