### PR TITLE
Update plugin metadata for 2021

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/lockable-resources-plugin-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "basil"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "basil"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,3 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: .github
 tag-template: lockable-resources-$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+# Automates creation of Release Drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into the default branch
+      - uses: release-drafter/release-drafter@v5.13.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,16 @@
-#!groovy
-def recentLTS = "2.249.1"
-buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-  [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+/*
+ * See the documentation for more options:
+ * https://github.com/jenkins-infra/pipeline-library/
+ */
+buildPlugin(useAci: true, configurations: [
+  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
+  // Jenkins version).
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+
+  // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
+  [ platform: 'linux', jdk: '8', jenkins: '2.277.1' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.277.1' ],
+
+  // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
+  [ platform: 'linux', jdk: '11', jenkins: '2.277.1' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.17</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,7 @@
     computers) that can be used by builds. If a build requires an external
     resource which is already locked, it will wait for the resource to be free.
   </description>
-  <url>https://github.com/jenkinsci/lockable-resources-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <inceptionYear>2013</inceptionYear>
   <licenses>
     <license>
@@ -30,6 +30,11 @@
   </licenses>
 
   <developers>
+    <developer>
+      <id>basil</id>
+      <name>Basil Crow</name>
+      <email>me@basilcrow.com</email>
+    </developer>
     <developer>
       <id>TobiX</id>
       <name>Tobias Gruetzmacher</name>
@@ -43,9 +48,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/lockable-resources-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/lockable-resources-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/lockable-resources-plugin</url>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 
@@ -53,39 +58,42 @@
     <revision>2.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <workflow-support.version>3.4</workflow-support.version>
-    <jenkins.version>2.138.4</jenkins.version>
-    <configuration-as-code.version>1.25</configuration-as-code.version>
-    <!-- For compatibility with modern Jenkins LTS -->
-    <slf4jVersion>1.7.26</slf4jVersion>
-    <jenkins-test-harness.version>2.67</jenkins-test-harness.version>
+    <jenkins.version>2.164.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.164.x</artifactId>
+        <version>10</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>${workflow-support.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.62</version>
     </dependency>
     <dependency>
       <groupId>com.infradna.tool</groupId>
@@ -104,39 +112,32 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>${workflow-support.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.74</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.38</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
-      <classifier>tests</classifier>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -160,7 +161,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.9</version>
+          <version>2.9.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Refreshes the plugin metadata with the latest from the [archetypes](https://github.com/jenkinsci/archetypes) and updates the `Jenkinsfile` to test against the latest LTS.