### PR TITLE
lockable-resources.js: URI-encode the resource name to make a button …

### DIFF
--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -11,7 +11,7 @@ function resource_action(button, action) {
   // TODO: Migrate to form:link after Jenkins 2.233 (for button-styled links)
   var form = document.createElement('form');
   form.setAttribute('method', 'POST');
-  form.setAttribute('action', action + "?resource=" + find_resource_name(button));
+  form.setAttribute('action', action + "?resource=" + encodeURIComponent(find_resource_name(button)));
   crumb.appendToForm(form);
   document.body.appendChild(form);
   form.submit();


### PR DESCRIPTION
…(fixes issue #237)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

I am not sure how to provide automated tests for this browser-only code. I checked with Firefox and MSIE that resources with a "hash sign" in a name that were not successfully handled by action buttons earlier (details in issue #237), are handled correctly now.

According to https://www.w3schools.com/jsref/jsref_encodeuricomponent.asp the `encodeURIComponent()` method is in JavaScript implementations of all major browsers.