### PR TITLE
Use build parameters as resource, label and number.

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import net.sf.json.JSONObject;
+import org.jenkins.plugins.lockableresources.queue.Utils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -40,32 +41,19 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 			String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
 		super();
 
-		if (resourceNames == null || resourceNames.trim().isEmpty()) {
-			this.resourceNames = null;
-		} else {
-			this.resourceNames = resourceNames.trim();
-		}
-		if (resourceNamesVar == null || resourceNamesVar.trim().isEmpty()) {
-			this.resourceNamesVar = null;
-		} else {
-			this.resourceNamesVar = resourceNamesVar.trim();
-		}
-		if (resourceNumber == null || resourceNumber.trim().isEmpty()) {
-			this.resourceNumber = null;
-		} else {
-			this.resourceNumber = resourceNumber.trim();
-		}
-		String labelNamePreparation = (labelName == null || labelName.trim().isEmpty()) ? null : labelName.trim();
+		this.resourceNames = Util.fixEmptyAndTrim(resourceNames);
+		this.resourceNamesVar = Util.fixEmptyAndTrim(resourceNamesVar);
+		this.resourceNumber = Util.fixEmptyAndTrim(resourceNumber);
 		if (resourceMatchScript != null) {
 			this.resourceMatchScript = resourceMatchScript.configuringWithKeyItem();
-			this.labelName = labelNamePreparation;
+			this.labelName = Util.fixEmptyAndTrim(labelName);
 		} else if (labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
 			this.resourceMatchScript = new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()),
 					false, null).configuring(ApprovalContext.create());
 			this.labelName = null;
 		} else {
 			this.resourceMatchScript = null;
-			this.labelName = labelNamePreparation;
+			this.labelName = Util.fixEmptyAndTrim(labelName);
 		}
 	}
 
@@ -159,6 +147,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 						"Only label, groovy expression, or resources can be defined, not more than one.");
 			} else {
 				List<String> wrongNames = new ArrayList<>();
+				List<String> varNames = new ArrayList<>();
 				for (String name : names.split("\\s+")) {
 					boolean found = false;
 					for (LockableResource r : LockableResourcesManager.get()
@@ -168,11 +157,20 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 							break;
 						}
 					}
-					if (!found)
-						wrongNames.add(name);
+					if (!found) {
+						if (Utils.isVariable(name)) {
+							varNames.add(name);
+						} else {
+							wrongNames.add(name);
+						}
+					}
 				}
