### PR TITLE
Update test instructions to require jenkins 2.249.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you have the proper environment, typing:
 
 should create a plugin as `target/*.hpi`, which you can install in your Jenkins instance. Running
 
-    $ mvn hpi:run -Djenkins.version=2.222.4
+    $ mvn hpi:run -Djenkins.version=2.249.1
 
 allows you to spin up a test Jenkins instance on [localhost] to test your
 local changes before committing.


### PR DESCRIPTION
The current instructions result in the following error when trying to launch a jenkins test instance:

```
Caused by: org.apache.maven.plugin.MojoExecutionException: Dependency io.jenkins.plugins:bootstrap4-api:jar:4.6.0-3 requires Jenkins 2.249.1 or higher.
```

Changing the version to 2.249.1 fixes the issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
