### PR TITLE
Set a numbered variable for each acquired lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,30 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 }
 ```
 
-*Resolve a variable configured with the resource*
+*Resolve a variable configured with the resource name*
 
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
 }
 ```
+
+When multiple locks are acquired, each will be assigned to a numbered variable:
+
+```groovy
+lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
+  // comma separated names of all acquired locks
+  echo env.LOCKED_RESOURCE
+
+  // first lock
+  echo env.LOCKED_RESOURCE0
+
+  // second lock
+  echo env.LOCKED_RESOURCE1
+}
+```
+
+
 
 *Skip executing the block if there is a queue*
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -8,10 +8,13 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -132,15 +135,16 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
 
                   @Override
                   public void expand(@NonNull EnvVars env) {
+                    final Map<String, String> variables = new HashMap<>();
                     final String resources = String.join(",", resourcenames);
-                    LOGGER.finest(
-                        "Setting ["
-                            + variable
-                            + "] to ["
-                            + resources
-                            + "] for the duration of the block");
-
-                    env.override(variable, resources);
+                    variables.put(variable, resources);
+                    for (int index = 0; index < resourcenames.size(); ++index) {
+                      variables.put(variable + index, resourcenames.get(index));
+                    }
+                    LOGGER.finest("Setting "
+                      + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))
+                      + " for the duration of the block");
+                    env.overrideAll(variables);
                   }
                 }));
       }

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
@@ -8,19 +8,20 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
+import java.util.List;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Restricted(NoExternalUse.class)
 public class ResourceVariableNameAction extends InvisibleAction {
 
-	private final StringParameterValue resourceNameParameter;
+	private final List<StringParameterValue> resourceNameParameter;
 
-	public ResourceVariableNameAction(StringParameterValue r) {
+	public ResourceVariableNameAction(List<StringParameterValue> r) {
 		this.resourceNameParameter = r;
 	}
 
-	StringParameterValue getParameter() {
+	List<StringParameterValue> getParameter() {
 		return resourceNameParameter;
 	}
 
@@ -30,8 +31,10 @@ public class ResourceVariableNameAction extends InvisibleAction {
 		@Override
 		public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) {
 			ResourceVariableNameAction a = r.getAction(ResourceVariableNameAction.class);
-			if (a != null && a.getParameter() != null && a.getParameter().getValue() != null) {
-				envs.put(a.getParameter().getName(), String.valueOf(a.getParameter().getValue()));
+			if (a != null && a.getParameter() != null) {
+				for (StringParameterValue envToSet : a.getParameter()) {
+					envs.override(envToSet.getName(), envToSet.getValue());
+				}
 			}
 		}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -17,10 +17,13 @@ import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
@@ -62,9 +65,23 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 						LOGGER.fine(build.getFullDisplayName()
 								+ " acquired lock on " + required);
 						if (resources.requiredVar != null) {
-							build.addAction(new ResourceVariableNameAction(new StringParameterValue(
-									resources.requiredVar,
-									required.toString().replaceAll("[\\]\\[]", ""))));
+							List<StringParameterValue> envsToSet = new ArrayList<>();
+
+							// add the comma separated list of names acquired
+							envsToSet.add(new StringParameterValue(
+								resources.requiredVar,
+								required.stream()
+									.map(LockableResource::getName)
+									.collect(Collectors.joining(","))));
+
+							// also add a numbered variable for each acquired lock
+							int index = 0;
+							for (LockableResource lr : required) {
+								envsToSet.add(new StringParameterValue(resources.requiredVar + index, lr.getName()));
+								++index;
+							}
+
+							build.addAction(new ResourceVariableNameAction(envsToSet));
 						}
 					} else {
 						listener.getLogger().printf("%s failed to lock %s%n",

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -832,9 +832,9 @@ public class LockStepTest extends LockStepTestBase {
     p.setDefinition(
       new CpsFlowDefinition(
         "lock(label: 'label1', variable: 'someVar', quantity: 2) {\n"
-          + "  echo \"VAR IS $env.someVar\"\n"
-          + "  echo \"VAR0 IS $env.someVar0\"\n"
-          + "  echo \"VAR1 IS $env.someVar1\"\n"
+          + "  echo \"VAR IS ${env.someVar.split(',').sort()}\"\n"
+          + "  echo \"VAR0or1 IS $env.someVar0\"\n"
+          + "  echo \"VAR0or1 IS $env.someVar1\"\n"
           + "  echo \"VAR2 IS $env.someVar2\"\n"
           + "}",
         true));
@@ -842,9 +842,9 @@ public class LockStepTest extends LockStepTestBase {
     j.waitForCompletion(b1);
 
     // Variable should have been filled
-    j.assertLogContains("VAR IS resource1,resource2", b1);
-    j.assertLogContains("VAR0 IS resource1", b1);
-    j.assertLogContains("VAR1 IS resource2", b1);
+    j.assertLogContains("VAR IS [resource1, resource2]", b1);
+    j.assertLogContains("VAR0or1 IS resource1", b1);
+    j.assertLogContains("VAR0or1 IS resource2", b1);
     j.assertLogContains("VAR2 IS null", b1);
   }
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -824,6 +824,31 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  //@Issue("JENKINS-XXXXX")
+  public void multipleLocksFillVariables() throws Exception {
+    LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
+    LockableResourcesManager.get().createResourceWithLabel("resource2", "label1");
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar', quantity: 2) {\n"
+          + "  echo \"VAR IS $env.someVar\"\n"
+          + "  echo \"VAR0 IS $env.someVar0\"\n"
+          + "  echo \"VAR1 IS $env.someVar1\"\n"
+          + "  echo \"VAR2 IS $env.someVar2\"\n"
+          + "}",
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+
+    // Variable should have been filled
+    j.assertLogContains("VAR IS resource1,resource2", b1);
+    j.assertLogContains("VAR0 IS resource1", b1);
+    j.assertLogContains("VAR1 IS resource2", b1);
+    j.assertLogContains("VAR2 IS null", b1);
+  }
+
+  @Test
   @Issue("JENKINS-50176")
   public void lockWithLabelFillsVariable() throws Exception {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");


### PR DESCRIPTION
This is a step towards implementing the feature from https://github.com/jenkinsci/lockable-resources-plugin/pull/20 where lock properties can be configured and exposed to the pipeline.

One of the issue with this new feature is that in some cases, multiple locks are acquired, making the exposition of properties cumbersome.

This alters the behaviour of the `variable` extraction in the following way:

- The environment variable with the name of the requested `variable` will still contain the lock name, or a comma separated list of lock names; *this does not break compatibility*
- Additional environment variables are set, with the `variable` name as a prefix and a number as a suffix, making it possible to retrieve individual lock names, ex:

```groovy
lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
  // comma separated names of all acquired locks
  echo env.LOCKED_RESOURCE

  // first lock
  echo env.LOCKED_RESOURCE0

  // second lock
  echo env.LOCKED_RESOURCE1
}
```

If this is approved, I will submit another PR to expose lock properties with the `<name><number>_<propertykey>` format.

This differs from the approach in https://github.com/jenkinsci/lockable-resources-plugin/pull/20 where new arguments were added to the plugin: `injectProperties`, `prefixProperties` and `uppercaseProperties`

In my implementation, instead I will simplify this to assume that when `variable` is set, the properties are also requested and should use the `variable` value (with index) for properties, ex.

```groovy
lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
 // name of the lock
  echo env.LOCKED_RESOURCE0
 // value of the property KEY_A for the acquired lock
  echo env.LOCKED_RESOURCE0_KEY_A
}
```

I don't think it is necessary to make the feature more complex than this to make it useful.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
