### PR TITLE
add ability to query lockable resources from standard /api uri

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -9,6 +9,7 @@
 package org.jenkins.plugins.lockableresources.actions;
 
 import hudson.Extension;
+import hudson.model.Api;
 import hudson.model.RootAction;
 import hudson.model.User;
 import hudson.security.AccessDeniedException2;
@@ -27,8 +28,11 @@ import org.jenkins.plugins.lockableresources.Messages;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 @Extension
+@ExportedBean
 public class LockableResourcesRootAction implements RootAction {
 
 	public static final PermissionGroup PERMISSIONS_GROUP = new PermissionGroup(
@@ -54,6 +58,10 @@ public class LockableResourcesRootAction implements RootAction {
 		return Jenkins.get().hasPermission(VIEW) ? ICON : null;
 	}
 
+	public Api getApi() {
+		return new Api(this);
+	}
+
 	public String getUserName() {
 		User current = User.current();
 		if (current != null)
@@ -72,6 +80,7 @@ public class LockableResourcesRootAction implements RootAction {
 		return Jenkins.get().hasPermission(VIEW) ? "lockable-resources" : "";
 	}
 
+	@Exported
 	public List<LockableResource> getResources() {
 		return LockableResourcesManager.get().getResources();
 	}

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_api.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_api.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<!--
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright (c) 2013, 6WIND S.A. All rights reserved.                 *
+ *                                                                     *
+ * This file is part of the Jenkins Lockable Resources Plugin and is   *
+ * published under the MIT license.                                    *
+ *                                                                     *
+ * See the "LICENSE.txt" file for more information.                    *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ -->
+<div>
+  This /api adds remote API access to read current resources.
+</div>


### PR DESCRIPTION
This is the first of several pull requests I intend to open from additional features we have required in our group at Western Digital.  This one simply turns on the default /api behavior to allow the lockable resources to be queried and used via the standard REST-ish API.  This is just standard code used to turn on the behavior generically.  The /api support is provided through the main Jenkins libraries so no additional tests are necessary, I think.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did (above)
- [x] Link to relevant issues in GitHub or Jira - https://github.com/jenkinsci/lockable-resources-plugin/issues/262
- [x] Link to relevant pull requests, esp. upstream and downstream changes (N/A)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (N/A)

This is my first PR so thanks for your patience if I need to do anything else.  This change is simple so wanted to get familiar with the process.  Thanks for your work and administration of this functionality, it has been very helpful.

