### PR TITLE
Migrate from Guava to Caffeine

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you have the proper environment, typing:
 
 should create a plugin as `target/*.hpi`, which you can install in your Jenkins instance. Running
 
-    $ mvn hpi:run -Djenkins.version=2.164.1
+    $ mvn hpi:run -Djenkins.version=2.222.4
 
 allows you to spin up a test Jenkins instance on [localhost] to test your
 local changes before committing.

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <revision>2.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.164.3</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -66,8 +66,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.164.x</artifactId>
-        <version>10</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>807.v6d348e44c987</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -75,6 +75,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -8,8 +8,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package org.jenkins.plugins.lockableresources.queue;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
@@ -37,7 +37,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Extension
 public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
-	private transient Cache<Long,Date> lastLogged = CacheBuilder.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).build();
+	private transient Cache<Long,Date> lastLogged = Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).build();
 
 	static final Logger LOGGER = Logger
 			.getLogger(LockableResourcesQueueTaskDispatcher.class.getName());


### PR DESCRIPTION
Remove the use of Guava from the plugin in order to be compatible with future Jenkins versions where Guava may be bumped or not exposed.