### PR TITLE
Fix with uninlined layouts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-def recentLTS = "2.222.4"
+def recentLTS = "2.249.1"
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <configuration-as-code.version>1.25</configuration-as-code.version>
     <!-- For compatibility with modern Jenkins LTS -->
     <slf4jVersion>1.7.26</slf4jVersion>
+    <jenkins-test-harness.version>2.67</jenkins-test-harness.version>
   </properties>
 
   <dependencies>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -9,24 +9,9 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <script>
-    function find_resource_name(element) {
-      var row = element.up('tr');
-      var resourceName = row.getAttribute('data-resource-name');
-      return resourceName;
-    }
-    function resource_action(button, action) {
-      // TODO: Migrate to form:link after Jenkins 2.233 (for button-styled links)
-      var form = document.createElement('form');
-      form.setAttribute('method', 'POST');
-      form.setAttribute('action', action + "?resource=" + find_resource_name(button));
-      crumb.appendToForm(form);
-      document.body.appendChild(form);
-      form.submit();
-    }
-  </script>
-
   <l:layout title="${it.displayName}" type="one-column">
+    <script type="text/javascript"
+            src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"></script>
     <l:main-panel>
       <h1>${%Lockable Resources}</h1>
       <table class="pane" style="width: auto;">

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2020, Tobias Gruetzmacher
+
+function find_resource_name(element) {
+  var row = element.up('tr');
+  var resourceName = row.getAttribute('data-resource-name');
+  return resourceName;
+}
+
+function resource_action(button, action) {
+  // TODO: Migrate to form:link after Jenkins 2.233 (for button-styled links)
+  var form = document.createElement('form');
+  form.setAttribute('method', 'POST');
+  form.setAttribute('action', action + "?resource=" + find_resource_name(button));
+  crumb.appendToForm(form);
+  document.body.appendChild(form);
+  form.submit();
+}


### PR DESCRIPTION
This fixes #216 and JENKINS-63780.

This wasn't discovered earlier because I didn't test against the latest LTS, but only against the previous LTS, so the the fault is entirely mine.

----
What follows is a rambling rant about HTML. Reader beware.

Oh, how I hate "tagsoup", which is the harmless name for a browser reading utterly broken HTML and trying to make sense of it. I broke the DOM of this page 16 months ago. Visually, nothing was wrong. The page still worked. Everything was "fine", just every browser had to work a little bit harder to display the page.

Then jenkinsci/jenkins#4741 came around and all hell broke loose. See, this added some metadata on the `<head>` tag, of which every "proper" HTML document only has one. But I broke the rules. I put something before the "original" `<head>` and broke the structure. And because that's not allowed, the browser has to "fix" the structure, so it invented a `<html>` and `<head>` for my broken code - and when it came around to the "original" `<head>` it said: "Nonono, we already have one of those, let's just throw it away!" and all the nice metadata on this tag was thrown away, too - one of those is the CSRF crumb, so the buttons cannot work after the security fix.