-				if (wrongNames.isEmpty()) {
+				if (wrongNames.isEmpty() && varNames.isEmpty()) {
 					return FormValidation.ok();
+				} else if (wrongNames.isEmpty()) {
+					return FormValidation
+							.warning("The following resources cannot be validated as they are the environment variables: "
+									+ varNames);
 				} else {
 					return FormValidation
 							.error("The following resources do not exist: "

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -8,6 +8,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources.queue;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
@@ -45,7 +46,8 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 			Job<?, ?> proj = Utils.getProject(build);
 			Set<LockableResource> required = new HashSet<>();
 			if (proj != null) {
-				LockableResourcesStruct resources = Utils.requiredResources(proj);
+				EnvVars env = new EnvVars(((AbstractBuild)build).getBuildVariables());
+				LockableResourcesStruct resources = Utils.requiredResources(proj, env);
 
 				if (resources != null) {
 					if (resources.requiredNumber != null || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -11,6 +11,7 @@ package org.jenkins.plugins.lockableresources.queue;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
@@ -53,56 +54,58 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 		if (project == null)
 			return null;
 
-		LockableResourcesStruct resources = Utils.requiredResources(project);
+		EnvVars env = new EnvVars();
+		for (ParametersAction pa : item.getActions(ParametersAction.class)) {
+			for (ParameterValue p : pa.getParameters()) {
+				try {
+					String value = p.createVariableResolver(null).resolve(p.getName());
+					if (value != null)
+						env.put(p.getName(), value);
+				}
+				catch (Exception e) {
+					LOGGER.log(Level.WARNING, "Unable to resolve parameter, " + p.getName(), e);
+				}
+			}
+		}
+
+		LockableResourcesStruct resources = Utils.requiredResources(project, env);
+
 		if (resources == null ||
 			(resources.required.isEmpty() && resources.label.isEmpty() && resources.getResourceMatchScript() == null)) {
 			return null;
 		}
 
-		int resourceNumber;
-		try {
-			resourceNumber = Integer.parseInt(resources.requiredNumber);
-		} catch (NumberFormatException e) {
-			resourceNumber = 0;
+		int resourceNumber = 0;
+		if (resources.requiredNumber != null) {
+			try {
+				resourceNumber = Integer.parseInt(resources.requiredNumber);
+			} catch (NumberFormatException e) {
+				LOGGER.log(Level.WARNING, "Failed to convert the required number to an integer, " + resources.requiredNumber, e);
+				resourceNumber = 0;
+			}
 		}
 
 		LOGGER.finest(project.getName() +
 			" trying to get resources with these details: " + resources);
 
 		if (resourceNumber > 0 || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {
-			Map<String, Object> params = new HashMap<>();
+			Map<String, Object> params = null;
 
-			// Inject Build Parameters, if possible and applicable to the "item" type
-			try {
-				List<ParametersAction> itemparams = item.getActions(ParametersAction.class);
-				if (itemparams != null) {
-					for ( ParametersAction actparam : itemparams) {
-						if (actparam == null) continue;
-						for ( ParameterValue p : actparam.getParameters() ) {
-							if (p == null) continue;
-							params.put(p.getName(), p.getValue());
-						}
+			if (resources.getResourceMatchScript() != null) {
+				params = new HashMap<>();
+				for (ParametersAction pa : item.getActions(ParametersAction.class)) {
+					for (ParameterValue p : pa.getParameters()) {
+						params.put(p.getName(), p.getValue());
 					}
 				}
-			} catch(Exception ex) {
-				// Report the error and go on with the build -
-				// perhaps this item is not a build with args, etc.
-				// Note this is likely to fail a bit later in such case.
-				if (LOGGER.isLoggable(Level.WARNING)) {
-					if (lastLogged.getIfPresent(item.getId()) == null) {
-						lastLogged.put(item.getId(), new Date());
-					String itemName = project.getFullName() + " (id=" + item.getId() + ")";
-					LOGGER.log(Level.WARNING, "Failed to get build params from item " + itemName, ex);
-					}
+
+				if (item.task instanceof MatrixConfiguration) {
+					MatrixConfiguration matrix = (MatrixConfiguration) item.task;
+					params.putAll(matrix.getCombination());
 				}
 			}
 
-			if (item.task instanceof MatrixConfiguration) {
-				MatrixConfiguration matrix = (MatrixConfiguration) item.task;
-				params.putAll(matrix.getCombination());
-			}
-
-			final List<LockableResource> selected ;
+			final List<LockableResource> selected;
 			try {
 				selected = LockableResourcesManager.get().tryQueue(
 					resources,

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -56,7 +56,7 @@ public class LockableResourcesStruct implements Serializable {
 
     requiredVar = property.getResourceNamesVar();
 
-    requiredNumber = property.getResourceNumber();
+    requiredNumber = env.expand(property.getResourceNumber());
     if (requiredNumber != null && requiredNumber.equals("0")) requiredNumber = null;
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
@@ -14,12 +14,18 @@ import hudson.model.Job;
 import hudson.model.Queue;
 
 import hudson.model.Run;
+import java.util.regex.Pattern;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 
 public final class Utils {
-private Utils() {
+    private Utils() {
+    }
 
-}
+    /**
+     * Pattern for capturing variables. Either $xyz, ${xyz} or ${a.b} but not $a.b
+     */
+    private static final Pattern VARIABLE = Pattern.compile("\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_.]+\\})");
+
 	public static Job<?, ?> getProject(Queue.Item item) {
 		if (item.task instanceof Job)
 			return (Job<?, ?>) item.task;
@@ -32,13 +38,12 @@ private Utils() {
 	}
 
 	public static LockableResourcesStruct requiredResources(
-			Job<?, ?> project) {
+			Job<?, ?> project, EnvVars env) {
 		RequiredResourcesProperty property = null;
-		EnvVars env = new EnvVars();
 
 		if (project instanceof MatrixConfiguration) {
-			env.putAll(((MatrixConfiguration) project).getCombination());
-			project = (Job<?, ?>) project.getParent();
+			env.putAll(((MatrixConfiguration)project).getCombination());
+			project = (Job<?, ?>)project.getParent();
 		}
 
 		property = project.getProperty(RequiredResourcesProperty.class);
@@ -47,4 +52,8 @@ private Utils() {
 
 		return null;
 	}
+
+    public static boolean isVariable(String name) {
+        return VARIABLE.matcher(name).matches();
+    }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -140,6 +140,29 @@ public class FreeStyleProjectTest {
   }
 
   @Test
+  public void configRoundTripWithParam() throws Exception {
+    FreeStyleProject withParam = j.createFreeStyleProject("withparam");
+    withParam.addProperty(new ParametersDefinitionProperty(
+        new StringParameterDefinition("param1", "some-resource", "parameter 1")
+    ));
+    withParam.addProperty(new RequiredResourcesProperty("${param1}", null, null, null, null));
+    FreeStyleProject withParamRoundTrip = j.configRoundtrip(withParam);
+
+    ParametersDefinitionProperty paramsProp =
+        withParamRoundTrip.getProperty(ParametersDefinitionProperty.class);
+    assertNotNull(paramsProp);
+
+    RequiredResourcesProperty resourcesProp =
+        withParamRoundTrip.getProperty(RequiredResourcesProperty.class);
+    assertNotNull(resourcesProp);
+    assertEquals("${param1}", resourcesProp.getResourceNames());
+    assertNull(resourcesProp.getResourceNamesVar());
+    assertNull(resourcesProp.getResourceNumber());
+    assertNull(resourcesProp.getLabelName());
+    assertNull(resourcesProp.getResourceMatchScript());
+  }
+
+  @Test
   public void configRoundTripWithScript() throws Exception {
     FreeStyleProject withScript = j.createFreeStyleProject("withScript");
     SecureGroovyScript origScript = new SecureGroovyScript("return true", false, null);
@@ -247,7 +270,90 @@ public class FreeStyleProjectTest {
   }
 
   @Test
-  public void labelFromParameter() throws IOException, InterruptedException, ExecutionException {
+  public void parallelResourceFromParameter() throws Exception {
+    LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResource("resource1");
+    lm.createResource("resource2");
+    lm.createResource("resource3");
+
+    StringParameterDefinition param1Def = new StringParameterDefinition("param1", "", "parameter 1");
+
+    FreeStyleProject f = j.createFreeStyleProject("f");
+    f.setConcurrentBuild(true);
+    f.addProperty(new ParametersDefinitionProperty(param1Def));
+    f.addProperty(new RequiredResourcesProperty("${param1}", null, null, null, null));
+    f.getBuildersList().add(new WaitBuilder());
+
+    List<ParameterValue> values1 = new ArrayList<ParameterValue>();
+    values1.add(param1Def.createValue("resource1"));
+    FreeStyleBuild fb1 = f.scheduleBuild2(0, new ParametersAction(values1)).waitForStart();
+    j.waitForMessage("acquired lock on [resource1]", fb1);
+    j.waitForMessage("Waiting...", fb1);
+    j.assertLogNotContains("Continue", fb1);
+    Thread.sleep(100);
+
+    List<ParameterValue> values2 = new ArrayList<ParameterValue>();
+    values2.add(param1Def.createValue("resource2"));
+    FreeStyleBuild fb2 = f.scheduleBuild2(0, new ParametersAction(values2)).waitForStart();
+    j.waitForMessage("acquired lock on [resource2]", fb2);
+    j.waitForMessage("Waiting...", fb2);
+    j.assertLogNotContains("Continue", fb2);
+
+    List<ParameterValue> values3 = new ArrayList<ParameterValue>();
+    values3.add(param1Def.createValue("resource1"));
+    QueueTaskFuture<FreeStyleBuild> qt3 = f.scheduleBuild2(0, new ParametersAction(values3));
+    TestHelpers.waitForQueue(j.jenkins, f, Queue.BlockedItem.class);
+
+    Queue.BlockedItem blockedItem = (Queue.BlockedItem)j.jenkins.getQueue().getItem(f);
+    assertThat(blockedItem.getCauseOfBlockage(), is(instanceOf(LockableResourcesQueueTaskDispatcher.BecauseResourcesLocked.class)));
+
+    synchronized (fb2) {
+      fb2.notifyAll();
+    }
+    Thread.sleep(100);
+
+    blockedItem = (Queue.BlockedItem)j.jenkins.getQueue().getItem(f);
+    assertThat(blockedItem.getCauseOfBlockage(), is(instanceOf(LockableResourcesQueueTaskDispatcher.BecauseResourcesLocked.class)));
+
+    j.assertLogNotContains("Continue", fb1);
+    synchronized (fb1) {
+      fb1.notifyAll();
+    }
+    j.assertLogContains("Continue", fb1);
+    j.waitForMessage("released lock on [resource1]", fb1);
+    j.waitForCompletion(fb1);
+
+    FreeStyleBuild fb3 = qt3.waitForStart();
+    j.waitForMessage("acquired lock on [resource1]", fb3);
+    j.waitForMessage("Waiting...", fb3);
+    j.assertLogNotContains("Continue", fb3);
+    synchronized (fb3) {
+      fb3.notifyAll();
+    }
+
+    j.waitUntilNoActivity();
+    assertTrue(
+            "#1 build should be started before the build of #2. "
+                    + "#1 started at " + fb1.getStartTimeInMillis()
+                    + ", #2 finished at " + fb2.getStartTimeInMillis(),
+            fb1.getStartTimeInMillis() < fb2.getStartTimeInMillis());
+
+    long fb1EndTime = fb1.getStartTimeInMillis() + fb1.getDuration();
+    long fb2EndTime = fb2.getStartTimeInMillis() + fb2.getDuration();
+    assertTrue(
+            "#2 build should be finished before the build of #1. "
+                    + "#1 finished at " + fb1EndTime
+                    + ", #2 finished at " + fb2EndTime,
+            fb2EndTime < fb1EndTime);
+      assertTrue(
+              "#3 build should be started after the build of #1. "
+                      + "#1 finished at " + fb1EndTime
+                      + ", #3 started at " + fb3.getStartTimeInMillis(),
+              fb1EndTime < fb3.getStartTimeInMillis());
+  }
+
+  @Test
+  public void labelFromParameter() throws Exception {
     LockableResourcesManager lm = LockableResourcesManager.get();
     lm.createResourceWithLabel("resource1", "resource");
     lm.createResourceWithLabel("resource2", "resource");
@@ -264,17 +370,19 @@ public class FreeStyleProjectTest {
     j.waitForCompletion(fb1);
     assertEquals("resource", fb1.getBuildVariableResolver().resolve("labelParam"));
     j.assertLogContains("acquired lock on [resource1, resource2]", fb1);
+    j.waitUntilNoActivity();
   }
 
   @Test
-  public void resourceNumberFromParameter() throws IOException, InterruptedException, ExecutionException {
+  public void resourceNumberFromParameter() throws Exception {
     LockableResourcesManager lm = LockableResourcesManager.get();
     lm.createResourceWithLabel("resource1", "resource");
     lm.createResourceWithLabel("resource2", "resource");
+    lm.createResourceWithLabel("resource3", "resource");
     lm.reserve(Arrays.asList(lm.fromName("resource1")), "user1");
 
     ParametersDefinitionProperty params = new ParametersDefinitionProperty(
-            new StringParameterDefinition("numParam", "1", "parameter 1")
+            new StringParameterDefinition("numParam", "2", "parameter 1")
     );
 
     FreeStyleProject f = j.createFreeStyleProject("f");
@@ -283,8 +391,9 @@ public class FreeStyleProjectTest {
 
     FreeStyleBuild fb1 = f.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(fb1);
-    assertEquals("1", fb1.getBuildVariableResolver().resolve("numParam"));
-    j.assertLogContains("acquired lock on [resource2]", fb1);
+    assertEquals("2", fb1.getBuildVariableResolver().resolve("numParam"));
+    j.assertLogContains("acquired lock on [resource3, resource2]", fb1);
+    j.waitUntilNoActivity();
   }
 
   public static class PrinterBuilder extends TestBuilder {
@@ -295,6 +404,20 @@ public class FreeStyleProjectTest {
       listener
           .getLogger()
           .println("resourceNameVar: " + build.getEnvironment(listener).get("resourceNameVar"));
+      return true;
+    }
+  }
+
+  private class WaitBuilder extends TestBuilder {
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException {
+      listener.getLogger().println("Waiting...");
+
+      synchronized (build) {
+        build.wait();
+      }
+      listener.getLogger().println("Continue");
       return true;
     }
   }

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -247,6 +247,26 @@ public class FreeStyleProjectTest {
   }
 
   @Test
+  public void labelFromParameter() throws IOException, InterruptedException, ExecutionException {
+    LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "resource");
+    lm.createResourceWithLabel("resource2", "resource");
+
+    ParametersDefinitionProperty params = new ParametersDefinitionProperty(
+            new StringParameterDefinition("labelParam", "resource", "parameter 1")
+    );
+
+    FreeStyleProject f = j.createFreeStyleProject("f");
+    f.addProperty(params);
+    f.addProperty(new RequiredResourcesProperty(null, null, null, "${labelParam}", null));
+
+    FreeStyleBuild fb1 = f.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(fb1);
+    assertEquals("resource", fb1.getBuildVariableResolver().resolve("labelParam"));
+    j.assertLogContains("acquired lock on [resource1, resource2]", fb1);
+  }
+
+  @Test
   public void resourceNumberFromParameter() throws IOException, InterruptedException, ExecutionException {
     LockableResourcesManager lm = LockableResourcesManager.get();
     lm.createResourceWithLabel("resource1", "resource");

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -15,14 +15,17 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
 import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.triggers.TimerTrigger;
 import hudson.util.OneShotEvent;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -211,15 +214,57 @@ public class FreeStyleProjectTest {
   }
 
   @Test
-  public void autoCreateResource() throws IOException, InterruptedException, ExecutionException {
+  public void autoCreateResource() throws Exception {
     FreeStyleProject f = j.createFreeStyleProject("f");
     f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
 
     FreeStyleBuild fb1 = f.scheduleBuild2(0).waitForStart();
     j.waitForMessage("acquired lock on [resource1]", fb1);
     j.waitForCompletion(fb1);
+    j.waitUntilNoActivity();
 
     assertNull(LockableResourcesManager.get().fromName("resource1"));
+  }
+
+  @Test
+  public void autoCreateResourceFromParameter() throws Exception {
+
+    ParametersDefinitionProperty params = new ParametersDefinitionProperty(
+            new StringParameterDefinition("param1", "resource1", "parameter 1")
+    );
+
+    FreeStyleProject f = j.createFreeStyleProject("f");
+    f.addProperty(params);
+    f.addProperty(new RequiredResourcesProperty("${param1}", null, null, null, null));
+
+    FreeStyleBuild fb1 = f.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(fb1);
+    assertEquals("resource1", fb1.getBuildVariableResolver().resolve("param1"));
+    j.assertLogContains("acquired lock on [resource1]", fb1);
+    j.waitUntilNoActivity();
+
+    assertNull(LockableResourcesManager.get().fromName("resource1"));
+  }
+
+  @Test
+  public void resourceNumberFromParameter() throws IOException, InterruptedException, ExecutionException {
+    LockableResourcesManager lm = LockableResourcesManager.get();
+    lm.createResourceWithLabel("resource1", "resource");
+    lm.createResourceWithLabel("resource2", "resource");
+    lm.reserve(Arrays.asList(lm.fromName("resource1")), "user1");
+
+    ParametersDefinitionProperty params = new ParametersDefinitionProperty(
+            new StringParameterDefinition("numParam", "1", "parameter 1")
+    );
+
+    FreeStyleProject f = j.createFreeStyleProject("f");
+    f.addProperty(params);
+    f.addProperty(new RequiredResourcesProperty(null, null, "${numParam}", "resource", null));
+
+    FreeStyleBuild fb1 = f.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(fb1);
+    assertEquals("1", fb1.getBuildVariableResolver().resolve("numParam"));
+    j.assertLogContains("acquired lock on [resource2]", fb1);
   }
 
   public static class PrinterBuilder extends TestBuilder {


### PR DESCRIPTION
Allows build parameters to specify resource names (issue #159), labels and number (issue #202) in Freestyle builds.

Used the code for PR #33 as a base and fixed the issues raised.
- Running in parallel.
- Parameter expansion is handled with the standard Jenkins '${parameter}' style.
- The label can also be specified with a parameter.

Tests added too.