### PR TITLE
Assign properties to lockable resources and retrieve them in environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,30 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 }
 ```
 
-*Resolve a variable configured with the resource*
+*Resolve a variable configured with the resource name*
 
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
 }
 ```
+
+When multiple locks are acquired, each will be assigned to a numbered variable:
+
+```groovy
+lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
+  // comma separated names of all acquired locks
+  echo env.LOCKED_RESOURCE
+
+  // first lock
+  echo env.LOCKED_RESOURCE0
+
+  // second lock
+  echo env.LOCKED_RESOURCE1
+}
+```
+
+
 
 *Skip executing the block if there is a queue*
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 }
 ```
 
-*Resolve a variable configured with the resource name*
+*Resolve a variable configured with the resource name and properties*
 
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
+  echo env.LOCKED_RESOURCE_PROP_ABC
 }
 ```
 
@@ -84,13 +85,13 @@ lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
 
   // first lock
   echo env.LOCKED_RESOURCE0
+  echo env.LOCKED_RESOURCE0_PROP_ABC
 
   // second lock
   echo env.LOCKED_RESOURCE1
+  echo env.LOCKED_RESOURCE0_PROP_ABC
 }
 ```
-
-
 
 *Skip executing the block if there is a queue*
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ unclassified:
         description: "Description_A"
         labels: "Label_A"
         reservedBy: "Reserved_A"
+        properties:
+          - name: "Property_A"
+            value: "Value"
 ```
 
 ## Changelog

--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -26,25 +26,25 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
  */
 @Deprecated
 public final class BackwardCompatibility {
-	private static final Logger LOG = Logger.getLogger(BackwardCompatibility.class.getName());
+  private static final Logger LOG = Logger.getLogger(BackwardCompatibility.class.getName());
 
-	private BackwardCompatibility() {}
+  private BackwardCompatibility() {}
 
-	@Initializer(after = InitMilestone.JOB_LOADED)
-	public static void compatibilityMigration() {
-		LOG.log(Level.FINE, "lockable-resource-plugin compatibility migration task run");
-		List<LockableResource> resources = LockableResourcesManager.get().getResources();
-		for (LockableResource resource : resources) {
-			List<StepContext> queuedContexts = resource.getQueuedContexts();
-			if (!queuedContexts.isEmpty()) {
-				for (StepContext queuedContext : queuedContexts) {
-					List<String> resourcesNames = new ArrayList<>();
-					resourcesNames.add(resource.getName());
-					LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-					LockableResourcesManager.get().queueContext(queuedContext, Collections.singletonList(resourceHolder), resource.getName(), null);
-				}
-				queuedContexts.clear();
-			}
-		}
-	}
+  @Initializer(after = InitMilestone.JOB_LOADED)
+  public static void compatibilityMigration() {
+    LOG.log(Level.FINE, "lockable-resource-plugin compatibility migration task run");
+    List<LockableResource> resources = LockableResourcesManager.get().getResources();
+    for (LockableResource resource : resources) {
+      List<StepContext> queuedContexts = resource.getQueuedContexts();
+      if (!queuedContexts.isEmpty()) {
+        for (StepContext queuedContext : queuedContexts) {
+          List<String> resourcesNames = new ArrayList<>();
+          resourcesNames.add(resource.getName());
+          LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
+          LockableResourcesManager.get().queueContext(queuedContext, Collections.singletonList(resourceHolder), resource.getName(), null);
+        }
+        queuedContexts.clear();
+      }
+    }
+  }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -108,12 +108,12 @@ public class LockStep extends Step implements Serializable {
     }
 
     public static FormValidation doCheckLabel(
-        @QueryParameter String value, @QueryParameter String resource) {
+      @QueryParameter String value, @QueryParameter String resource) {
       return LockStepResource.DescriptorImpl.doCheckLabel(value, resource);
     }
 
     public static FormValidation doCheckResource(
-        @QueryParameter String value, @QueryParameter String label) {
+      @QueryParameter String value, @QueryParameter String label) {
       return LockStepResource.DescriptorImpl.doCheckLabel(label, value);
     }
 
@@ -127,8 +127,8 @@ public class LockStep extends Step implements Serializable {
   public String toString() {
     if (extra != null && !extra.isEmpty()) {
       return getResources().stream()
-          .map(res -> "{" + res.toString() + "}")
-          .collect(Collectors.joining(","));
+        .map(res -> "{" + res.toString() + "}")
+        .collect(Collectors.joining(","));
     } else if (resource != null || label != null) {
       return LockStepResource.toString(resource, label, quantity);
     } else {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -57,30 +57,30 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
         resources.add(resource.resource);
       }
       resourceHolderList.add(
-          new LockableResourcesStruct(resources, resource.label, resource.quantity));
+        new LockableResourcesStruct(resources, resource.label, resource.quantity));
     }
 
     // determine if there are enough resources available to proceed
     Set<LockableResource> available =
-        LockableResourcesManager.get()
-            .checkResourcesAvailability(resourceHolderList, logger, null, step.skipIfLocked);
+      LockableResourcesManager.get()
+        .checkResourcesAvailability(resourceHolderList, logger, null, step.skipIfLocked);
     Run<?, ?> run = getContext().get(Run.class);
     if (available == null
-        || !LockableResourcesManager.get()
-            .lock(
-                available,
-                run,
-                getContext(),
-                step.toString(),
-                step.variable,
-                step.inversePrecedence)) {
+      || !LockableResourcesManager.get()
+      .lock(
+        available,
+        run,
+        getContext(),
+        step.toString(),
+        step.variable,
+        step.inversePrecedence)) {
       // if the resource is known, we could output the active/blocking job/build
       LockableResource resource = LockableResourcesManager.get().fromName(step.resource);
       boolean buildNameKnown = resource != null && resource.getBuildName() != null;
       if (step.skipIfLocked) {
         if (buildNameKnown) {
           logger.println(
-              "[" + step + "] is locked by " + resource.getBuildName() + ", skipping execution...");
+            "[" + step + "] is locked by " + resource.getBuildName() + ", skipping execution...");
         } else {
           logger.println("[" + step + "] is locked, skipping execution...");
         }
@@ -93,27 +93,27 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
           logger.println("[" + step + "] is locked, waiting...");
         }
         LockableResourcesManager.get()
-            .queueContext(getContext(), resourceHolderList, step.toString(), step.variable);
+          .queueContext(getContext(), resourceHolderList, step.toString(), step.variable);
       }
     } // proceed is called inside lock if execution is possible
     return false;
   }
 
   public static void proceed(
-      final Map<String, List<LockableResourceProperty>> lockedResources,
-      StepContext context,
-      String resourceDescription,
-      final String variable,
-      boolean inversePrecedence) {
+    final Map<String, List<LockableResourceProperty>> lockedResources,
+    StepContext context,
+    String resourceDescription,
+    final String variable,
+    boolean inversePrecedence) {
     Run<?, ?> r;
     FlowNode node;
     try {
       r = context.get(Run.class);
       node = context.get(FlowNode.class);
       context
-          .get(TaskListener.class)
-          .getLogger()
-          .println("Lock acquired on [" + resourceDescription + "]");
+        .get(TaskListener.class)
+        .getLogger()
+        .println("Lock acquired on [" + resourceDescription + "]");
     } catch (Exception e) {
       context.onFailure(e);
       return;
@@ -123,38 +123,38 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     try {
       PauseAction.endCurrentPause(node);
       BodyInvoker bodyInvoker =
-          context
-              .newBodyInvoker()
-              .withCallback(new Callback(new ArrayList<>(lockedResources.keySet()), resourceDescription, inversePrecedence));
+        context
+          .newBodyInvoker()
+          .withCallback(new Callback(new ArrayList<>(lockedResources.keySet()), resourceDescription, inversePrecedence));
       if (variable != null && variable.length() > 0) {
         // set the variable for the duration of the block
         bodyInvoker.withContext(
-            EnvironmentExpander.merge(
-                context.get(EnvironmentExpander.class),
-                new EnvironmentExpander() {
-                  private static final long serialVersionUID = -3431466225193397896L;
+          EnvironmentExpander.merge(
+            context.get(EnvironmentExpander.class),
+            new EnvironmentExpander() {
+              private static final long serialVersionUID = -3431466225193397896L;
 
-                  @Override
-                  public void expand(@NonNull EnvVars env) {
-                    final Map<String, String> variables = new HashMap<>();
-                    final String resourceNames = lockedResources.keySet().stream().collect(Collectors.joining(","));
-                    variables.put(variable, resourceNames);
-                    int index = 0;
-                    for (Entry<String, List<LockableResourceProperty>> lockResourceEntry : lockedResources.entrySet()) {
-                      String lockEnvName = variable + index;
-                      variables.put(lockEnvName, lockResourceEntry.getKey());
-                      for (LockableResourceProperty lockProperty : lockResourceEntry.getValue()) {
-                        String propEnvName = lockEnvName + "_" + lockProperty.getName();
-                        variables.put(propEnvName, lockProperty.getValue());
-                      }
-                      ++index;
-                    }
-                    LOGGER.finest("Setting "
-                      + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))
-                      + " for the duration of the block");
-                    env.overrideAll(variables);
+              @Override
+              public void expand(@NonNull EnvVars env) {
+                final Map<String, String> variables = new HashMap<>();
+                final String resourceNames = lockedResources.keySet().stream().collect(Collectors.joining(","));
+                variables.put(variable, resourceNames);
+                int index = 0;
+                for (Entry<String, List<LockableResourceProperty>> lockResourceEntry : lockedResources.entrySet()) {
+                  String lockEnvName = variable + index;
+                  variables.put(lockEnvName, lockResourceEntry.getKey());
+                  for (LockableResourceProperty lockProperty : lockResourceEntry.getValue()) {
+                    String propEnvName = lockEnvName + "_" + lockProperty.getName();
+                    variables.put(propEnvName, lockProperty.getValue());
                   }
-                }));
+                  ++index;
+                }
+                LOGGER.finest("Setting "
+                  + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))
+                  + " for the duration of the block");
+                env.overrideAll(variables);
+              }
+            }));
       }
       bodyInvoker.start();
     } catch (IOException | InterruptedException e) {
@@ -170,9 +170,9 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     private final boolean inversePrecedence;
 
     Callback(
-        List<String> resourceNames,
-        String resourceDescription,
-        boolean inversePrecedence) {
+      List<String> resourceNames,
+      String resourceDescription,
+      boolean inversePrecedence) {
       this.resourceNames = resourceNames;
       this.resourceDescription = resourceDescription;
       this.inversePrecedence = inversePrecedence;
@@ -181,11 +181,11 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     @Override
     protected void finished(StepContext context) throws Exception {
       LockableResourcesManager.get()
-          .unlockNames(this.resourceNames, context.get(Run.class), this.inversePrecedence);
+        .unlockNames(this.resourceNames, context.get(Run.class), this.inversePrecedence);
       context
-          .get(TaskListener.class)
-          .getLogger()
-          .println("Lock released on resource [" + resourceDescription + "]");
+        .get(TaskListener.class)
+        .getLogger()
+        .println("Lock released on resource [" + resourceDescription + "]");
       LOGGER.finest("Lock released on [" + resourceDescription + "]");
     }
   }
@@ -195,9 +195,9 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
     if (!cleaned) {
       LOGGER.log(
-          Level.WARNING,
-          "Cannot remove context from lockable resource waiting list. "
-              + "The context is not in the waiting list.");
+        Level.WARNING,
+        "Cannot remove context from lockable resource waiting list. "
+          + "The context is not in the waiting list.");
     }
     getContext().onFailure(cause);
   }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -99,7 +100,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
   }
 
   public static void proceed(
-      final List<String> resourcenames,
+      final Map<String, List<LockableResourceProperty>> lockedResources,
       StepContext context,
       String resourceDescription,
       final String variable,
@@ -124,7 +125,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
       BodyInvoker bodyInvoker =
           context
               .newBodyInvoker()
-              .withCallback(new Callback(resourcenames, resourceDescription, inversePrecedence));
+              .withCallback(new Callback(new ArrayList<>(lockedResources.keySet()), resourceDescription, inversePrecedence));
       if (variable != null && variable.length() > 0) {
         // set the variable for the duration of the block
         bodyInvoker.withContext(
@@ -136,10 +137,17 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
                   @Override
                   public void expand(@NonNull EnvVars env) {
                     final Map<String, String> variables = new HashMap<>();
-                    final String resources = String.join(",", resourcenames);
-                    variables.put(variable, resources);
-                    for (int index = 0; index < resourcenames.size(); ++index) {
-                      variables.put(variable + index, resourcenames.get(index));
+                    final String resourceNames = lockedResources.keySet().stream().collect(Collectors.joining(","));
+                    variables.put(variable, resourceNames);
+                    int index = 0;
+                    for (Entry<String, List<LockableResourceProperty>> lockResourceEntry : lockedResources.entrySet()) {
+                      String lockEnvName = variable + index;
+                      variables.put(lockEnvName, lockResourceEntry.getKey());
+                      for (LockableResourceProperty lockProperty : lockResourceEntry.getValue()) {
+                        String propEnvName = lockEnvName + "_" + lockProperty.getName();
+                        variables.put(propEnvName, lockProperty.getValue());
+                      }
+                      ++index;
                     }
                     LOGGER.finest("Setting "
                       + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -8,10 +8,13 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -132,15 +135,16 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
 
                   @Override
                   public void expand(@NonNull EnvVars env) {
+                    final Map<String, String> variables = new HashMap<>();
                     final String resources = String.join(",", resourcenames);
-                    LOGGER.finest(
-                        "Setting ["
-                            + variable
-                            + "] to ["
-                            + resources
-                            + "] for the duration of the block");
-
-                    env.override(variable, resources);
+                    variables.put(variable, resources);
+                    for (int index = 0; index < resourcenames.size(); ++index) {
+                      variables.put(variable + index, resourcenames.get(index));
+                    }
+                    LOGGER.finest("Setting "
+                      + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))
+                      + " for the duration of the block");
+                    env.overrideAll(variables);
                   }
                 }));
       }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -16,112 +16,112 @@ import org.kohsuke.stapler.QueryParameter;
 
 public class LockStepResource extends AbstractDescribableImpl<LockStepResource> implements Serializable {
 
-	@CheckForNull
-	public String resource = null;
+  @CheckForNull
+  public String resource = null;
 
-	@CheckForNull
-	public String label = null;
+  @CheckForNull
+  public String label = null;
 
-	public int quantity = 0;
+  public int quantity = 0;
 
-	LockStepResource(@Nullable String resource, @Nullable String label, int quantity) {
-		this.resource = resource;
-		this.label = label;
-		this.quantity = quantity;
-	}
+  LockStepResource(@Nullable String resource, @Nullable String label, int quantity) {
+    this.resource = resource;
+    this.label = label;
+    this.quantity = quantity;
+  }
 
-	@DataBoundConstructor
-	public LockStepResource(@Nullable String resource) {
-		if (resource != null && !resource.isEmpty()) {
-			this.resource = resource;
-		}
-	}
+  @DataBoundConstructor
+  public LockStepResource(@Nullable String resource) {
+    if (resource != null && !resource.isEmpty()) {
+      this.resource = resource;
+    }
+  }
 
-	@DataBoundSetter
-	public void setLabel(String label) {
-		if (label != null && !label.isEmpty()) {
-			this.label = label;
-		}
-	}
+  @DataBoundSetter
+  public void setLabel(String label) {
+    if (label != null && !label.isEmpty()) {
+      this.label = label;
+    }
+  }
 
-	@DataBoundSetter
-	public void setQuantity(int quantity) {
-		this.quantity = quantity;
-	}
+  @DataBoundSetter
+  public void setQuantity(int quantity) {
+    this.quantity = quantity;
+  }
 
-	@Override
-	public String toString() {
-		return toString(resource, label, quantity);
-	}
+  @Override
+  public String toString() {
+    return toString(resource, label, quantity);
+  }
 
-	public static String toString(String resource, String label, int quantity) {
-		// a label takes always priority
-		if (label != null) {
-			if (quantity > 0) {
-				return "Label: " + label + ", Quantity: " + quantity;
-			}
-			return "Label: " + label;
-		}
-		// make sure there is an actual resource specified
-		if (resource != null) {
-			return resource;
-		}
-		return "[no resource/label specified - probably a bug]";
-	}
+  public static String toString(String resource, String label, int quantity) {
+    // a label takes always priority
+    if (label != null) {
+      if (quantity > 0) {
+        return "Label: " + label + ", Quantity: " + quantity;
+      }
+      return "Label: " + label;
+    }
+    // make sure there is an actual resource specified
+    if (resource != null) {
+      return resource;
+    }
+    return "[no resource/label specified - probably a bug]";
+  }
 
-	/**
-	 * Label and resource are mutual exclusive.
-	 */
-	public void validate() {
-		validate(resource, label, quantity);
-	}
+  /**
+   * Label and resource are mutual exclusive.
+   */
+  public void validate() {
+    validate(resource, label, quantity);
+  }
 
-	/**
-	 * Label and resource are mutual exclusive.
-	 * The label, if provided, must be configured (at least one resource must have this label).
-	 */
-	public static void validate(String resource, String label, int quantity) {
-		if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
-			throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
-		}
-		if (label != null && !LockableResourcesManager.get().isValidLabel( label ) ) {
-			throw new IllegalArgumentException("The label does not exist: " + label);
-		}
-	}
+  /**
+   * Label and resource are mutual exclusive.
+   * The label, if provided, must be configured (at least one resource must have this label).
+   */
+  public static void validate(String resource, String label, int quantity) {
+    if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
+      throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
+    }
+    if (label != null && !LockableResourcesManager.get().isValidLabel( label ) ) {
+      throw new IllegalArgumentException("The label does not exist: " + label);
+    }
+  }
 
-	private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-	@Extension
-	public static class DescriptorImpl extends Descriptor<LockStepResource> {
+  @Extension
+  public static class DescriptorImpl extends Descriptor<LockStepResource> {
 
     @NonNull
-		@Override
-		public String getDisplayName() {
-			return "Resource";
-		}
+    @Override
+    public String getDisplayName() {
+      return "Resource";
+    }
 
-		public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
-			return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
-		}
+    public AutoCompletionCandidates doAutoCompleteResource(@QueryParameter String value) {
+      return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value);
+    }
 
-		public static FormValidation doCheckLabel(@QueryParameter String value, @QueryParameter String resource) {
-			String resourceLabel = Util.fixEmpty(value);
-			String resourceName = Util.fixEmpty(resource);
-			if (resourceLabel != null && resourceName != null) {
-				return FormValidation.error("Label and resource name cannot be specified simultaneously.");
-			}
-			if ((resourceLabel == null) && (resourceName == null)) {
-				return FormValidation.error("Either label or resource name must be specified.");
-			}
-			if (resourceLabel != null && !LockableResourcesManager.get().isValidLabel(resourceLabel)) {
-				return FormValidation.error("The label does not exist: " + resourceLabel);
-			}
-			return FormValidation.ok();
-		}
+    public static FormValidation doCheckLabel(@QueryParameter String value, @QueryParameter String resource) {
+      String resourceLabel = Util.fixEmpty(value);
+      String resourceName = Util.fixEmpty(resource);
+      if (resourceLabel != null && resourceName != null) {
+        return FormValidation.error("Label and resource name cannot be specified simultaneously.");
+      }
+      if ((resourceLabel == null) && (resourceName == null)) {
+        return FormValidation.error("Either label or resource name must be specified.");
+      }
+      if (resourceLabel != null && !LockableResourcesManager.get().isValidLabel(resourceLabel)) {
+        return FormValidation.error("The label does not exist: " + resourceLabel);
+      }
+      return FormValidation.ok();
+    }
 
-		public static FormValidation doCheckResource(@QueryParameter String value, @QueryParameter String label) {
-			return doCheckLabel(label, value);
-		}
-	}
+    public static FormValidation doCheckResource(@QueryParameter String value, @QueryParameter String label) {
+      return doCheckLabel(label, value);
+    }
+  }
 
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -83,6 +83,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * being held, it becomes ephemeral and will disappear when freed.
    */
   private boolean ephemeral;
+  private List<LockableResourceProperty> properties = new ArrayList<>();
 
   private long queueItemId = NOT_QUEUED;
   private String queueItemProject = null;
@@ -171,6 +172,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @Exported
   public boolean isEphemeral() {
     return ephemeral;
+  }
+
+  @Exported
+  public List<LockableResourceProperty> getProperties() {
+    return properties;
+  }
+
+  @DataBoundSetter
+  public void setProperties(List<LockableResourceProperty> properties) {
+    this.properties = (properties == null ? new ArrayList<>() : properties);
   }
 
   public boolean isValidLabel(String candidate, Map<String, Object> params) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -49,7 +49,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 @ExportedBean(defaultVisibility = 999)
 public class LockableResource extends AbstractDescribableImpl<LockableResource>
-    implements Serializable {
+  implements Serializable {
 
   private static final Logger LOGGER = Logger.getLogger(LockableResource.class.getName());
   public static final int NOT_QUEUED = 0;
@@ -207,8 +207,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Restricted(NoExternalUse.class)
   public boolean scriptMatches(
-      @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
-      throws ExecutionException {
+    @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
+    throws ExecutionException {
     Binding binding = new Binding(params);
     binding.setVariable("resourceName", name);
     binding.setVariable("resourceDescription", description);
@@ -216,22 +216,22 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     binding.setVariable("resourceNote", note);
     try {
       Object result =
-          script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding, null);
+        script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding, null);
       if (LOGGER.isLoggable(Level.FINE)) {
         LOGGER.fine(
-            "Checked resource "
-                + name
-                + " for "
-                + script.getScript()
-                + " with "
-                + binding
-                + " -> "
-                + result);
+          "Checked resource "
+            + name
+            + " for "
+            + script.getScript()
+            + " with "
+            + binding
+            + " -> "
+            + result);
       }
       return (Boolean) result;
     } catch (Exception e) {
       throw new ExecutionException(
-          "Cannot get boolean result out of groovy expression. See system log for more info", e);
+        "Cannot get boolean result out of groovy expression. See system log for more info", e);
     }
   }
 
@@ -425,11 +425,11 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   /** Tell LRM to recycle this resource, including notifications for
-    * whoever may be waiting in the queue so they can proceed immediately.
-    * WARNING: Do not use this from inside the lock step closure which
-    * originally locked this resource, to avoid nasty surprises!
-    * Just stick with unReserve() and close the closure, if needed.
-    */
+   * whoever may be waiting in the queue so they can proceed immediately.
+   * WARNING: Do not use this from inside the lock step closure which
+   * originally locked this resource, to avoid nasty surprises!
+   * Just stick with unReserve() and close the closure, if needed.
+   */
   public void recycle() {
     try {
       List<LockableResource> resources = new ArrayList<>();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
@@ -1,0 +1,66 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright (c) 2013, 6WIND S.A. All rights reserved.                 *
+ *                                                                     *
+ * This file is part of the Jenkins Lockable Resources Plugin and is   *
+ * published under the MIT license.                                    *
+ *                                                                     *
+ * See the "LICENSE.txt" file for more information.                    *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+package org.jenkins.plugins.lockableresources;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import java.io.Serializable;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.export.Exported;
+
+public class LockableResourceProperty extends AbstractDescribableImpl<LockableResourceProperty>
+  implements Serializable {
+
+  private String name;
+  private String value;
+
+  @DataBoundConstructor
+  public LockableResourceProperty() {
+  }
+
+  @DataBoundSetter
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @DataBoundSetter
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Exported
+  public String getName() {
+    return name;
+  }
+
+  @Exported
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Extension
+  public static class DescriptorImpl extends Descriptor<LockableResourceProperty> {
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+      return "Property";
+    }
+  }
+
+  private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -203,9 +203,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized boolean queue(
-      List<LockableResource> resources,
-      long queueItemId,
-      String queueProjectName) {
+      List<LockableResource> resources, long queueItemId, String queueProjectName) {
     for (LockableResource r : resources) {
       if (r.isReserved() || r.isQueued(queueItemId) || r.isLocked()) {
         return false;
@@ -335,7 +333,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       candidates = cachedCandidates.getIfPresent(queueItemId);
       if (candidates != null) {
         candidates.retainAll(resources);
-      } else {
+    } else {
         candidates = (systemGroovyScript == null)
             ? getResourcesWithLabel(requiredResources.label, params)
             : getResourcesMatchingScript(systemGroovyScript, params);
@@ -472,8 +470,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized void unlock(
-      List<LockableResource> resourcesToUnLock,
-      @Nullable Run<?, ?> build) {
+      List<LockableResource> resourcesToUnLock, @Nullable Run<?, ?> build) {
     unlock(resourcesToUnLock, build, false);
   }
 
@@ -601,20 +598,17 @@ public class LockableResourcesManager extends GlobalConfiguration {
   /** @see #getNextQueuedContext(List, List, boolean, QueuedContextStruct) */
   @CheckForNull
   private QueuedContextStruct getNextQueuedContext(
-      List<String> resourceNamesToUnLock,
-      boolean inversePrecedence,
-      QueuedContextStruct from
-  ) {
+      List<String> resourceNamesToUnLock, boolean inversePrecedence, QueuedContextStruct from) {
       return this.getNextQueuedContext(resourceNamesToUnLock, null, inversePrecedence, from);
   }
 
   /**
    * Returns the next queued context with all its requirements satisfied.
    *
-   * @param resourceNamesToUnLock resource names locked at the moment but
-   *     available if required (as they are going to be unlocked soon)
-   * @param resourceNamesToUnReserve resource names reserved at the moment but
-   *     available if required (as they are going to be un-reserved soon)
+   * @param resourceNamesToUnLock resource names locked at the moment but available if required (as
+   *     they are going to be unlocked soon)
+   * @param resourceNamesToUnReserve resource names reserved at the moment but available if required
+   *     (as they are going to be un-reserved soon)
    * @param inversePrecedence false pick up context as they are in the queue or true to take the
    *     most recent one (satisfying requirements)
    * @return the context or null
@@ -624,14 +618,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
       @Nullable List<String> resourceNamesToUnLock,
       @Nullable List<String> resourceNamesToUnReserve,
       boolean inversePrecedence,
-      QueuedContextStruct from
-  ) {
+      QueuedContextStruct from) {
     QueuedContextStruct newestEntry = null;
     int fromIndex = from != null ? this.queuedContexts.indexOf(from) + 1 : 0;
     if (!inversePrecedence) {
       for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
         QueuedContextStruct entry = this.queuedContexts.get(i);
-        if (checkResourcesAvailability(entry.getResources(), null, resourceNamesToUnLock, resourceNamesToUnReserve) != null) {
+        if (checkResourcesAvailability(
+                entry.getResources(), null, resourceNamesToUnLock, resourceNamesToUnReserve)
+            != null) {
           return entry;
         }
       }
@@ -640,7 +635,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
       List<QueuedContextStruct> orphan = new ArrayList<>();
       for (int i = fromIndex; i < this.queuedContexts.size(); i++) {
         QueuedContextStruct entry = this.queuedContexts.get(i);
-        if (checkResourcesAvailability(entry.getResources(), null, resourceNamesToUnLock, resourceNamesToUnReserve) != null) {
+        if (checkResourcesAvailability(
+                entry.getResources(), null, resourceNamesToUnLock, resourceNamesToUnReserve)
+            != null) {
           try {
             Run<?, ?> run = entry.getContext().get(Run.class);
             if (run != null && run.getStartTimeInMillis() > newest) {
@@ -712,13 +709,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /**
-   * Reserves an available resource for the userName indefinitely
-   * (until that person, or some explicit scripted action, decides
-   * to release the resource).
+   * Reserves an available resource for the userName indefinitely (until that person, or some
+   * explicit scripted action, decides to release the resource).
    */
-  public synchronized boolean reserve(
-      List<LockableResource> resources,
-      String userName) {
+  public synchronized boolean reserve(List<LockableResource> resources, String userName) {
     for (LockableResource r : resources) {
       if (r.isReserved() || r.isLocked() || r.isQueued()) {
         return false;
@@ -732,15 +726,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /**
-   * Reserves a resource that may be or not be locked by some
-   * job (or reserved by some user) already, giving it away to
-   * the userName indefinitely (until that person, or some
-   * explicit scripted action, later decides to release the
-   * resource).
+   * Reserves a resource that may be or not be reserved by some job already, giving it away to the
+   * userName indefinitely (until that person, or some explicit scripted action, decides to release
+   * the resource).
    */
-  public synchronized boolean steal(
-      List<LockableResource> resources,
-      String userName) {
+  public synchronized boolean steal(List<LockableResource> resources, String userName) {
     for (LockableResource r : resources) {
       r.setReservedBy(userName);
       r.setStolen();
@@ -751,14 +741,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /**
-   * Reserves a resource that may be or not be reserved by some
-   * person already, giving it away to the userName indefinitely
-   * (until that person, or some explicit scripted action, decides
-   * to release the resource).
+   * Reserves a resource that may be or not be reserved by some person already, giving it away to
+   * the userName indefinitely (until that person, or some explicit scripted action, decides to
+   * release the resource).
    */
-  public synchronized void reassign(
-      List<LockableResource> resources,
-      String userName) {
+  public synchronized void reassign(List<LockableResource> resources, String userName) {
     for (LockableResource r : resources) {
       if (r.isReserved() || r.isLocked() || r.isQueued()) {
         r.unReserve();
@@ -815,8 +802,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // remove context from queue and process it
     Set<LockableResource> requiredResourceForNextContext =
         checkResourcesAvailability(
-            nextContext.getResources(), nextContextLogger,
-            null, resourceNamesToUnreserve);
+            nextContext.getResources(), nextContextLogger, null, resourceNamesToUnreserve);
     this.queuedContexts.remove(nextContext);
 
     // resourceNamesToUnreserve contains the names of the previous resources.
@@ -886,12 +872,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
     save();
   }
 
-  /** Make the lockable resource re-usable and notify the queue(s), if any
-   * WARNING: Do not use this from inside the lock step closure which
-   * originally locked this resource, to avoid nasty surprises!
-   * Namely, this *might* let a second consumer use the resource quickly,
-   * but when the original closure ends and unlocks again that resource,
-   * a third consumer might then effectively hijack it from the second one.
+  /**
+   * Make the lockable resource re-usable and notify the queue(s), if any WARNING: Do not use this
+   * from inside the lock step closure which originally locked this resource, to avoid nasty
+   * surprises! Namely, this *might* let a second consumer use the resource quickly, but when the
+   * original closure ends and unlocks again that resource, a third consumer might then effectively
+   * hijack it from the second one.
    */
   public synchronized void recycle(List<LockableResource> resources) {
     // Not calling reset() because that also un-queues the resource
@@ -959,7 +945,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
       @Nullable List<String> reservedResourcesAboutToBeUnreserved) {
     boolean skipIfLocked = false;
     return this.checkResourcesAvailability(
-        requiredResourcesList, logger,
+        requiredResourcesList,
+        logger,
         lockedResourcesAboutToBeUnlocked,
         reservedResourcesAboutToBeUnreserved,
         skipIfLocked);
@@ -1022,17 +1009,18 @@ public class LockableResourcesManager extends GlobalConfiguration {
       // Determine if these resources can be reused
       // FIXME? Why is this check not outside the for loop?
       if (lockedResourcesAboutToBeUnlocked != null
-      ||  reservedResourcesAboutToBeUnreserved != null
-      ) {
+          || reservedResourcesAboutToBeUnreserved != null) {
         for (LockableResource candidate : requiredResources.candidates) {
           if (selected.size() >= requiredResources.requiredAmount) {
             break;
           }
 
           String candidateName = candidate.getName();
-          boolean listedUnlock = (lockedResourcesAboutToBeUnlocked != null
+          boolean listedUnlock =
+              (lockedResourcesAboutToBeUnlocked != null
             &&  lockedResourcesAboutToBeUnlocked.contains(candidateName));
-          boolean listedUnreserve = (reservedResourcesAboutToBeUnreserved != null
+          boolean listedUnreserve =
+              (reservedResourcesAboutToBeUnreserved != null
             &&  reservedResourcesAboutToBeUnreserved.contains(candidateName));
           boolean isReserved = candidate.isReserved();
           boolean isLocked = candidate.isLocked();
@@ -1057,9 +1045,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
               // notified until you lock/unlock that resource again.
               if (logger != null) {
                 logger.println(
-                  "Candidate resource '" + candidateName +
-                  "' is reserved by '" + candidate.getReservedBy() +
-                  "', not treating as available.");
+                    "Candidate resource '"
+                        + candidateName
+                        + "' is reserved by '"
+                        + candidate.getReservedBy()
+                        + "', not treating as available.");
               }
               totalReserved += 1;
               continue;
@@ -1083,10 +1073,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // Note that if arguments lockedResourcesAboutToBeUnlocked==null
     // and reservedResourcesAboutToBeUnreserved==null, then
     // the loop above was effectively skipped
-    if (totalSelected == 0 && totalReserved == 0
+    if (totalSelected == 0
+        && totalReserved == 0
     &&  (lockedResourcesAboutToBeUnlocked != null
-         || reservedResourcesAboutToBeUnreserved != null)
-    ) {
+            || reservedResourcesAboutToBeUnreserved != null)) {
       return null;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1030,12 +1030,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
           }
 
           String candidateName = candidate.getName();
-          Boolean listedUnlock = (lockedResourcesAboutToBeUnlocked != null
+          boolean listedUnlock = (lockedResourcesAboutToBeUnlocked != null
             &&  lockedResourcesAboutToBeUnlocked.contains(candidateName));
-          Boolean listedUnreserve = (reservedResourcesAboutToBeUnreserved != null
+          boolean listedUnreserve = (reservedResourcesAboutToBeUnreserved != null
             &&  reservedResourcesAboutToBeUnreserved.contains(candidateName));
-          Boolean isReserved = candidate.isReserved();
-          Boolean isLocked = candidate.isLocked();
+          boolean isReserved = candidate.isReserved();
+          boolean isLocked = candidate.isLocked();
 
           if (isReserved) {
             if (listedUnreserve) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -333,7 +333,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       candidates = cachedCandidates.getIfPresent(queueItemId);
       if (candidates != null) {
         candidates.retainAll(resources);
-    } else {
+      } else {
         candidates = (systemGroovyScript == null)
             ? getResourcesWithLabel(requiredResources.label, params)
             : getResourcesMatchingScript(systemGroovyScript, params);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -184,8 +184,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
    */
   @NonNull
   public List<LockableResource> getResourcesMatchingScript(
-      @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
-      throws ExecutionException {
+    @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
+    throws ExecutionException {
     List<LockableResource> found = new ArrayList<>();
     for (LockableResource r : this.resources) {
       if (r.scriptMatches(script, params)) found.add(r);
@@ -223,21 +223,21 @@ public class LockableResourcesManager extends GlobalConfiguration {
   @Deprecated
   @CheckForNull
   public synchronized List<LockableResource> queue(
-      LockableResourcesStruct requiredResources,
-      long queueItemId,
-      String queueItemProject,
-      int number, // 0 means all
-      Map<String, Object> params,
-      Logger log) {
+    LockableResourcesStruct requiredResources,
+    long queueItemId,
+    String queueItemProject,
+    int number, // 0 means all
+    Map<String, Object> params,
+    Logger log) {
     try {
       return tryQueue(requiredResources, queueItemId, queueItemProject, number, params, log);
     } catch (ExecutionException ex) {
       if (LOGGER.isLoggable(Level.WARNING)) {
         String itemName = queueItemProject + " (id=" + queueItemId + ")";
         LOGGER.log(
-            Level.WARNING,
-            "Failed to queue item " + itemName,
-            ex.getCause() != null ? ex.getCause() : ex);
+          Level.WARNING,
+          "Failed to queue item " + itemName,
+          ex.getCause() != null ? ex.getCause() : ex);
       }
       return null;
     }
@@ -306,21 +306,21 @@ public class LockableResourcesManager extends GlobalConfiguration {
    */
   @CheckForNull
   public synchronized List<LockableResource> tryQueue(
-      LockableResourcesStruct requiredResources,
-      long queueItemId,
-      String queueItemProject,
-      int number,
-      Map<String, Object> params,
-      Logger log)
-      throws ExecutionException {
+    LockableResourcesStruct requiredResources,
+    long queueItemId,
+    String queueItemProject,
+    int number,
+    Map<String, Object> params,
+    Logger log)
+    throws ExecutionException {
     List<LockableResource> selected = new ArrayList<>();
 
     if (!checkCurrentResourcesStatus(selected, queueItemProject, queueItemId, log)) {
       // The project has another buildable item waiting -> bail out
       log.log(
-          Level.FINEST,
-          "{0} has another build waiting resources." + " Waiting for it to proceed first.",
-          new Object[] {queueItemProject});
+        Level.FINEST,
+        "{0} has another build waiting resources." + " Waiting for it to proceed first.",
+        new Object[] {queueItemProject});
       return null;
     }
 
@@ -329,14 +329,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
     List<LockableResource> candidates = requiredResources.required; // default candidates
 
     if (candidatesByScript ||
-        (requiredResources.label != null && !requiredResources.label.isEmpty())) {
+      (requiredResources.label != null && !requiredResources.label.isEmpty())) {
       candidates = cachedCandidates.getIfPresent(queueItemId);
       if (candidates != null) {
         candidates.retainAll(resources);
       } else {
         candidates = (systemGroovyScript == null)
-            ? getResourcesWithLabel(requiredResources.label, params)
-            : getResourcesMatchingScript(systemGroovyScript, params);
+          ? getResourcesWithLabel(requiredResources.label, params)
+          : getResourcesMatchingScript(systemGroovyScript, params);
         cachedCandidates.put(queueItemId, candidates);
       }
     }
@@ -361,9 +361,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     if (selected.size() != required_amount) {
       log.log(
-          Level.FINEST,
-          "{0} found {1} resource(s) to queue." + "Waiting for correct amount: {2}.",
-          new Object[] {queueItemProject, selected.size(), required_amount});
+        Level.FINEST,
+        "{0} found {1} resource(s) to queue." + "Waiting for correct amount: {2}.",
+        new Object[] {queueItemProject, selected.size(), required_amount});
       // just to be sure, clean up
       for (LockableResource x : resources) {
         if (x.getQueueItemProject() != null && x.getQueueItemProject().equals(queueItemProject))
@@ -381,7 +381,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   // Adds already selected (in previous queue round) resources to 'selected'
   // Return false if another item queued for this project -> bail out
   private boolean checkCurrentResourcesStatus(
-      List<LockableResource> selected, String project, long taskId, Logger log) {
+    List<LockableResource> selected, String project, long taskId, Logger log) {
     for (LockableResource r : resources) {
       // This project might already have something in queue
       String rProject = r.getQueueItemProject();
@@ -392,9 +392,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
         } else {
           // The project has another buildable item waiting -> bail out
           log.log(
-              Level.FINEST,
-              "{0} has another build " + "that already queued resource {1}. Continue queueing.",
-              new Object[] {project, r});
+            Level.FINEST,
+            "{0} has another build " + "that already queued resource {1}. Continue queueing.",
+            new Object[] {project, r});
           return false;
         }
       }
@@ -403,18 +403,18 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized boolean lock(
-      Set<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
+    Set<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
     return lock(resources, build, context, null, null, false);
   }
 
   /** Try to lock the resource and return true if locked. */
   public synchronized boolean lock(
-      Set<LockableResource> resources,
-      Run<?, ?> build,
-      @Nullable StepContext context,
-      @Nullable String logmessage,
-      final String variable,
-      boolean inversePrecedence) {
+    Set<LockableResource> resources,
+    Run<?, ?> build,
+    @Nullable StepContext context,
+    @Nullable String logmessage,
+    final String variable,
+    boolean inversePrecedence) {
     boolean needToWait = false;
 
     for (LockableResource r : resources) {
@@ -443,19 +443,19 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   private synchronized void freeResources(
-      List<String> unlockResourceNames, @Nullable Run<?, ?> build) {
+    List<String> unlockResourceNames, @Nullable Run<?, ?> build) {
     for (String unlockResourceName : unlockResourceNames) {
       Iterator<LockableResource> resourceIterator = this.resources.iterator();
       while (resourceIterator.hasNext()) {
         LockableResource resource = resourceIterator.next();
         if (resource != null
-            && resource.getName() != null
-            && resource.getName().equals(unlockResourceName)) {
+          && resource.getName() != null
+          && resource.getName().equals(unlockResourceName)) {
           if (build == null
-              || (resource.getBuild() != null
-                  && build
-                      .getExternalizableId()
-                      .equals(resource.getBuild().getExternalizableId()))) {
+            || (resource.getBuild() != null
+            && build
+            .getExternalizableId()
+            .equals(resource.getBuild().getExternalizableId()))) {
             // No more contexts, unlock resource
             resource.unqueue();
             resource.setBuild(null);
@@ -475,9 +475,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized void unlock(
-      @Nullable List<LockableResource> resourcesToUnLock,
-      @Nullable Run<?, ?> build,
-      boolean inversePrecedence) {
+    @Nullable List<LockableResource> resourcesToUnLock,
+    @Nullable Run<?, ?> build,
+    boolean inversePrecedence) {
     List<String> resourceNamesToUnLock = new ArrayList<>();
     if (resourcesToUnLock != null) {
       for (LockableResource r : resourcesToUnLock) {
@@ -489,9 +489,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized void unlockNames(
-      @Nullable List<String> resourceNamesToUnLock,
-      @Nullable Run<?, ?> build,
-      boolean inversePrecedence) {
+    @Nullable List<String> resourceNamesToUnLock,
+    @Nullable Run<?, ?> build,
+    boolean inversePrecedence) {
     // make sure there is a list of resource names to unlock
     if (resourceNamesToUnLock == null || resourceNamesToUnLock.isEmpty()) {
       return;
@@ -504,7 +504,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     while (!remainingResourceNamesToUnLock.isEmpty()) {
       // check if there are resources which can be unlocked (and shall not be unlocked)
       nextContext =
-          this.getNextQueuedContext(remainingResourceNamesToUnLock, inversePrecedence, nextContext);
+        this.getNextQueuedContext(remainingResourceNamesToUnLock, inversePrecedence, nextContext);
 
       // no context is queued which can be started once these resources are free'd.
       if (nextContext == null) {
@@ -514,8 +514,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
       }
 
       Set<LockableResource> requiredResourceForNextContext =
-          checkResourcesAvailability(
-              nextContext.getResources(), null, remainingResourceNamesToUnLock);
+        checkResourcesAvailability(
+          nextContext.getResources(), null, remainingResourceNamesToUnLock);
 
       // resourceNamesToUnlock contains the names of the previous resources.
       // requiredResourceForNextContext contains the resource objects which are required for the
@@ -524,7 +524,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       // reused.
       boolean needToWait = false;
       for (LockableResource requiredResource : requiredResourceForNextContext) {
-        if(requiredResource.isStolen()) {
+        if (requiredResource.isStolen()) {
           needToWait = true;
           break;
         }
@@ -551,13 +551,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
             // skip this context, as the build cannot be retrieved (maybe it was deleted while
             // running?)
             LOGGER.log(
-                Level.WARNING,
-                "Skipping queued context for lock. Cannot get the Run object from the context to "
-                    + "proceed with lock; this could be a legitimate state if the build waiting "
-                    + "for the lock was deleted or hard killed. More information is logged at "
-                    + "Level.FINE for debugging purposes.");
+              Level.WARNING,
+              "Skipping queued context for lock. Cannot get the Run object from the context to "
+                + "proceed with lock; this could be a legitimate state if the build waiting "
+                + "for the lock was deleted or hard killed. More information is logged at "
+                + "Level.FINE for debugging purposes.");
             LOGGER.log(
-                Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
+              Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
             unlockNames(remainingResourceNamesToUnLock, build, inversePrecedence);
             return;
           }
@@ -569,7 +569,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
           boolean resourceStillNeeded = false;
           for (LockableResource requiredResource : requiredResourceForNextContext) {
             if (resourceNameToUnlock != null
-                && resourceNameToUnlock.equals(requiredResource.getName())) {
+              && resourceNameToUnlock.equals(requiredResource.getName())) {
               resourceStillNeeded = true;
               break;
             }
@@ -585,11 +585,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
         // continue with next context
         LockStepExecution.proceed(
-            resourcesToLock,
-            nextContext.getContext(),
-            nextContext.getResourceDescription(),
-            nextContext.getVariableName(),
-            inversePrecedence);
+          resourcesToLock,
+          nextContext.getContext(),
+          nextContext.getResourceDescription(),
+          nextContext.getVariableName(),
+          inversePrecedence);
       }
     }
     save();
@@ -599,7 +599,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   @CheckForNull
   private QueuedContextStruct getNextQueuedContext(
       List<String> resourceNamesToUnLock, boolean inversePrecedence, QueuedContextStruct from) {
-      return this.getNextQueuedContext(resourceNamesToUnLock, null, inversePrecedence, from);
+    return this.getNextQueuedContext(resourceNamesToUnLock, null, inversePrecedence, from);
   }
 
   /**
@@ -615,9 +615,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
    */
   @CheckForNull
   private QueuedContextStruct getNextQueuedContext(
-      @Nullable List<String> resourceNamesToUnLock,
-      @Nullable List<String> resourceNamesToUnReserve,
-      boolean inversePrecedence,
+    @Nullable List<String> resourceNamesToUnLock,
+    @Nullable List<String> resourceNamesToUnReserve,
+    boolean inversePrecedence,
       QueuedContextStruct from) {
     QueuedContextStruct newestEntry = null;
     int fromIndex = from != null ? this.queuedContexts.indexOf(from) + 1 : 0;
@@ -775,16 +775,16 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     // check if there are resources which can be unlocked (and shall not be unlocked)
     QueuedContextStruct nextContext =
-        this.getNextQueuedContext(null, resourceNamesToUnreserve, false, null);
+      this.getNextQueuedContext(null, resourceNamesToUnreserve, false, null);
 
     // no context is queued which can be started once these resources are free'd.
     if (nextContext == null) {
       LOGGER.log(
-          Level.FINER,
-          () ->
-              "No context queued for resources "
-                  + String.join(", ", resourceNamesToUnreserve)
-                  + " so unreserving and proceeding.");
+        Level.FINER,
+        () ->
+          "No context queued for resources "
+            + String.join(", ", resourceNamesToUnreserve)
+            + " so unreserving and proceeding.");
       unreserveResources(resources);
       return;
     }
@@ -801,7 +801,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     // remove context from queue and process it
     Set<LockableResource> requiredResourceForNextContext =
-        checkResourcesAvailability(
+      checkResourcesAvailability(
             nextContext.getResources(), nextContextLogger, null, resourceNamesToUnreserve);
     this.queuedContexts.remove(nextContext);
 
@@ -836,24 +836,24 @@ public class LockableResourcesManager extends GlobalConfiguration {
           // skip this context, as the build cannot be retrieved (maybe it was deleted while
           // running?)
           LOGGER.log(
-              Level.WARNING,
-              "Skipping queued context for lock. Cannot get the Run object from the context to "
-                  + "proceed with lock; this could be a legitimate state if the build waiting for "
-                  + "the lock was deleted or hard killed. More information is logged at "
-                  + "Level.FINE for debugging purposes.");
+            Level.WARNING,
+            "Skipping queued context for lock. Cannot get the Run object from the context to "
+              + "proceed with lock; this could be a legitimate state if the build waiting for "
+              + "the lock was deleted or hard killed. More information is logged at "
+              + "Level.FINE for debugging purposes.");
           LOGGER.log(
-              Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
+            Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
           return;
         }
       }
 
       // continue with next context
       LockStepExecution.proceed(
-          resourcesToLock,
-          nextContext.getContext(),
-          nextContext.getResourceDescription(),
-          nextContext.getVariableName(),
-          false);
+        resourcesToLock,
+        nextContext.getContext(),
+        nextContext.getResourceDescription(),
+        nextContext.getVariableName(),
+        false);
     }
     save();
   }
@@ -897,13 +897,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
       bc.commit();
     } catch (IOException exception) {
       LOGGER.log(
-          Level.WARNING, "Exception occurred while committing bulkchange operation.", exception);
+        Level.WARNING, "Exception occurred while committing bulkchange operation.", exception);
       return false;
     }
 
     // Copy unconfigurable properties from old instances
     boolean updated = false;
-    for (LockableResource oldDeclaredResource: oldDeclaredResources) {
+    for (LockableResource oldDeclaredResource : oldDeclaredResources) {
       final LockableResource updatedResource = fromName(oldDeclaredResource.getName());
       if (updatedResource != null) {
         updatedResource.copyUnconfigurableProperties(oldDeclaredResource);
@@ -919,22 +919,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
   public synchronized Set<LockableResource> checkResourcesAvailability(
-      List<LockableResourcesStruct> requiredResourcesList,
-      @Nullable PrintStream logger,
-      @Nullable List<String> lockedResourcesAboutToBeUnlocked) {
-    boolean skipIfLocked = false;
-    return this.checkResourcesAvailability(
-        requiredResourcesList, logger, lockedResourcesAboutToBeUnlocked, null, skipIfLocked);
-  }
-
-  /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
-  public synchronized Set<LockableResource> checkResourcesAvailability(
     List<LockableResourcesStruct> requiredResourcesList,
     @Nullable PrintStream logger,
-    @Nullable List<String> lockedResourcesAboutToBeUnlocked,
-    boolean skipIfLocked) {
+    @Nullable List<String> lockedResourcesAboutToBeUnlocked) {
+    boolean skipIfLocked = false;
     return this.checkResourcesAvailability(
-        requiredResourcesList, logger, lockedResourcesAboutToBeUnlocked, null, skipIfLocked);
+      requiredResourcesList, logger, lockedResourcesAboutToBeUnlocked, null, skipIfLocked);
   }
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
@@ -942,14 +932,24 @@ public class LockableResourcesManager extends GlobalConfiguration {
       List<LockableResourcesStruct> requiredResourcesList,
       @Nullable PrintStream logger,
       @Nullable List<String> lockedResourcesAboutToBeUnlocked,
-      @Nullable List<String> reservedResourcesAboutToBeUnreserved) {
+      boolean skipIfLocked) {
+    return this.checkResourcesAvailability(
+      requiredResourcesList, logger, lockedResourcesAboutToBeUnlocked, null, skipIfLocked);
+  }
+
+  /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
+  public synchronized Set<LockableResource> checkResourcesAvailability(
+    List<LockableResourcesStruct> requiredResourcesList,
+    @Nullable PrintStream logger,
+    @Nullable List<String> lockedResourcesAboutToBeUnlocked,
+    @Nullable List<String> reservedResourcesAboutToBeUnreserved) {
     boolean skipIfLocked = false;
     return this.checkResourcesAvailability(
-        requiredResourcesList,
-        logger,
-        lockedResourcesAboutToBeUnlocked,
-        reservedResourcesAboutToBeUnreserved,
-        skipIfLocked);
+      requiredResourcesList,
+      logger,
+      lockedResourcesAboutToBeUnlocked,
+      reservedResourcesAboutToBeUnreserved,
+      skipIfLocked);
   }
 
   /**
@@ -958,11 +958,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
    * available, returns null.
    */
   public synchronized Set<LockableResource> checkResourcesAvailability(
-      List<LockableResourcesStruct> requiredResourcesList,
-      @Nullable PrintStream logger,
-      @Nullable List<String> lockedResourcesAboutToBeUnlocked,
-      @Nullable List<String> reservedResourcesAboutToBeUnreserved,
-      boolean skipIfLocked) {
+    List<LockableResourcesStruct> requiredResourcesList,
+    @Nullable PrintStream logger,
+    @Nullable List<String> lockedResourcesAboutToBeUnlocked,
+    @Nullable List<String> reservedResourcesAboutToBeUnreserved,
+    boolean skipIfLocked) {
 
     List<LockableResourcesCandidatesStruct> requiredResourcesCandidatesList = new ArrayList<>();
 
@@ -989,7 +989,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       }
 
       requiredResourcesCandidatesList.add(
-          new LockableResourcesCandidatesStruct(candidates, requiredAmount));
+        new LockableResourcesCandidatesStruct(candidates, requiredAmount));
     }
 
     // Process freed resources
@@ -1018,10 +1018,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
           String candidateName = candidate.getName();
           boolean listedUnlock =
               (lockedResourcesAboutToBeUnlocked != null
-            &&  lockedResourcesAboutToBeUnlocked.contains(candidateName));
+                  && lockedResourcesAboutToBeUnlocked.contains(candidateName));
           boolean listedUnreserve =
               (reservedResourcesAboutToBeUnreserved != null
-            &&  reservedResourcesAboutToBeUnreserved.contains(candidateName));
+                  && reservedResourcesAboutToBeUnreserved.contains(candidateName));
           boolean isReserved = candidate.isReserved();
           boolean isLocked = candidate.isLocked();
 
@@ -1045,11 +1045,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
               // notified until you lock/unlock that resource again.
               if (logger != null) {
                 logger.println(
-                    "Candidate resource '"
-                        + candidateName
-                        + "' is reserved by '"
-                        + candidate.getReservedBy()
-                        + "', not treating as available.");
+                  "Candidate resource '"
+                    + candidateName
+                    + "' is reserved by '"
+                    + candidate.getReservedBy()
+                    + "', not treating as available.");
               }
               totalReserved += 1;
               continue;
@@ -1075,7 +1075,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // the loop above was effectively skipped
     if (totalSelected == 0
         && totalReserved == 0
-    &&  (lockedResourcesAboutToBeUnlocked != null
+        && (lockedResourcesAboutToBeUnlocked != null
             || reservedResourcesAboutToBeUnreserved != null)) {
       return null;
     }
@@ -1118,11 +1118,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
         // (not enough of something from that list), we bail out quickly.
         if (logger != null && !skipIfLocked) {
           logger.println(
-              "Found "
-                  + selected.size()
-                  + " available resource(s). Waiting for correct amount: "
-                  + requiredAmount
-                  + ".");
+            "Found "
+              + selected.size()
+              + " available resource(s). Waiting for correct amount: "
+              + requiredAmount
+              + ".");
         }
         return null;
       }
@@ -1138,10 +1138,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
    * this context is not yet queued.
    */
   public synchronized void queueContext(
-      StepContext context,
-      List<LockableResourcesStruct> requiredResources,
-      String resourceDescription,
-      String variableName) {
+    StepContext context,
+    List<LockableResourcesStruct> requiredResources,
+    String resourceDescription,
+    String variableName) {
     for (QueuedContextStruct entry : this.queuedContexts) {
       if (entry.getContext() == context) {
         return;
@@ -1149,13 +1149,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     this.queuedContexts.add(
-        new QueuedContextStruct(context, requiredResources, resourceDescription, variableName));
+      new QueuedContextStruct(context, requiredResources, resourceDescription, variableName));
     save();
   }
 
   public synchronized boolean unqueueContext(StepContext context) {
     for (Iterator<QueuedContextStruct> iter = this.queuedContexts.listIterator();
-        iter.hasNext(); ) {
+      iter.hasNext(); ) {
       if (iter.next().getContext() == context) {
         iter.remove();
         save();
@@ -1167,7 +1167,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   public static LockableResourcesManager get() {
     return (LockableResourcesManager)
-        Jenkins.get().getDescriptorOrDie(LockableResourcesManager.class);
+      Jenkins.get().getDescriptorOrDie(LockableResourcesManager.class);
   }
 
   @Override

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -29,248 +29,248 @@ import org.kohsuke.stapler.StaplerRequest;
 
 public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
-	private final String resourceNames;
-	private final String resourceNamesVar;
-	private final String resourceNumber;
-	private final String labelName;
-	private final @CheckForNull SecureGroovyScript resourceMatchScript;
+  private final String resourceNames;
+  private final String resourceNamesVar;
+  private final String resourceNumber;
+  private final String labelName;
+  private final @CheckForNull SecureGroovyScript resourceMatchScript;
 
-	@DataBoundConstructor
-	public RequiredResourcesProperty(String resourceNames,
-			String resourceNamesVar, String resourceNumber,
-			String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
-		super();
+  @DataBoundConstructor
+  public RequiredResourcesProperty(String resourceNames,
+    String resourceNamesVar, String resourceNumber,
+    String labelName, @CheckForNull SecureGroovyScript resourceMatchScript) {
+    super();
 
-		if (resourceNames == null || resourceNames.trim().isEmpty()) {
-			this.resourceNames = null;
-		} else {
-			this.resourceNames = resourceNames.trim();
-		}
-		if (resourceNamesVar == null || resourceNamesVar.trim().isEmpty()) {
-			this.resourceNamesVar = null;
-		} else {
-			this.resourceNamesVar = resourceNamesVar.trim();
-		}
-		if (resourceNumber == null || resourceNumber.trim().isEmpty()) {
-			this.resourceNumber = null;
-		} else {
-			this.resourceNumber = resourceNumber.trim();
-		}
-		String labelNamePreparation = (labelName == null || labelName.trim().isEmpty()) ? null : labelName.trim();
-		if (resourceMatchScript != null) {
-			this.resourceMatchScript = resourceMatchScript.configuringWithKeyItem();
-			this.labelName = labelNamePreparation;
-		} else if (labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
-			this.resourceMatchScript = new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()),
-					false, null).configuring(ApprovalContext.create());
-			this.labelName = null;
-		} else {
-			this.resourceMatchScript = null;
-			this.labelName = labelNamePreparation;
-		}
-	}
+    if (resourceNames == null || resourceNames.trim().isEmpty()) {
+      this.resourceNames = null;
+    } else {
+      this.resourceNames = resourceNames.trim();
+    }
+    if (resourceNamesVar == null || resourceNamesVar.trim().isEmpty()) {
+      this.resourceNamesVar = null;
+    } else {
+      this.resourceNamesVar = resourceNamesVar.trim();
+    }
+    if (resourceNumber == null || resourceNumber.trim().isEmpty()) {
+      this.resourceNumber = null;
+    } else {
+      this.resourceNumber = resourceNumber.trim();
+    }
+    String labelNamePreparation = (labelName == null || labelName.trim().isEmpty()) ? null : labelName.trim();
+    if (resourceMatchScript != null) {
+      this.resourceMatchScript = resourceMatchScript.configuringWithKeyItem();
+      this.labelName = labelNamePreparation;
+    } else if (labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
+      this.resourceMatchScript = new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()),
+        false, null).configuring(ApprovalContext.create());
+      this.labelName = null;
+    } else {
+      this.resourceMatchScript = null;
+      this.labelName = labelNamePreparation;
+    }
+  }
 
   /**
    * @deprecated groovy script was added (since 2.0)
    */
-	@Deprecated
-	public RequiredResourcesProperty(String resourceNames,
-									 String resourceNamesVar, String resourceNumber,
-									 String labelName) {
-		this(resourceNames, resourceNamesVar, resourceNumber, labelName, null);
-	}
+  @Deprecated
+  public RequiredResourcesProperty(String resourceNames,
+    String resourceNamesVar, String resourceNumber,
+    String labelName) {
+    this(resourceNames, resourceNamesVar, resourceNumber, labelName, null);
+  }
 
-	private Object readResolve() {
-		// SECURITY-368 migration logic
-		if (resourceMatchScript == null && labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
-			return new RequiredResourcesProperty(resourceNames, resourceNamesVar, resourceNumber, null,
-					new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()), false, null)
-							.configuring(ApprovalContext.create()));
-		}
+  private Object readResolve() {
+    // SECURITY-368 migration logic
+    if (resourceMatchScript == null && labelName != null && labelName.startsWith(LockableResource.GROOVY_LABEL_MARKER)) {
+      return new RequiredResourcesProperty(resourceNames, resourceNamesVar, resourceNumber, null,
+        new SecureGroovyScript(labelName.substring(LockableResource.GROOVY_LABEL_MARKER.length()), false, null)
+          .configuring(ApprovalContext.create()));
+    }
 
-		return this;
-	}
+    return this;
+  }
 
-	public String[] getResources() {
-		String names = Util.fixEmptyAndTrim(resourceNames);
-		if (names != null)
-			return names.split("\\s+");
-		else
-			return new String[0];
-	}
+  public String[] getResources() {
+    String names = Util.fixEmptyAndTrim(resourceNames);
+    if (names != null)
+      return names.split("\\s+");
+    else
+      return new String[0];
+  }
 
-	public String getResourceNames() {
-		return resourceNames;
-	}
+  public String getResourceNames() {
+    return resourceNames;
+  }
 
-	public String getResourceNamesVar() {
-		return resourceNamesVar;
-	}
+  public String getResourceNamesVar() {
+    return resourceNamesVar;
+  }
 
-	public String getResourceNumber() {
-		return resourceNumber;
-	}
+  public String getResourceNumber() {
+    return resourceNumber;
+  }
 
-	public String getLabelName() {
-		return labelName;
-	}
+  public String getLabelName() {
+    return labelName;
+  }
 
-	/**
-	 * Gets a system Groovy script to be executed in order to determine if the {@link LockableResource} matches the condition.
-	 * @return System Groovy Script if defined
-	 * @since 2.0
-	 * @see LockableResource#scriptMatches(org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript, java.util.Map)
-	 */
-	@CheckForNull
-	public SecureGroovyScript getResourceMatchScript() {
-		return resourceMatchScript;
-	}
+  /**
+   * Gets a system Groovy script to be executed in order to determine if the {@link LockableResource} matches the condition.
+   * @return System Groovy Script if defined
+   * @since 2.0
+   * @see LockableResource#scriptMatches(org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript, java.util.Map)
+   */
+  @CheckForNull
+  public SecureGroovyScript getResourceMatchScript() {
+    return resourceMatchScript;
+  }
 
-	@Extension
-	public static class DescriptorImpl extends JobPropertyDescriptor {
+  @Extension
+  public static class DescriptorImpl extends JobPropertyDescriptor {
 
-		@NonNull
-		@Override
-		public String getDisplayName() {
-			return "Required Lockable Resources";
-		}
+    @NonNull
+    @Override
+    public String getDisplayName() {
+      return "Required Lockable Resources";
+    }
 
-		@Override
-		public boolean isApplicable(Class<? extends Job> jobType) {
-			return AbstractProject.class.isAssignableFrom(jobType);
-		}
+    @Override
+    public boolean isApplicable(Class<? extends Job> jobType) {
+      return AbstractProject.class.isAssignableFrom(jobType);
+    }
 
-		@Override
-		public RequiredResourcesProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-			if (formData.containsKey("required-lockable-resources")) {
-				return (RequiredResourcesProperty) super.newInstance(req, formData.getJSONObject("required-lockable-resources"));
-			}
-			return null;
-		}
+    @Override
+    public RequiredResourcesProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+      if (formData.containsKey("required-lockable-resources")) {
+        return (RequiredResourcesProperty) super.newInstance(req, formData.getJSONObject("required-lockable-resources"));
+      }
+      return null;
+    }
 
-		public FormValidation doCheckResourceNames(@QueryParameter String value,
-												   @QueryParameter String labelName,
-												   @QueryParameter boolean script) {
-			String labelVal = Util.fixEmptyAndTrim(labelName);
-			String names = Util.fixEmptyAndTrim(value);
+    public FormValidation doCheckResourceNames(@QueryParameter String value,
+      @QueryParameter String labelName,
+      @QueryParameter boolean script) {
+      String labelVal = Util.fixEmptyAndTrim(labelName);
+      String names = Util.fixEmptyAndTrim(value);
 
-			if (names == null) {
-				return FormValidation.ok();
-			} else if (labelVal != null || script) {
-				return FormValidation.error(
-						"Only label, groovy expression, or resources can be defined, not more than one.");
-			} else {
-				List<String> wrongNames = new ArrayList<>();
-				for (String name : names.split("\\s+")) {
-					boolean found = false;
-					for (LockableResource r : LockableResourcesManager.get()
-							.getResources()) {
-						if (r.getName().equals(name)) {
-							found = true;
-							break;
-						}
-					}
-					if (!found)
-						wrongNames.add(name);
-				}
-				if (wrongNames.isEmpty()) {
-					return FormValidation.ok();
-				} else {
-					return FormValidation
-							.error("The following resources do not exist: "
-									+ wrongNames);
-				}
-			}
-		}
-
-		public FormValidation doCheckLabelName(
-				@QueryParameter String value,
-				@QueryParameter String resourceNames,
-				@QueryParameter boolean script) {
-			String label = Util.fixEmptyAndTrim(value);
-			String names = Util.fixEmptyAndTrim(resourceNames);
-
-			if (label == null) {
-				return FormValidation.ok();
-			} else if (names != null || script) {
-				return FormValidation.error(
-						"Only label, groovy expression, or resources can be defined, not more than one.");
-			} else {
-				if (LockableResourcesManager.get().isValidLabel(label)) {
-					return FormValidation.ok();
-				} else {
-					return FormValidation.error(
-							"The label does not exist: " + label);
-				}
-			}
-		}
-
-		public FormValidation doCheckResourceNumber(@QueryParameter String value,
-				@QueryParameter String resourceNames,
-                @QueryParameter String labelName,
-                @QueryParameter String resourceMatchScript)
-        {
-
-			String number = Util.fixEmptyAndTrim(value);
-			String names = Util.fixEmptyAndTrim(resourceNames);
-			String label = Util.fixEmptyAndTrim(labelName);
-            String script = Util.fixEmptyAndTrim(resourceMatchScript);
-
-			if (number == null || number.equals("") || number.trim().equals("0")) {
-				return FormValidation.ok();
-			}
-
-			int numAsInt;
-			try {
-				numAsInt = Integer.parseInt(number);
-			} catch(NumberFormatException e)  {
-				return FormValidation.error(
-					"Could not parse the given value as integer.");
-			}
-			int numResources = 0;
-			if (names != null) {
-				numResources = names.split("\\s+").length;
-            } else if (label != null || script != null) {
-                	numResources = Integer.MAX_VALUE;
+      if (names == null) {
+        return FormValidation.ok();
+      } else if (labelVal != null || script) {
+        return FormValidation.error(
+          "Only label, groovy expression, or resources can be defined, not more than one.");
+      } else {
+        List<String> wrongNames = new ArrayList<>();
+        for (String name : names.split("\\s+")) {
+          boolean found = false;
+          for (LockableResource r : LockableResourcesManager.get()
+            .getResources()) {
+            if (r.getName().equals(name)) {
+              found = true;
+              break;
             }
+          }
+          if (!found)
+            wrongNames.add(name);
+        }
+        if (wrongNames.isEmpty()) {
+          return FormValidation.ok();
+        } else {
+          return FormValidation
+            .error("The following resources do not exist: "
+              + wrongNames);
+        }
+      }
+    }
 
-			if (numResources < numAsInt) {
-				return FormValidation.error(String.format(
-					"Given amount %d is greater than amount of resources: %d.",
-					numAsInt,
-					numResources));
-			}
-			return FormValidation.ok();
-		}
+    public FormValidation doCheckLabelName(
+      @QueryParameter String value,
+      @QueryParameter String resourceNames,
+      @QueryParameter boolean script) {
+      String label = Util.fixEmptyAndTrim(value);
+      String names = Util.fixEmptyAndTrim(resourceNames);
 
-		public AutoCompletionCandidates doAutoCompleteLabelName(
-				@QueryParameter String value) {
-			AutoCompletionCandidates c = new AutoCompletionCandidates();
+      if (label == null) {
+        return FormValidation.ok();
+      } else if (names != null || script) {
+        return FormValidation.error(
+          "Only label, groovy expression, or resources can be defined, not more than one.");
+      } else {
+        if (LockableResourcesManager.get().isValidLabel(label)) {
+          return FormValidation.ok();
+        } else {
+          return FormValidation.error(
+            "The label does not exist: " + label);
+        }
+      }
+    }
 
-			value = Util.fixEmptyAndTrim(value);
+    public FormValidation doCheckResourceNumber(@QueryParameter String value,
+      @QueryParameter String resourceNames,
+      @QueryParameter String labelName,
+      @QueryParameter String resourceMatchScript)
+    {
 
-			for (String l : LockableResourcesManager.get().getAllLabels())
-				if (value != null && l.startsWith(value))
-					c.add(l);
+      String number = Util.fixEmptyAndTrim(value);
+      String names = Util.fixEmptyAndTrim(resourceNames);
+      String label = Util.fixEmptyAndTrim(labelName);
+      String script = Util.fixEmptyAndTrim(resourceMatchScript);
 
-			return c;
-		}
+      if (number == null || number.equals("") || number.trim().equals("0")) {
+        return FormValidation.ok();
+      }
 
-		public static AutoCompletionCandidates doAutoCompleteResourceNames(
-				@QueryParameter String value) {
-			AutoCompletionCandidates c = new AutoCompletionCandidates();
+      int numAsInt;
+      try {
+        numAsInt = Integer.parseInt(number);
+      } catch(NumberFormatException e)  {
+        return FormValidation.error(
+          "Could not parse the given value as integer.");
+      }
+      int numResources = 0;
+      if (names != null) {
+        numResources = names.split("\\s+").length;
+      } else if (label != null || script != null) {
+        numResources = Integer.MAX_VALUE;
+      }
 
-			value = Util.fixEmptyAndTrim(value);
+      if (numResources < numAsInt) {
+        return FormValidation.error(String.format(
+          "Given amount %d is greater than amount of resources: %d.",
+          numAsInt,
+          numResources));
+      }
+      return FormValidation.ok();
+    }
 
-			if (value != null) {
-				for (LockableResource r : LockableResourcesManager.get()
-						.getResources()) {
-					if (r.getName().startsWith(value))
-						c.add(r.getName());
-				}
-			}
+    public AutoCompletionCandidates doAutoCompleteLabelName(
+      @QueryParameter String value) {
+      AutoCompletionCandidates c = new AutoCompletionCandidates();
 
-			return c;
-		}
-	}
+      value = Util.fixEmptyAndTrim(value);
+
+      for (String l : LockableResourcesManager.get().getAllLabels())
+        if (value != null && l.startsWith(value))
+          c.add(l);
+
+      return c;
+    }
+
+    public static AutoCompletionCandidates doAutoCompleteResourceNames(
+      @QueryParameter String value) {
+      AutoCompletionCandidates c = new AutoCompletionCandidates();
+
+      value = Util.fixEmptyAndTrim(value);
+
+      if (value != null) {
+        for (LockableResource r : LockableResourcesManager.get()
+          .getResources()) {
+          if (r.getName().startsWith(value))
+            c.add(r.getName());
+        }
+      }
+
+      return c;
+    }
+  }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -150,7 +150,7 @@ public class LockableResourcesRootAction implements RootAction {
 	@RequirePOST
 	public void doSteal(StaplerRequest req, StaplerResponse rsp)
 		throws IOException, ServletException {
-		Jenkins.getInstance().checkPermission(STEAL);
+		Jenkins.get().checkPermission(STEAL);
 
 		String name = req.getParameter("resource");
 		LockableResource r = LockableResourcesManager.get().fromName(name);
@@ -171,7 +171,7 @@ public class LockableResourcesRootAction implements RootAction {
 	@RequirePOST
 	public void doReassign(StaplerRequest req, StaplerResponse rsp)
 		throws IOException, ServletException {
-		Jenkins.getInstance().checkPermission(STEAL);
+		Jenkins.get().checkPermission(STEAL);
 
 		String name = req.getParameter("resource");
 		LockableResource r = LockableResourcesManager.get().fromName(name);
@@ -182,8 +182,8 @@ public class LockableResourcesRootAction implements RootAction {
 
 		String userName = getUserName();
 		if ( userName == null ||
-			( !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) &&
-			  !Jenkins.getInstance().hasPermission(STEAL) )
+			( !Jenkins.get().hasPermission(Jenkins.ADMINISTER) &&
+			  !Jenkins.get().hasPermission(STEAL) )
 		) {
 			throw new AccessDeniedException2(Jenkins.getAuthentication(),
 					STEAL);

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -201,7 +201,7 @@ public class LockableResourcesRootAction implements RootAction {
       // Can not achieve much by re-assigning the
       // resource I already hold to myself again,
       // that would just burn the compute resources.
-      // ...unless something catches the event? (TODO?)
+      //...unless something catches the event? (TODO?)
       return;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -27,227 +27,234 @@ import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.Messages;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @Extension
 @ExportedBean
 public class LockableResourcesRootAction implements RootAction {
 
-	public static final PermissionGroup PERMISSIONS_GROUP = new PermissionGroup(
-			LockableResourcesManager.class, Messages._LockableResourcesRootAction_PermissionGroup());
-	public static final Permission UNLOCK = new Permission(PERMISSIONS_GROUP,
-			Messages.LockableResourcesRootAction_UnlockPermission(),
-			Messages._LockableResourcesRootAction_UnlockPermission_Description(), Jenkins.ADMINISTER,
-			PermissionScope.JENKINS);
-	public static final Permission RESERVE = new Permission(PERMISSIONS_GROUP,
-			Messages.LockableResourcesRootAction_ReservePermission(),
-			Messages._LockableResourcesRootAction_ReservePermission_Description(), Jenkins.ADMINISTER,
-			PermissionScope.JENKINS);
-	public static final Permission STEAL = new Permission(PERMISSIONS_GROUP,
-			Messages.LockableResourcesRootAction_StealPermission(),
-			Messages._LockableResourcesRootAction_StealPermission_Description(), Jenkins.ADMINISTER,
-			PermissionScope.JENKINS);
-	public static final Permission VIEW = new Permission(PERMISSIONS_GROUP,
-			Messages.LockableResourcesRootAction_ViewPermission(),
-			Messages._LockableResourcesRootAction_ViewPermission_Description(), Jenkins.ADMINISTER,
-			PermissionScope.JENKINS);
+  public static final PermissionGroup PERMISSIONS_GROUP =
+    new PermissionGroup(
+      LockableResourcesManager.class, Messages._LockableResourcesRootAction_PermissionGroup());
+  public static final Permission UNLOCK =
+    new Permission(
+      PERMISSIONS_GROUP,
+      Messages.LockableResourcesRootAction_UnlockPermission(),
+      Messages._LockableResourcesRootAction_UnlockPermission_Description(),
+      Jenkins.ADMINISTER,
+      PermissionScope.JENKINS);
+  public static final Permission RESERVE =
+    new Permission(
+      PERMISSIONS_GROUP,
+      Messages.LockableResourcesRootAction_ReservePermission(),
+      Messages._LockableResourcesRootAction_ReservePermission_Description(),
+      Jenkins.ADMINISTER,
+      PermissionScope.JENKINS);
+  public static final Permission STEAL =
+    new Permission(
+      PERMISSIONS_GROUP,
+      Messages.LockableResourcesRootAction_StealPermission(),
+      Messages._LockableResourcesRootAction_StealPermission_Description(),
+      Jenkins.ADMINISTER,
+      PermissionScope.JENKINS);
+  public static final Permission VIEW =
+    new Permission(
+      PERMISSIONS_GROUP,
+      Messages.LockableResourcesRootAction_ViewPermission(),
+      Messages._LockableResourcesRootAction_ViewPermission_Description(),
+      Jenkins.ADMINISTER,
+      PermissionScope.JENKINS);
 
-	public static final String ICON = "/plugin/lockable-resources/img/device.svg";
+  public static final String ICON = "/plugin/lockable-resources/img/device.svg";
 
-	@Override
-	public String getIconFileName() {
-		return Jenkins.get().hasPermission(VIEW) ? ICON : null;
-	}
+  @Override
+  public String getIconFileName() {
+    return Jenkins.get().hasPermission(VIEW) ? ICON : null;
+  }
 
-	public Api getApi() {
-		return new Api(this);
-	}
+  public Api getApi() {
+    return new Api(this);
+  }
 
-	public String getUserName() {
-		User current = User.current();
-		if (current != null)
-			return current.getFullName();
-		else
-			return null;
-	}
+  public String getUserName() {
+    User current = User.current();
+    if (current != null) return current.getFullName();
+    else return null;
+  }
 
-	@Override
-	public String getDisplayName() {
-	  return Messages.LockableResourcesRootAction_PermissionGroup();
-	}
+  @Override
+  public String getDisplayName() {
+    return Messages.LockableResourcesRootAction_PermissionGroup();
+  }
 
-	@Override
-	public String getUrlName() {
-		return Jenkins.get().hasPermission(VIEW) ? "lockable-resources" : "";
-	}
+  @Override
+  public String getUrlName() {
+    return Jenkins.get().hasPermission(VIEW) ? "lockable-resources" : "";
+  }
 
-	@Exported
-	public List<LockableResource> getResources() {
-		return LockableResourcesManager.get().getResources();
-	}
+  @Exported
+  public List<LockableResource> getResources() {
+    return LockableResourcesManager.get().getResources();
+  }
 
-	public LockableResource getResource(final String resourceName) {
-		return LockableResourcesManager.get().fromName(resourceName);
-	}
+  public LockableResource getResource(final String resourceName) {
+    return LockableResourcesManager.get().fromName(resourceName);
+  }
 
-	public int getFreeResourceAmount(String label) {
-		return LockableResourcesManager.get().getFreeResourceAmount(label);
-	}
+  public int getFreeResourceAmount(String label) {
+    return LockableResourcesManager.get().getFreeResourceAmount(label);
+  }
 
-	public Set<String> getAllLabels() {
-		return LockableResourcesManager.get().getAllLabels();
-	}
+  public Set<String> getAllLabels() {
+    return LockableResourcesManager.get().getAllLabels();
+  }
 
-	public int getNumberOfAllLabels() {
-		return LockableResourcesManager.get().getAllLabels().size();
-	}
+  public int getNumberOfAllLabels() {
+    return LockableResourcesManager.get().getAllLabels().size();
+  }
 
-	@RequirePOST
-	public void doUnlock(StaplerRequest req, StaplerResponse rsp)
-			throws IOException, ServletException {
-		Jenkins.get().checkPermission(UNLOCK);
+  @RequirePOST
+  public void doUnlock(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(UNLOCK);
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().unlock(resources, null);
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    LockableResourcesManager.get().unlock(resources, null);
 
-		rsp.forwardToPreviousPage(req);
-	}
+    rsp.forwardToPreviousPage(req);
+  }
 
-	@RequirePOST
-	public void doReserve(StaplerRequest req, StaplerResponse rsp)
-		throws IOException, ServletException {
-		Jenkins.get().checkPermission(RESERVE);
+  @RequirePOST
+  public void doReserve(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(RESERVE);
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		String userName = getUserName();
-		if (userName != null) {
-			if (!LockableResourcesManager.get().reserve(resources, userName)) {
-				rsp.sendError(423, "Resource '" + name + "' already reserved or locked!");
-				return;
-			}
-		}
-		rsp.forwardToPreviousPage(req);
-	}
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    String userName = getUserName();
+    if (userName != null) {
+      if (!LockableResourcesManager.get().reserve(resources, userName)) {
+        rsp.sendError(423, "Resource '" + name + "' already reserved or locked!");
+        return;
+      }
+    }
+    rsp.forwardToPreviousPage(req);
+  }
 
-	@RequirePOST
-	public void doSteal(StaplerRequest req, StaplerResponse rsp)
-		throws IOException, ServletException {
-		Jenkins.get().checkPermission(STEAL);
+  @RequirePOST
+  public void doSteal(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(STEAL);
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		String userName = getUserName();
-		if (userName != null)
-			LockableResourcesManager.get().steal(resources, userName);
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    String userName = getUserName();
+    if (userName != null) LockableResourcesManager.get().steal(resources, userName);
 
-		rsp.forwardToPreviousPage(req);
-	}
+    rsp.forwardToPreviousPage(req);
+  }
 
-	@RequirePOST
-	public void doReassign(StaplerRequest req, StaplerResponse rsp)
-		throws IOException, ServletException {
-		Jenkins.get().checkPermission(STEAL);
+  @RequirePOST
+  public void doReassign(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(STEAL);
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		String userName = getUserName();
-		if ( userName == null ||
-			( !Jenkins.get().hasPermission(Jenkins.ADMINISTER) &&
-			  !Jenkins.get().hasPermission(STEAL) )
-		) {
-			throw new AccessDeniedException2(Jenkins.getAuthentication(),
-					STEAL);
-		}
+    String userName = getUserName();
+    if (userName == null
+      || (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+      && !Jenkins.get().hasPermission(STEAL))) {
+      throw new AccessDeniedException2(Jenkins.getAuthentication(), STEAL);
+    }
 
-		if (userName.equals(r.getReservedBy())) {
-			// Can not achieve much by re-assigning the
-			// resource I already hold to myself again,
-			// that would just burn the compute resources.
-			//...unless something catches the event? (TODO?)
-			return;
-		}
+    if (userName.equals(r.getReservedBy())) {
+      // Can not achieve much by re-assigning the
+      // resource I already hold to myself again,
+      // that would just burn the compute resources.
+      // ...unless something catches the event? (TODO?)
+      return;
+    }
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().reassign(resources, userName);
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    LockableResourcesManager.get().reassign(resources, userName);
 
-		rsp.forwardToPreviousPage(req);
-	}
+    rsp.forwardToPreviousPage(req);
+  }
 
-	@RequirePOST
-	public void doUnreserve(StaplerRequest req, StaplerResponse rsp)
-		throws IOException, ServletException {
-		Jenkins.get().checkPermission(RESERVE);
+  @RequirePOST
+  public void doUnreserve(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(RESERVE);
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		String userName = getUserName();
-		if ((userName == null || !userName.equals(r.getReservedBy()))
-				&& !Jenkins.get().hasPermission(Jenkins.ADMINISTER))
-			throw new AccessDeniedException2(Jenkins.getAuthentication(),
-					RESERVE);
+    String userName = getUserName();
+    if ((userName == null || !userName.equals(r.getReservedBy()))
+      && !Jenkins.get().hasPermission(Jenkins.ADMINISTER))
+      throw new AccessDeniedException2(Jenkins.getAuthentication(), RESERVE);
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().unreserve(resources);
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    LockableResourcesManager.get().unreserve(resources);
 
-		rsp.forwardToPreviousPage(req);
-	}
+    rsp.forwardToPreviousPage(req);
+  }
 
-	@RequirePOST
-	public void doReset(StaplerRequest req, StaplerResponse rsp)
-		throws IOException, ServletException {
-		Jenkins.get().checkPermission(UNLOCK);
-		// Should this also be permitted by "STEAL"?..
+  @RequirePOST
+  public void doReset(StaplerRequest req, StaplerResponse rsp)
+    throws IOException, ServletException {
+    Jenkins.get().checkPermission(UNLOCK);
+    // Should this also be permitted by "STEAL"?..
 
-		String name = req.getParameter("resource");
-		LockableResource r = LockableResourcesManager.get().fromName(name);
-		if (r == null) {
-			rsp.sendError(404, "Resource not found " + name);
-			return;
-		}
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, "Resource not found " + name);
+      return;
+    }
 
-		List<LockableResource> resources = new ArrayList<>();
-		resources.add(r);
-		LockableResourcesManager.get().reset(resources);
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    LockableResourcesManager.get().reset(resources);
 
-		rsp.forwardToPreviousPage(req);
-	}
+    rsp.forwardToPreviousPage(req);
+  }
 
   @RequirePOST
   public void doSaveNote(final StaplerRequest req, final StaplerResponse rsp)

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -16,62 +16,62 @@ import org.jenkins.plugins.lockableresources.LockableResource;
 
 public class LockedResourcesBuildAction implements Action {
 
-	private final List<ResourcePOJO> lockedResources;
+  private final List<ResourcePOJO> lockedResources;
 
-	public LockedResourcesBuildAction(List<ResourcePOJO> lockedResources) {
-		this.lockedResources = lockedResources;
-	}
+  public LockedResourcesBuildAction(List<ResourcePOJO> lockedResources) {
+    this.lockedResources = lockedResources;
+  }
 
-	public List<ResourcePOJO> getLockedResources() {
-		return lockedResources;
-	}
+  public List<ResourcePOJO> getLockedResources() {
+    return lockedResources;
+  }
 
-	@Override
-	public String getIconFileName() {
-		return LockableResourcesRootAction.ICON;
-	}
+  @Override
+  public String getIconFileName() {
+    return LockableResourcesRootAction.ICON;
+  }
 
-	@Override
-	public String getDisplayName() {
-		return "Locked Resources";
-	}
+  @Override
+  public String getDisplayName() {
+    return "Locked Resources";
+  }
 
-	@Override
-	public String getUrlName() {
-		return "locked-resources";
-	}
+  @Override
+  public String getUrlName() {
+    return "locked-resources";
+  }
 
-	public static LockedResourcesBuildAction fromResources(
-			Collection<LockableResource> resources) {
-		List<ResourcePOJO> resPojos = new ArrayList<>();
-		for (LockableResource r : resources)
-			resPojos.add(new ResourcePOJO(r));
-		return new LockedResourcesBuildAction(resPojos);
-	}
+  public static LockedResourcesBuildAction fromResources(
+    Collection<LockableResource> resources) {
+    List<ResourcePOJO> resPojos = new ArrayList<>();
+    for (LockableResource r : resources)
+      resPojos.add(new ResourcePOJO(r));
+    return new LockedResourcesBuildAction(resPojos);
+  }
 
-	public static class ResourcePOJO {
+  public static class ResourcePOJO {
 
-		private String name;
-		private String description;
+    private String name;
+    private String description;
 
-		public ResourcePOJO(String name, String description) {
-			this.name = name;
-			this.description = description;
-		}
+    public ResourcePOJO(String name, String description) {
+      this.name = name;
+      this.description = description;
+    }
 
-		public ResourcePOJO(LockableResource r) {
-			this.name = r.getName();
-			this.description = r.getDescription();
-		}
+    public ResourcePOJO(LockableResource r) {
+      this.name = r.getName();
+      this.description = r.getDescription();
+    }
 
-		public String getName() {
-			return name;
-		}
+    public String getName() {
+      return name;
+    }
 
-		public String getDescription() {
-			return description;
-		}
+    public String getDescription() {
+      return description;
+    }
 
-	}
+  }
 
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/ResourceVariableNameAction.java
@@ -8,19 +8,20 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
+import java.util.List;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Restricted(NoExternalUse.class)
 public class ResourceVariableNameAction extends InvisibleAction {
 
-	private final StringParameterValue resourceNameParameter;
+	private final List<StringParameterValue> resourceNameParameter;
 
-	public ResourceVariableNameAction(StringParameterValue r) {
+	public ResourceVariableNameAction(List<StringParameterValue> r) {
 		this.resourceNameParameter = r;
 	}
 
-	StringParameterValue getParameter() {
+	List<StringParameterValue> getParameter() {
 		return resourceNameParameter;
 	}
 
@@ -30,8 +31,10 @@ public class ResourceVariableNameAction extends InvisibleAction {
 		@Override
 		public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) {
 			ResourceVariableNameAction a = r.getAction(ResourceVariableNameAction.class);
-			if (a != null && a.getParameter() != null && a.getParameter().getValue() != null) {
-				envs.put(a.getParameter().getName(), String.valueOf(a.getParameter().getValue()));
+			if (a != null && a.getParameter() != null) {
+				for (StringParameterValue envToSet : a.getParameter()) {
+					envs.override(envToSet.getName(), envToSet.getValue());
+				}
 			}
 		}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -17,10 +17,13 @@ import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
@@ -62,9 +65,23 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 						LOGGER.fine(build.getFullDisplayName()
 								+ " acquired lock on " + required);
 						if (resources.requiredVar != null) {
-							build.addAction(new ResourceVariableNameAction(new StringParameterValue(
-									resources.requiredVar,
-									required.toString().replaceAll("[\\]\\[]", ""))));
+							List<StringParameterValue> envsToSet = new ArrayList<>();
+
+							// add the comma separated list of names acquired
+							envsToSet.add(new StringParameterValue(
+								resources.requiredVar,
+								required.stream()
+									.map(LockableResource::getName)
+									.collect(Collectors.joining(","))));
+
+							// also add a numbered variable for each acquired lock
+							int index = 0;
+							for (LockableResource lr : required) {
+								envsToSet.add(new StringParameterValue(resources.requiredVar + index, lr.getName()));
+								++index;
+							}
+
+							build.addAction(new ResourceVariableNameAction(envsToSet));
 						}
 					} else {
 						listener.getLogger().printf("%s failed to lock %s%n",

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.LockableResource;
+import org.jenkins.plugins.lockableresources.LockableResourceProperty;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
 import org.jenkins.plugins.lockableresources.actions.ResourceVariableNameAction;
@@ -74,10 +75,15 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 									.map(LockableResource::getName)
 									.collect(Collectors.joining(","))));
 
-							// also add a numbered variable for each acquired lock
+							// also add a numbered variable for each acquired lock along with properties of the lock
 							int index = 0;
 							for (LockableResource lr : required) {
-								envsToSet.add(new StringParameterValue(resources.requiredVar + index, lr.getName()));
+								String lockEnvName = resources.requiredVar + index;
+								envsToSet.add(new StringParameterValue(lockEnvName, lr.getName()));
+								for (LockableResourceProperty lockProperty : lr.getProperties()) {
+									String propEnvName = lockEnvName + "_" + lockProperty.getName();
+									envsToSet.add(new StringParameterValue(propEnvName, lockProperty.getValue()));
+								}
 								++index;
 							}
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -33,107 +33,107 @@ import org.jenkins.plugins.lockableresources.actions.ResourceVariableNameAction;
 @Extension
 public class LockRunListener extends RunListener<Run<?, ?>> {
 
-	static final String LOG_PREFIX = "[lockable-resources]";
-	static final Logger LOGGER = Logger.getLogger(LockRunListener.class
-			.getName());
+  static final String LOG_PREFIX = "[lockable-resources]";
+  static final Logger LOGGER = Logger.getLogger(LockRunListener.class
+    .getName());
 
-	@Override
-	public void onStarted(Run<?, ?> build, TaskListener listener) {
-		// Skip locking for multiple configuration projects,
-		// only the child jobs will actually lock resources.
-		if (build instanceof MatrixBuild)
-			return;
+  @Override
+  public void onStarted(Run<?, ?> build, TaskListener listener) {
+    // Skip locking for multiple configuration projects,
+    // only the child jobs will actually lock resources.
+    if (build instanceof MatrixBuild)
+      return;
 
-		if (build instanceof AbstractBuild) {
-			Job<?, ?> proj = Utils.getProject(build);
-			Set<LockableResource> required = new HashSet<>();
-			if (proj != null) {
-				LockableResourcesStruct resources = Utils.requiredResources(proj);
+    if (build instanceof AbstractBuild) {
+      Job<?, ?> proj = Utils.getProject(build);
+      Set<LockableResource> required = new HashSet<>();
+      if (proj != null) {
+        LockableResourcesStruct resources = Utils.requiredResources(proj);
 
-				if (resources != null) {
-					if (resources.requiredNumber != null || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {
-						required.addAll(LockableResourcesManager.get().
-								getResourcesFromProject(proj.getFullName()));
-					} else {
-						required.addAll(resources.required);
-					}
+        if (resources != null) {
+          if (resources.requiredNumber != null || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {
+            required.addAll(LockableResourcesManager.get().
+              getResourcesFromProject(proj.getFullName()));
+          } else {
+            required.addAll(resources.required);
+          }
 
-					if (LockableResourcesManager.get().lock(required, build, null)) {
-						build.addAction(LockedResourcesBuildAction
-								.fromResources(required));
-						listener.getLogger().printf("%s acquired lock on %s%n",
-								LOG_PREFIX, required);
-						LOGGER.fine(build.getFullDisplayName()
-								+ " acquired lock on " + required);
-						if (resources.requiredVar != null) {
-							List<StringParameterValue> envsToSet = new ArrayList<>();
+          if (LockableResourcesManager.get().lock(required, build, null)) {
+            build.addAction(LockedResourcesBuildAction
+              .fromResources(required));
+            listener.getLogger().printf("%s acquired lock on %s%n",
+              LOG_PREFIX, required);
+            LOGGER.fine(build.getFullDisplayName()
+              + " acquired lock on " + required);
+            if (resources.requiredVar != null) {
+              List<StringParameterValue> envsToSet = new ArrayList<>();
 
-							// add the comma separated list of names acquired
-							envsToSet.add(new StringParameterValue(
-								resources.requiredVar,
-								required.stream()
-									.map(LockableResource::getName)
-									.collect(Collectors.joining(","))));
+              // add the comma separated list of names acquired
+              envsToSet.add(new StringParameterValue(
+                resources.requiredVar,
+                required.stream()
+                  .map(LockableResource::getName)
+                  .collect(Collectors.joining(","))));
 
-							// also add a numbered variable for each acquired lock along with properties of the lock
-							int index = 0;
-							for (LockableResource lr : required) {
-								String lockEnvName = resources.requiredVar + index;
-								envsToSet.add(new StringParameterValue(lockEnvName, lr.getName()));
-								for (LockableResourceProperty lockProperty : lr.getProperties()) {
-									String propEnvName = lockEnvName + "_" + lockProperty.getName();
-									envsToSet.add(new StringParameterValue(propEnvName, lockProperty.getValue()));
-								}
-								++index;
-							}
+              // also add a numbered variable for each acquired lock along with properties of the lock
+              int index = 0;
+              for (LockableResource lr : required) {
+                String lockEnvName = resources.requiredVar + index;
+                envsToSet.add(new StringParameterValue(lockEnvName, lr.getName()));
+                for (LockableResourceProperty lockProperty : lr.getProperties()) {
+                  String propEnvName = lockEnvName + "_" + lockProperty.getName();
+                  envsToSet.add(new StringParameterValue(propEnvName, lockProperty.getValue()));
+                }
+                ++index;
+              }
 
-							build.addAction(new ResourceVariableNameAction(envsToSet));
-						}
-					} else {
-						listener.getLogger().printf("%s failed to lock %s%n",
-								LOG_PREFIX, required);
-						LOGGER.fine(build.getFullDisplayName() + " failed to lock "
-								+ required);
-					}
-				}
-			}
-		}
-	}
+              build.addAction(new ResourceVariableNameAction(envsToSet));
+            }
+          } else {
+            listener.getLogger().printf("%s failed to lock %s%n",
+              LOG_PREFIX, required);
+            LOGGER.fine(build.getFullDisplayName() + " failed to lock "
+              + required);
+          }
+        }
+      }
+    }
+  }
 
-	@Override
-	public void onCompleted(Run<?, ?> build, @NonNull TaskListener listener) {
-		// Skip unlocking for multiple configuration projects,
-		// only the child jobs will actually unlock resources.
-		if (build instanceof MatrixBuild)
-			return;
+  @Override
+  public void onCompleted(Run<?, ?> build, @NonNull TaskListener listener) {
+    // Skip unlocking for multiple configuration projects,
+    // only the child jobs will actually unlock resources.
+    if (build instanceof MatrixBuild)
+      return;
 
-		// obviously project name cannot be obtained here
-		List<LockableResource> required = LockableResourcesManager.get()
-				.getResourcesFromBuild(build);
-		if (!required.isEmpty()) {
-			LockableResourcesManager.get().unlock(required, build);
-			listener.getLogger().printf("%s released lock on %s%n",
-					LOG_PREFIX, required);
-			LOGGER.fine(build.getFullDisplayName() + " released lock on "
-					+ required);
-		}
+    // obviously project name cannot be obtained here
+    List<LockableResource> required = LockableResourcesManager.get()
+      .getResourcesFromBuild(build);
+    if (!required.isEmpty()) {
+      LockableResourcesManager.get().unlock(required, build);
+      listener.getLogger().printf("%s released lock on %s%n",
+        LOG_PREFIX, required);
+      LOGGER.fine(build.getFullDisplayName() + " released lock on "
+        + required);
+    }
 
-	}
+  }
 
-	@Override
-	public void onDeleted(Run<?, ?> build) {
-		// Skip unlocking for multiple configuration projects,
-		// only the child jobs will actually unlock resources.
-		if (build instanceof MatrixBuild)
-			return;
+  @Override
+  public void onDeleted(Run<?, ?> build) {
+    // Skip unlocking for multiple configuration projects,
+    // only the child jobs will actually unlock resources.
+    if (build instanceof MatrixBuild)
+      return;
 
-		List<LockableResource> required = LockableResourcesManager.get()
-				.getResourcesFromBuild(build);
-		if (!required.isEmpty()) {
-			LockableResourcesManager.get().unlock(required, build);
-			LOGGER.fine(build.getFullDisplayName() + " released lock on "
-					+ required);
-		}
-	}
+    List<LockableResource> required = LockableResourcesManager.get()
+      .getResourcesFromBuild(build);
+    if (!required.isEmpty()) {
+      LockableResourcesManager.get().unlock(required, build);
+      LOGGER.fine(build.getFullDisplayName() + " released lock on "
+        + required);
+    }
+  }
 
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesCandidatesStruct.java
@@ -5,20 +5,20 @@ import org.jenkins.plugins.lockableresources.LockableResource;
 
 public class LockableResourcesCandidatesStruct {
 
-	public List<LockableResource> candidates;
-	public int requiredAmount;
-	public List<LockableResource> selected;
+  public List<LockableResource> candidates;
+  public int requiredAmount;
+  public List<LockableResource> selected;
 
-	public LockableResourcesCandidatesStruct(List<LockableResource> candidates, int requiredAmount) {
-		this.candidates = candidates;
-		this.requiredAmount = requiredAmount;
-	}
+  public LockableResourcesCandidatesStruct(List<LockableResource> candidates, int requiredAmount) {
+    this.candidates = candidates;
+    this.requiredAmount = requiredAmount;
+  }
 
-    @Override
-    public String toString()
-    {
-        return "LockableResourcesCandidatesStruct [candidates=" + candidates + ", requiredAmount=" + requiredAmount
-                + ", selected=" + selected + "]";
-    }
+  @Override
+  public String toString()
+  {
+    return "LockableResourcesCandidatesStruct [candidates=" + candidates + ", requiredAmount=" + requiredAmount
+      + ", selected=" + selected + "]";
+  }
 
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -38,10 +38,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
   private transient Cache<Long, Date> lastLogged =
-      Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).build();
+    Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).build();
 
   static final Logger LOGGER =
-      Logger.getLogger(LockableResourcesQueueTaskDispatcher.class.getName());
+    Logger.getLogger(LockableResourcesQueueTaskDispatcher.class.getName());
 
   @Override
   public CauseOfBlockage canRun(Queue.Item item) {
@@ -54,9 +54,9 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     LockableResourcesStruct resources = Utils.requiredResources(project);
     if (resources == null
-        || (resources.required.isEmpty()
-            && resources.label.isEmpty()
-            && resources.getResourceMatchScript() == null)) {
+      || (resources.required.isEmpty()
+      && resources.label.isEmpty()
+      && resources.getResourceMatchScript() == null)) {
       return null;
     }
 
@@ -70,8 +70,8 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
     LOGGER.finest(project.getName() + " trying to get resources with these details: " + resources);
 
     if (resourceNumber > 0
-        || !resources.label.isEmpty()
-        || resources.getResourceMatchScript() != null) {
+      || !resources.label.isEmpty()
+      || resources.getResourceMatchScript() != null) {
       Map<String, Object> params = new HashMap<>();
 
       // Inject Build Parameters, if possible and applicable to the "item" type
@@ -105,9 +105,9 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
       final List<LockableResource> selected;
       try {
         selected =
-            LockableResourcesManager.get()
-                .tryQueue(
-                    resources, item.getId(), project.getFullName(), resourceNumber, params, LOGGER);
+          LockableResourcesManager.get()
+            .tryQueue(
+              resources, item.getId(), project.getFullName(), resourceNumber, params, LOGGER);
       } catch (ExecutionException ex) {
         Throwable toReport = ex.getCause();
         if (toReport == null) { // We care about the cause only
@@ -135,7 +135,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     } else {
       if (LockableResourcesManager.get()
-          .queue(resources.required, item.getId(), project.getFullDisplayName())) {
+        .queue(resources.required, item.getId(), project.getFullDisplayName())) {
         LOGGER.finest(project.getName() + " reserved resources " + resources.required);
         return null;
       } else {
@@ -171,8 +171,8 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
           }
           // TODO: Developers should extend here if LockableResourcesStruct is extended
           LOGGER.log(
-              Level.WARNING,
-              "Failed to classify reason of waiting for resource: " + this.rscStruct);
+            Level.WARNING,
+            "Failed to classify reason of waiting for resource: " + this.rscStruct);
           return "Waiting for lockable resources";
         }
       } else {
@@ -189,7 +189,7 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
     @NonNull private final Throwable cause;
 
     public BecauseResourcesQueueFailed(
-        @NonNull LockableResourcesStruct resources, @NonNull Throwable cause) {
+      @NonNull LockableResourcesStruct resources, @NonNull Throwable cause) {
       this.cause = cause;
       this.resources = resources;
     }
@@ -198,13 +198,13 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
     public String getShortDescription() {
       // TODO: Just a copy-paste from BecauseResourcesLocked, seems strange
       String resourceInfo =
-          resources.label.isEmpty()
-              ? resources.required.toString()
-              : "with label " + resources.label;
+        resources.label.isEmpty()
+          ? resources.required.toString()
+          : "with label " + resources.label;
       return "Execution failed while acquiring the resource "
-          + resourceInfo
-          + ". "
-          + cause.getMessage();
+        + resourceInfo
+        + ". "
+        + cause.getMessage();
     }
   }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -70,13 +70,13 @@ public class LockableResourcesStruct implements Serializable {
   }
 
   public LockableResourcesStruct(
-      @Nullable List<String> resources, @Nullable String label, int quantity, String variable) {
+    @Nullable List<String> resources, @Nullable String label, int quantity, String variable) {
     this(resources, label, quantity);
     requiredVar = variable;
   }
 
   public LockableResourcesStruct(
-      @Nullable List<String> resources, @Nullable String label, int quantity) {
+    @Nullable List<String> resources, @Nullable String label, int quantity) {
     required = new ArrayList<>();
     if (resources != null) {
       for (String resource : resources) {
@@ -123,15 +123,15 @@ public class LockableResourcesStruct implements Serializable {
   @Override
   public String toString() {
     return "Required resources: "
-        + this.required
-        + ", Required label: "
-        + this.label
-        + ", Required label script: "
-        + (this.resourceMatchScript != null ? this.resourceMatchScript.getScript() : "")
-        + ", Variable name: "
-        + this.requiredVar
-        + ", Number of resources: "
-        + this.requiredNumber;
+      + this.required
+      + ", Required label: "
+      + this.label
+      + ", Required label script: "
+      + (this.resourceMatchScript != null ? this.resourceMatchScript.getScript() : "")
+      + ", Variable name: "
+      + this.requiredVar
+      + ", Number of resources: "
+      + this.requiredNumber;
   }
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -19,63 +19,63 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
  */
 public class QueuedContextStruct implements Serializable {
 
-	/*
-	 * Reference to the pipeline step context.
-	 */
-	private StepContext context;
+  /*
+   * Reference to the pipeline step context.
+   */
+  private StepContext context;
 
-	/*
-	 * Reference to the resources required by the step context.
-	 */
-	private List<LockableResourcesStruct> lockableResourcesStruct;
+  /*
+   * Reference to the resources required by the step context.
+   */
+  private List<LockableResourcesStruct> lockableResourcesStruct;
 
-	/*
-	 * Description of the required resources used within logging messages.
-	 */
-	private String resourceDescription;
+  /*
+   * Description of the required resources used within logging messages.
+   */
+  private String resourceDescription;
 
-	/*
-	 * Name of the variable to save the locks taken.
-	 */
-	private String variableName;
+  /*
+   * Name of the variable to save the locks taken.
+   */
+  private String variableName;
 
-	/*
-	 * Constructor for the QueuedContextStruct class.
-	 */
-	public QueuedContextStruct(StepContext context, List<LockableResourcesStruct> lockableResourcesStruct, String resourceDescription, String variableName) {
-		this.context = context;
-		this.lockableResourcesStruct = lockableResourcesStruct;
-		this.resourceDescription = resourceDescription;
-		this.variableName = variableName;
-	}
+  /*
+   * Constructor for the QueuedContextStruct class.
+   */
+  public QueuedContextStruct(StepContext context, List<LockableResourcesStruct> lockableResourcesStruct, String resourceDescription, String variableName) {
+    this.context = context;
+    this.lockableResourcesStruct = lockableResourcesStruct;
+    this.resourceDescription = resourceDescription;
+    this.variableName = variableName;
+  }
 
-	/*
-	 * Gets the pipeline step context.
-	 */
-	public StepContext getContext() {
-		return this.context;
-	}
+  /*
+   * Gets the pipeline step context.
+   */
+  public StepContext getContext() {
+    return this.context;
+  }
 
-	/*
-	 * Gets the required resources.
-	 */
-	public List<LockableResourcesStruct> getResources() {
-		return this.lockableResourcesStruct;
-	}
+  /*
+   * Gets the required resources.
+   */
+  public List<LockableResourcesStruct> getResources() {
+    return this.lockableResourcesStruct;
+  }
 
-	/*
-	 * Gets the resource description for logging messages.
-	 */
-	public String getResourceDescription() {
-		return this.resourceDescription;
-	}
+  /*
+   * Gets the resource description for logging messages.
+   */
+  public String getResourceDescription() {
+    return this.resourceDescription;
+  }
 
-	/*
-	 * Gets the variable name to save the locks taken.
-	 */
-	public String getVariableName() {
-		return this.variableName;
-	}
+  /*
+   * Gets the variable name to save the locks taken.
+   */
+  public String getVariableName() {
+    return this.variableName;
+  }
 
-	private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
@@ -26,7 +26,7 @@ public final class Utils {
     return null;
   }
 
-  @CheckForNull
+  @NonNull
   public static Job<?, ?> getProject(@NonNull Run<?, ?> build) {
     return build.getParent();
   }

--- a/src/main/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScript.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScript.java
@@ -46,78 +46,78 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class SerializableSecureGroovyScript implements Serializable {
 
-	private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-	@CheckForNull
-	private final String script;
-	private final boolean sandbox;
-	/**
-	 * {@code null} if and only if the {@link #script is null}.
-	 */
-	@Nullable
-	private final ArrayList<SerializableClassPathEntry> classPathEntries;
+  @CheckForNull
+  private final String script;
+  private final boolean sandbox;
+  /**
+   * {@code null} if and only if the {@link #script is null}.
+   */
+  @Nullable
+  private final ArrayList<SerializableClassPathEntry> classPathEntries;
 
-	private static final Logger LOGGER = Logger.getLogger(SerializableSecureGroovyScript.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(SerializableSecureGroovyScript.class.getName());
 
-	public SerializableSecureGroovyScript(@CheckForNull SecureGroovyScript secureScript) {
-		if (secureScript == null) {
-			script = null;
-			sandbox = false;
-			classPathEntries = null;
-		} else {
-			this.script = secureScript.getScript();
-			this.sandbox = secureScript.isSandbox();
+  public SerializableSecureGroovyScript(@CheckForNull SecureGroovyScript secureScript) {
+    if (secureScript == null) {
+      script = null;
+      sandbox = false;
+      classPathEntries = null;
+    } else {
+      this.script = secureScript.getScript();
+      this.sandbox = secureScript.isSandbox();
 
-			List<ClasspathEntry> classpath = secureScript.getClasspath();
-			classPathEntries = new ArrayList<>(classpath.size());
-			for (ClasspathEntry e : classpath) {
-				classPathEntries.add(new SerializableClassPathEntry(e));
-			}
-		}
-	}
+      List<ClasspathEntry> classpath = secureScript.getClasspath();
+      classPathEntries = new ArrayList<>(classpath.size());
+      for (ClasspathEntry e : classpath) {
+        classPathEntries.add(new SerializableClassPathEntry(e));
+      }
+    }
+  }
 
-	@CheckForNull
-	public SecureGroovyScript rehydrate() {
-		if (script == null) {
-			return null;
-		}
+  @CheckForNull
+  public SecureGroovyScript rehydrate() {
+    if (script == null) {
+      return null;
+    }
 
-		ArrayList<ClasspathEntry> p = new ArrayList<>(classPathEntries.size());
-		for (SerializableClassPathEntry e : classPathEntries) {
-			ClasspathEntry entry = e.rehydrate();
-			if (entry != null) {
-				p.add(entry);
-			}
-		}
+    ArrayList<ClasspathEntry> p = new ArrayList<>(classPathEntries.size());
+    for (SerializableClassPathEntry e : classPathEntries) {
+      ClasspathEntry entry = e.rehydrate();
+      if (entry != null) {
+        p.add(entry);
+      }
+    }
 
-		return new SecureGroovyScript(script, sandbox, p);
-	}
+    return new SecureGroovyScript(script, sandbox, p);
+  }
 
-	private static class SerializableClassPathEntry implements Serializable {
+  private static class SerializableClassPathEntry implements Serializable {
 
-		private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-		private final String url;
+    private final String url;
 
-		private SerializableClassPathEntry(@NonNull ClasspathEntry entry) {
-			this.url = entry.getPath();
-		}
+    private SerializableClassPathEntry(@NonNull ClasspathEntry entry) {
+      this.url = entry.getPath();
+    }
 
-		@CheckForNull
-		private ClasspathEntry rehydrate(){
-			try {
-				ClasspathEntry entry = new ClasspathEntry(url);
-				if (ScriptApproval.get().checking(entry).kind.equals(FormValidation.Kind.OK)) {
-					return entry;
-				} else {
-					return null;
-				}
-			} catch (MalformedURLException ex) {
-				// Unrealistic
-				LOGGER.log(Level.SEVERE, "Failed to rehydrate the URL " + url + ". It will be skipped", ex);
-				return null;
-			}
-		}
+    @CheckForNull
+    private ClasspathEntry rehydrate(){
+      try {
+        ClasspathEntry entry = new ClasspathEntry(url);
+        if (ScriptApproval.get().checking(entry).kind.equals(FormValidation.Kind.OK)) {
+          return entry;
+        } else {
+          return null;
+        }
+      } catch (MalformedURLException ex) {
+        // Unrealistic
+        LOGGER.log(Level.SEVERE, "Failed to rehydrate the URL " + url + ". It will be skipped", ex);
+        return null;
+      }
+    }
 
-	}
+  }
 }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -1,32 +1,32 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Resource}" field="resource">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Label}" field="label">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Quantity}" field="quantity">
-		<f:number/>
-	</f:entry>
-	<f:entry title="${%Result variable}" field="variable">
-		<f:textbox/>
-	</f:entry>
-	<f:entry field="inversePrecedence">
-		<f:checkbox title="${%Inverse precedence}"/>
-	</f:entry>
-	<f:entry field="skipIfLocked">
-		<f:checkbox title="${%Skip queue}"/>
-	</f:entry>
-	<f:entry title="${%Extra resources}">
-		<f:repeatable field="extra" header="" minimum="0" add="${%Add Resource}">
-			<table width="100%">
-				<st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockStepResource"/>
-				<f:entry title="">
-					<div align="right"><f:repeatableDeleteButton/></div>
-				</f:entry>
-			</table>
-		</f:repeatable>
-	</f:entry>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Resource}" field="resource">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Label}" field="label">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Quantity}" field="quantity">
+    <f:number/>
+  </f:entry>
+  <f:entry title="${%Result variable}" field="variable">
+    <f:textbox/>
+  </f:entry>
+  <f:entry field="inversePrecedence">
+    <f:checkbox title="${%Inverse precedence}"/>
+  </f:entry>
+  <f:entry field="skipIfLocked">
+    <f:checkbox title="${%Skip queue}"/>
+  </f:entry>
+  <f:entry title="${%Extra resources}">
+    <f:repeatable field="extra" header="" minimum="0" add="${%Add Resource}">
+      <table width="100%">
+        <st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockStepResource"/>
+        <f:entry title="">
+          <div align="right"><f:repeatableDeleteButton/></div>
+        </f:entry>
+      </table>
+    </f:repeatable>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-inversePrecedence.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-inversePrecedence.html
@@ -1,8 +1,8 @@
 <div>
-	<p>
-		By default waiting builds get the lock in the same order they requested to acquire it.
-	</p>
-	<p>
-		By checking this option the newest build in the waiting queue will get the lock first.
-	</p>
+  <p>
+    By default waiting builds get the lock in the same order they requested to acquire it.
+  </p>
+  <p>
+    By checking this option the newest build in the waiting queue will get the lock first.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-label.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-label.html
@@ -1,6 +1,6 @@
 <div>
-	<p>
-		The label of the resources to be locked as defined in Global settings.
-		Either a resource or a label need to be specified.
-	</p>
+  <p>
+    The label of the resources to be locked as defined in Global settings.
+    Either a resource or a label need to be specified.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-quantity.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-quantity.html
@@ -1,7 +1,7 @@
 <div>
-	<p>
-		The quantity of resources with the specified label to be locked as defined in Global settings.
-		Either a resource or a label need to be specified.
+  <p>
+    The quantity of resources with the specified label to be locked as defined in Global settings.
+    Either a resource or a label need to be specified.
     Empty value or 0 means lock all matching resources.
-	</p>
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-resource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-resource.html
@@ -1,7 +1,7 @@
 <div>
-	<p>
-		The resource name to lock as defined in Global settings.
-		If the resource does not exist in Global Settings it will be automatically created on build execution.
-		Either a resource or a label need to be specified.
-	</p>
+  <p>
+    The resource name to lock as defined in Global settings.
+    If the resource does not exist in Global Settings it will be automatically created on build execution.
+    Either a resource or a label need to be specified.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-skipIfLocked.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-skipIfLocked.html
@@ -1,8 +1,8 @@
 <div>
-	<p>
-		By default waiting builds get the lock.
-	</p>
-	<p>
-		By checking this option the body will not be executed if there is a queue. It will only take the lock if it can be taken immediately.
-	</p>
+  <p>
+    By default waiting builds get the lock.
+  </p>
+  <p>
+    By checking this option the body will not be executed if there is a queue. It will only take the lock if it can be taken immediately.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
@@ -1,13 +1,13 @@
 <div>
-	<p>
-		Name of an environment variable that will receive the comma separated list of the names of the locked resources while the block executes.
-	</p>
-	<p>
-		e.g.:
-		<pre>
+  <p>
+    Name of an environment variable that will receive the comma separated list of the names of the locked resources while the block executes.
+  </p>
+  <p>
+    e.g.:
+    <pre>
 lock(label: 'label', variable: 'var') {
     echo "Resource locked: ${env.var}"
 }
 		</pre>
-	</p>
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/config.jelly
@@ -1,13 +1,13 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Resource}" field="resource">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Label}" field="label">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Quantity}" field="quantity">
-		<f:number/>
-	</f:entry>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Resource}" field="resource">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Label}" field="label">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Quantity}" field="quantity">
+    <f:number/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
@@ -1,6 +1,6 @@
 <div>
-	<p>
-		The label of the resources to be locked as defined in Global settings.
-		Either a resource or a label need to be specified.
-	</p>
+  <p>
+    The label of the resources to be locked as defined in Global settings.
+    Either a resource or a label need to be specified.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-quantity.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-quantity.html
@@ -1,7 +1,7 @@
 <div>
-	<p>
-		The quantity of resources with the specified label to be locked as defined in Global settings.
-		Either a resource or a label need to be specified.
+  <p>
+    The quantity of resources with the specified label to be locked as defined in Global settings.
+    Either a resource or a label need to be specified.
     Empty value or 0 means lock all matching resources.
-	</p>
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-resource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-resource.html
@@ -1,7 +1,7 @@
 <div>
-	<p>
-		The resource name to lock as defined in Global settings.
-		If the resource does not exist in Global Settings it will be automatically created on build execution.
-		Either a resource or a label need to be specified.
-	</p>
+  <p>
+    The resource name to lock as defined in Global settings.
+    If the resource does not exist in Global Settings it will be automatically created on build execution.
+    Either a resource or a label need to be specified.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -10,16 +10,16 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Name}" field="name">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Description}" field="description">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Labels}" field="labels">
-		<f:textbox/>
-	</f:entry>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Name}" field="name">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Description}" field="description">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Labels}" field="labels">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Reserved by}" field="reservedBy">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourceProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourceProperty/config.jelly
@@ -10,26 +10,11 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Name}" field="name">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Description}" field="description">
-		<f:textbox/>
-	</f:entry>
-	<f:entry title="${%Labels}" field="labels">
-		<f:textbox/>
-	</f:entry>
-  <f:entry title="${%Reserved by}" field="reservedBy">
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Name}" field="name">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%Properties}">
-    <f:repeatableProperty field="properties" header="" minimum="0" add="${%Add Property}">
-      <f:block>
-        <div align="right">
-          <f:repeatableDeleteButton value="${%Delete Property}" />
-        </div>
-      </f:block>
-    </f:repeatableProperty>
+  <f:entry title="${%Value}" field="value">
+    <f:textbox/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
@@ -10,17 +10,17 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:section title="${%Lockable Resources Manager}">
-		<f:entry title="${%Lockable Resources}">
-			<f:repeatable field="declaredResources" header="${%Resource}" minimum="0" add="${%Add Lockable Resource}">
-				<table width="100%">
-					<st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockableResource"/>
-					<f:entry title="">
-						<div align="right"><f:repeatableDeleteButton/></div>
-					</f:entry>
-				</table>
-			</f:repeatable>
-		</f:entry>
-	</f:section>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="${%Lockable Resources Manager}">
+    <f:entry title="${%Lockable Resources}">
+      <f:repeatable field="declaredResources" header="${%Resource}" minimum="0" add="${%Add Lockable Resource}">
+        <table width="100%">
+          <st:include page="config.jelly" class="org.jenkins.plugins.lockableresources.LockableResource"/>
+          <f:entry title="">
+            <div align="right"><f:repeatableDeleteButton/></div>
+          </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+  </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
@@ -10,24 +10,24 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:optionalBlock title="${%This build requires lockable resources}"
-					name="required-lockable-resources"
-					checked="${instance!=null}">
-		<f:nested>
-			<f:entry title="${%Resources}" field="resourceNames">
-				<f:textbox autoCompleteDelimChar=" "/>
-			</f:entry>
-			<f:entry title="${%Label}" field="labelName">
-				<f:textbox autoCompleteDelimChar=" "/>
-			</f:entry>
-			<f:optionalProperty title="${%Groovy Expression}" field="resourceMatchScript"/>
-			<f:entry title="${%Reserved resources variable name}" field="resourceNamesVar">
-				<f:textbox/>
-			</f:entry>
-			<f:entry title="${%Number of resources to request}" field="resourceNumber">
-				<f:textbox/>
-			</f:entry>
-		</f:nested>
-	</f:optionalBlock>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:optionalBlock title="${%This build requires lockable resources}"
+    name="required-lockable-resources"
+    checked="${instance!=null}">
+    <f:nested>
+      <f:entry title="${%Resources}" field="resourceNames">
+        <f:textbox autoCompleteDelimChar=" "/>
+      </f:entry>
+      <f:entry title="${%Label}" field="labelName">
+        <f:textbox autoCompleteDelimChar=" "/>
+      </f:entry>
+      <f:optionalProperty title="${%Groovy Expression}" field="resourceMatchScript"/>
+      <f:entry title="${%Reserved resources variable name}" field="resourceNamesVar">
+        <f:textbox/>
+      </f:entry>
+      <f:entry title="${%Number of resources to request}" field="resourceNumber">
+        <f:textbox/>
+      </f:entry>
+    </f:nested>
+  </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-labelName.html
@@ -1,8 +1,8 @@
 <div>
-<p>
-If you have created a pool of resources, i.e. a label, you can take it into use
-here. The build will select the resource(s) from the pool that includes all
-resources sharing the given label.
-Only one of Label, Groovy Expression or Resources fields may be specified.
-</p>
+  <p>
+    If you have created a pool of resources, i.e. a label, you can take it into use
+    here. The build will select the resource(s) from the pool that includes all
+    resources sharing the given label.
+    Only one of Label, Groovy Expression or Resources fields may be specified.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceMatchScript.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceMatchScript.html
@@ -1,28 +1,28 @@
 <div>
-    <p>
-        You can specify a groovy expression to be evaluated each time a resource is checked
-        to be appropriate for a build. The expression must result into a boolean value. The
-        following variables are available, in addition to optional arguments of the currently
-        evaluated build:
-    </p>
-    <dl>
-        <dt>resourceName</dt>
-        <dd>as per resource configuration</dd>
-        <dt>resourceDescription</dt>
-        <dd>as per resource configuration</dd>
-        <dt>resourceLabels</dt>
-        <dd><code>java.util.List&lt;String&gt;</code> of labels as per resource configuration</dd>
-    </dl>
-    <p>
-        For matrix jobs, axis names and axis values can be referenced as well. Examples:
-    </p>
-    <ul>
-        <li><code>resourceLabels.contains("hardcoded")</code></li>
-        <li><code>resourceLabels.contains(axisName)</code></li>
-        <li><code>resourceName == axisName</code></li>
-    </ul>
+  <p>
+    You can specify a groovy expression to be evaluated each time a resource is checked
+    to be appropriate for a build. The expression must result into a boolean value. The
+    following variables are available, in addition to optional arguments of the currently
+    evaluated build:
+  </p>
+  <dl>
+    <dt>resourceName</dt>
+    <dd>as per resource configuration</dd>
+    <dt>resourceDescription</dt>
+    <dd>as per resource configuration</dd>
+    <dt>resourceLabels</dt>
+    <dd><code>java.util.List&lt;String&gt;</code> of labels as per resource configuration</dd>
+  </dl>
+  <p>
+    For matrix jobs, axis names and axis values can be referenced as well. Examples:
+  </p>
+  <ul>
+    <li><code>resourceLabels.contains("hardcoded")</code></li>
+    <li><code>resourceLabels.contains(axisName)</code></li>
+    <li><code>resourceName == axisName</code></li>
+  </ul>
 
-    <p>
-      The script's contents need to pass approval by the <a href="https://plugins.jenkins.io/script-security">Script Security Plugin</a>.
-    </p>
+  <p>
+    The script's contents need to pass approval by the <a href="https://plugins.jenkins.io/script-security">Script Security Plugin</a>.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNames.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNames.html
@@ -1,8 +1,8 @@
 <div>
-<p>
-When a build is scheduled, it will attempt to lock the specified resources. If
-some (or all) the resources are already locked by another build, the build will
-be queued until they are released. It is possible to specify an amount for
-requested resources below.
-</p>
+  <p>
+    When a build is scheduled, it will attempt to lock the specified resources. If
+    some (or all) the resources are already locked by another build, the build will
+    be queued until they are released. It is possible to specify an amount for
+    requested resources below.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNamesVar.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNamesVar.html
@@ -1,6 +1,6 @@
 <div>
-<p>
-Name for the Jenkins variable to store the reserved resources in. Leave empty
-to disable.
-</p>
+  <p>
+    Name for the Jenkins variable to store the reserved resources in. Leave empty
+    to disable.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNumber.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-resourceNumber.html
@@ -1,8 +1,8 @@
 <div>
-<p>
-Number of resources to request, empty value or 0 means all.
-<br>
-This is useful, if you have a pool of similar resources, from which you want
-one or more to be reserved.
-</p>
+  <p>
+    Number of resources to request, empty value or 0 means all.
+    <br>
+    This is useful, if you have a pool of similar resources, from which you want
+    one or more to be reserved.
+  </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -78,15 +78,15 @@
                       </j:if>
                       <j:if
                         test="${it.UserName != null and it.UserName != resource.reservedBy and ( h.hasPermission(it.STEAL) or h.hasPermission(app.ADMINISTER) )}">
-                          <j:choose>
-                              <j:when
-                                test="${resource.reservedBy.contains('#')}">
-                                <br/><button onClick="resource_action(this, 'reassign');">Reassign from a job</button>
-                              </j:when>
-                              <j:otherwise> <!-- TODO: Want to need any rights here vs. for jobs? -->
-                                <br/><button onClick="resource_action(this, 'reassign');">Reassign from a user</button>
-                              </j:otherwise>
-                          </j:choose>
+                        <j:choose>
+                          <j:when
+                            test="${resource.reservedBy.contains('#')}">
+                            <br/><button onClick="resource_action(this, 'reassign');">Reassign from a job</button>
+                          </j:when>
+                          <j:otherwise> <!-- TODO: Want to need any rights here vs. for jobs? -->
+                            <br/><button onClick="resource_action(this, 'reassign');">Reassign from a user</button>
+                          </j:otherwise>
+                        </j:choose>
                       </j:if>
                     </j:if>
                   </td>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/noteForm.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/noteForm.jelly
@@ -33,17 +33,17 @@ THE SOFTWARE.
   <j:set var="note" value="${resourceObject.note}"/>
   <l:ajax>
     <f:block>
-    <form action="saveNote?resource=${resource}" method="post" style="flex-grow: 1;">
-      <div>
-        <f:entry help="${app.markupFormatter.helpUrl}">
-          <f:textarea name="note" value="${note}"
-                      codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
-        </f:entry>
-      </div>
-      <div align="right">
-        <f:submit value="${%Save}"/>
-      </div>
-    </form>
+      <form action="saveNote?resource=${resource}" method="post" style="flex-grow: 1;">
+        <div>
+          <f:entry help="${app.markupFormatter.helpUrl}">
+            <f:textarea name="note" value="${note}"
+              codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+          </f:entry>
+        </div>
+        <div align="right">
+          <f:submit value="${%Save}"/>
+        </div>
+      </form>
     </f:block>
   </l:ajax>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
@@ -10,25 +10,25 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<l:layout title="${it.displayName}">
-		<j:invokeStatic var="currentThread" className="java.lang.Thread" method="currentThread" />
-		<j:invoke var="buildClass" on="${currentThread.contextClassLoader}" method="loadClass">
-			<j:arg value="hudson.model.AbstractBuild" />
-		</j:invoke>
-		<j:set var="build" value="${request.findAncestorObject(buildClass)}" />
-		<st:include page="sidepanel.jelly" it="${build}" />
-		<l:main-panel>
-			<h1>${%Locked Resources}</h1>
-			<p>This build has locked the following resources:</p>
-			<ul>
-<j:forEach var="resource" items="${it.lockedResources}" varStatus="loop">
-				<li>
-					<strong>${resource.name}</strong> - <em>${resource.description}</em>
-				</li>
-</j:forEach>
-			</ul>
-		</l:main-panel>
-	</l:layout>
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+  xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <l:layout title="${it.displayName}">
+    <j:invokeStatic var="currentThread" className="java.lang.Thread" method="currentThread" />
+    <j:invoke var="buildClass" on="${currentThread.contextClassLoader}" method="loadClass">
+      <j:arg value="hudson.model.AbstractBuild" />
+    </j:invoke>
+    <j:set var="build" value="${request.findAncestorObject(buildClass)}" />
+    <st:include page="sidepanel.jelly" it="${build}" />
+    <l:main-panel>
+      <h1>${%Locked Resources}</h1>
+      <p>This build has locked the following resources:</p>
+      <ul>
+        <j:forEach var="resource" items="${it.lockedResources}" varStatus="loop">
+          <li>
+            <strong>${resource.name}</strong> - <em>${resource.description}</em>
+          </li>
+        </j:forEach>
+      </ul>
+    </l:main-panel>
+  </l:layout>
 </j:jelly>

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -18,23 +18,23 @@ function resource_action(button, action) {
 }
 
 function replaceNote(element, resourceName) {
-    var d = document.getElementById("note-" + resourceName);
-    $(d).down().next().innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
-    new Ajax.Request(
-        "noteForm",
-        {
-          parameters: {resource: resourceName},
-          onComplete : function(x) {
-            d.innerHTML = x.responseText;
-            evalInnerHtmlScripts(x.responseText,function() {
-                Behaviour.applySubtree(d);
-                d.getElementsByTagName("TEXTAREA")[0].focus();
-            });
-            layoutUpdateCallback.call();
-          }
+  var d = document.getElementById("note-" + resourceName);
+  $(d).down().next().innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
+  new Ajax.Request(
+      "noteForm",
+      {
+        parameters: {resource: resourceName},
+        onComplete : function(x) {
+          d.innerHTML = x.responseText;
+          evalInnerHtmlScripts(x.responseText,function() {
+            Behaviour.applySubtree(d);
+            d.getElementsByTagName("TEXTAREA")[0].focus();
+          });
+          layoutUpdateCallback.call();
         }
-    );
-    return false;
+      }
+  );
+  return false;
 }
 
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -23,11 +23,11 @@ public class ConfigurationAsCodeTest {
   @Test
   public void should_support_configuration_as_code() {
     List<LockableResource> declaredResources =
-        LockableResourcesManager.get().getDeclaredResources();
+      LockableResourcesManager.get().getDeclaredResources();
     assertEquals(
-        "The number of declared resources is wrong. Check your configuration-as-code.yml",
-        1,
-        declaredResources.size());
+      "The number of declared resources is wrong. Check your configuration-as-code.yml",
+      1,
+      declaredResources.size());
 
     LockableResource declaredResource = declaredResources.get(0);
     assertEquals("Resource_A", declaredResource.getName());
@@ -38,9 +38,9 @@ public class ConfigurationAsCodeTest {
 
     List<LockableResource> resources = LockableResourcesManager.get().getResources();
     assertEquals(
-        "The number of resources is wrong. Check your configuration-as-code.yml",
-        1,
-        resources.size());
+      "The number of resources is wrong. Check your configuration-as-code.yml",
+      1,
+      resources.size());
 
     LockableResource resource = resources.get(0);
     assertEquals("Resource_A", resource.getName());

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -62,8 +62,8 @@ public class FreeStyleProjectTest {
 
     FreeStyleProject p = j.createFreeStyleProject("p");
     p.addProperty(
-        new RequiredResourcesProperty(
-            null, null, null, "groovy:resourceName == 'resource1'", null));
+      new RequiredResourcesProperty(
+        null, null, null, "groovy:resourceName == 'resource1'", null));
 
     p.save();
 
@@ -84,10 +84,10 @@ public class FreeStyleProjectTest {
     p3.getBuildersList().add(p3Builder);
 
     final QueueTaskFuture<FreeStyleBuild> taskA =
-        p3.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+      p3.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
     TestHelpers.waitForQueue(j.jenkins, p3);
     final QueueTaskFuture<FreeStyleBuild> taskB =
-        p2.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+      p2.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
 
     p3Builder.release();
     final FreeStyleBuild buildA = taskA.get(60, TimeUnit.SECONDS);
@@ -96,12 +96,12 @@ public class FreeStyleProjectTest {
 
     long buildAEndTime = buildA.getStartTimeInMillis() + buildA.getDuration();
     assertTrue(
-        "Project A build should be finished before the build of project B starts. "
-            + "A finished at "
-            + buildAEndTime
-            + ", B started at "
-            + buildB.getStartTimeInMillis(),
-        buildB.getStartTimeInMillis() >= buildAEndTime);
+      "Project A build should be finished before the build of project B starts. "
+        + "A finished at "
+        + buildAEndTime
+        + ", B started at "
+        + buildB.getStartTimeInMillis(),
+      buildB.getStartTimeInMillis() >= buildAEndTime);
   }
 
   @Test
@@ -110,11 +110,11 @@ public class FreeStyleProjectTest {
 
     FreeStyleProject withResource = j.createFreeStyleProject("withResource");
     withResource.addProperty(
-        new RequiredResourcesProperty("resource1", "resourceNameVar", null, null, null));
+      new RequiredResourcesProperty("resource1", "resourceNameVar", null, null, null));
     FreeStyleProject withResourceRoundTrip = j.configRoundtrip(withResource);
 
     RequiredResourcesProperty withResourceProp =
-        withResourceRoundTrip.getProperty(RequiredResourcesProperty.class);
+      withResourceRoundTrip.getProperty(RequiredResourcesProperty.class);
     assertNotNull(withResourceProp);
     assertEquals("resource1", withResourceProp.getResourceNames());
     assertEquals("resourceNameVar", withResourceProp.getResourceNamesVar());
@@ -130,7 +130,7 @@ public class FreeStyleProjectTest {
     FreeStyleProject withLabelRoundTrip = j.configRoundtrip(withLabel);
 
     RequiredResourcesProperty withLabelProp =
-        withLabelRoundTrip.getProperty(RequiredResourcesProperty.class);
+      withLabelRoundTrip.getProperty(RequiredResourcesProperty.class);
     assertNotNull(withLabelProp);
     assertNull(withLabelProp.getResourceNames());
     assertNull(withLabelProp.getResourceNamesVar());
@@ -147,7 +147,7 @@ public class FreeStyleProjectTest {
     FreeStyleProject withScriptRoundTrip = j.configRoundtrip(withScript);
 
     RequiredResourcesProperty withScriptProp =
-        withScriptRoundTrip.getProperty(RequiredResourcesProperty.class);
+      withScriptRoundTrip.getProperty(RequiredResourcesProperty.class);
     assertNotNull(withScriptProp);
     assertNull(withScriptProp.getResourceNames());
     assertNull(withScriptProp.getResourceNamesVar());
@@ -165,24 +165,24 @@ public class FreeStyleProjectTest {
     j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
 
     j.jenkins.setAuthorizationStrategy(
-        new MockAuthorizationStrategy()
-            .grant(Jenkins.READ, Item.READ)
-            .everywhere()
-            .toAuthenticated()
-            .grant(Jenkins.ADMINISTER)
-            .everywhere()
-            .to("bob")
-            .grant(Item.CONFIGURE, Item.BUILD)
-            .everywhere()
-            .to("alice"));
+      new MockAuthorizationStrategy()
+        .grant(Jenkins.READ, Item.READ)
+        .everywhere()
+        .toAuthenticated()
+        .grant(Jenkins.ADMINISTER)
+        .everywhere()
+        .to("bob")
+        .grant(Item.CONFIGURE, Item.BUILD)
+        .everywhere()
+        .to("alice"));
 
     final String SCRIPT =
-        "resourceName == "
-            + "org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction.ICON;";
+      "resourceName == "
+        + "org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction.ICON;";
 
     FreeStyleProject p = j.createFreeStyleProject();
     SecureGroovyScript groovyScript =
-        new SecureGroovyScript(SCRIPT, true, null).configuring(ApprovalContext.create());
+      new SecureGroovyScript(SCRIPT, true, null).configuring(ApprovalContext.create());
 
     p.addProperty(new RequiredResourcesProperty(null, null, null, null, groovyScript));
 
@@ -195,21 +195,21 @@ public class FreeStyleProjectTest {
 
     Queue.BlockedItem blockedItem = (Queue.BlockedItem) j.jenkins.getQueue().getItem(p);
     assertThat(
-        blockedItem.getCauseOfBlockage(),
-        is(instanceOf(LockableResourcesQueueTaskDispatcher.BecauseResourcesQueueFailed.class)));
+      blockedItem.getCauseOfBlockage(),
+      is(instanceOf(LockableResourcesQueueTaskDispatcher.BecauseResourcesQueueFailed.class)));
 
     ScriptApproval approval = ScriptApproval.get();
     List<ScriptApproval.PendingSignature> pending =
-        new ArrayList<>(approval.getPendingSignatures());
+      new ArrayList<>(approval.getPendingSignatures());
 
     assertFalse(pending.isEmpty());
     assertEquals(1, pending.size());
     ScriptApproval.PendingSignature firstPending = pending.get(0);
 
     assertEquals(
-        "staticField org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction "
-            + "ICON",
-        firstPending.signature);
+      "staticField org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction "
+        + "ICON",
+      firstPending.signature);
     approval.approveSignature(firstPending.signature);
 
     j.assertBuildStatusSuccess(futureBuild);
@@ -231,10 +231,10 @@ public class FreeStyleProjectTest {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-        throws InterruptedException, IOException {
+      throws InterruptedException, IOException {
       listener
-          .getLogger()
-          .println("resourceNameVar: " + build.getEnvironment(listener).get("resourceNameVar"));
+        .getLogger()
+        .println("resourceNameVar: " + build.getEnvironment(listener).get("resourceNameVar"));
       return true;
     }
   }
@@ -245,7 +245,7 @@ public class FreeStyleProjectTest {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-        throws InterruptedException {
+      throws InterruptedException {
       event.block();
       return true;
     }

--- a/src/test/java/org/jenkins/plugins/lockableresources/InteroperabilityTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/InteroperabilityTest.java
@@ -24,23 +24,23 @@ public class InteroperabilityTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	echo 'Locked'\n" + "}\n" + "echo 'Finish'", true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	echo 'Locked'\n" + "}\n" + "echo 'Finish'", true));
 
     FreeStyleProject f = j.createFreeStyleProject("f");
     f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
     f.getBuildersList()
-        .add(
-            new TestBuilder() {
+      .add(
+        new TestBuilder() {
 
-              @Override
-              public boolean perform(
-                  AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-                  throws InterruptedException {
-                semaphore.acquire();
-                return true;
-              }
-            });
+          @Override
+          public boolean perform(
+            AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException {
+            semaphore.acquire();
+            return true;
+          }
+        });
     semaphore.acquire();
     FreeStyleBuild f1 = f.scheduleBuild2(0).waitForStart();
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepHardKillTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepHardKillTest.java
@@ -24,19 +24,19 @@ public class LockStepHardKillTest extends LockStepTestBase {
 
     WorkflowJob p1 = j.jenkins.createProject(WorkflowJob.class, "p1");
     p1.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') { echo 'locked!'; semaphore 'wait-inside'; echo 'Semaphore 1 unblocked'; }", true));
+      new CpsFlowDefinition(
+        "lock('resource1') { echo 'locked!'; semaphore 'wait-inside'; echo 'Semaphore 1 unblocked'; }", true));
     WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
     j.waitForMessage("locked!", b1);
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" +
-            "  semaphore 'wait-inside'\n" +
-            "  echo 'Semaphore 2 unblocked'\n" +
-            "}", true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" +
+          "  semaphore 'wait-inside'\n" +
+          "  echo 'Semaphore 2 unblocked'\n" +
+          "}", true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
 
     // Make sure that b2 is blocked on b1's lock.
@@ -47,11 +47,11 @@ public class LockStepHardKillTest extends LockStepTestBase {
     // lock.
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" +
-            "  semaphore 'wait-inside'\n" +
-            "  echo 'Semaphore 3 unblocked'\n" +
-            "}", true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" +
+          "  semaphore 'wait-inside'\n" +
+          "  echo 'Semaphore 3 unblocked'\n" +
+          "}", true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
 
     // Make sure that b3 is also blocked still on b1's lock.
@@ -85,20 +85,20 @@ public class LockStepHardKillTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "retry(99) {\n"
-                + "    lock('resource1') {\n"
-                + "        semaphore('wait-inside')\n"
-                + "     }\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "retry(99) {\n"
+          + "    lock('resource1') {\n"
+          + "        semaphore('wait-inside')\n"
+          + "     }\n"
+          + "}",
+        true));
 
     WorkflowRun prevBuild = null;
     for (int i = 0; i < 3; i++) {
       WorkflowRun rNext = p.scheduleBuild2(0).waitForStart();
       if (prevBuild != null) {
         j.waitForMessage(
-            "[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
+          "[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         interruptTermKill(prevBuild);
       }
@@ -120,13 +120,13 @@ public class LockStepHardKillTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource2", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "retry(99) {\n"
-                + "    lock(label: 'label1', quantity: 1) {\n"
-                + "        semaphore('wait-inside')\n"
-                + "     }\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "retry(99) {\n"
+          + "    lock(label: 'label1', quantity: 1) {\n"
+          + "        semaphore('wait-inside')\n"
+          + "     }\n"
+          + "}",
+        true));
 
     WorkflowRun firstPrev = null;
     WorkflowRun secondPrev = null;

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -824,6 +824,31 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
+  //@Issue("JENKINS-XXXXX")
+  public void multipleLocksFillVariables() throws Exception {
+    LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
+    LockableResourcesManager.get().createResourceWithLabel("resource2", "label1");
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar', quantity: 2) {\n"
+          + "  echo \"VAR IS $env.someVar\"\n"
+          + "  echo \"VAR0 IS $env.someVar0\"\n"
+          + "  echo \"VAR1 IS $env.someVar1\"\n"
+          + "  echo \"VAR2 IS $env.someVar2\"\n"
+          + "}",
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+
+    // Variable should have been filled
+    j.assertLogContains("VAR IS resource1,resource2", b1);
+    j.assertLogContains("VAR0 IS resource1", b1);
+    j.assertLogContains("VAR1 IS resource2", b1);
+    j.assertLogContains("VAR2 IS null", b1);
+  }
+
+  @Test
   @Issue("JENKINS-50176")
   public void lockWithLabelFillsVariable() throws Exception {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
+import com.google.common.collect.ImmutableMap;
 import hudson.Functions;
 import hudson.model.Result;
 import java.util.ArrayList;
@@ -846,6 +847,29 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("VAR0 IS resource1", b1);
     j.assertLogContains("VAR1 IS resource2", b1);
     j.assertLogContains("VAR2 IS null", b1);
+  }
+
+  @Test
+  //@Issue("JENKINS-XXXXX")
+  public void multipleLocksFillVariablesWithProperties() throws Exception {
+    LockableResourcesManager.get().createResourceWithLabelAndProperties("resource1", "label1", ImmutableMap.of("MYKEY", "MYVAL1"));
+    LockableResourcesManager.get().createResourceWithLabelAndProperties("resource2", "label1", ImmutableMap.of("MYKEY", "MYVAL2"));
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar', quantity: 2) {\n"
+          + "  echo \"$env.someVar0 HAS MYKEY=$env.someVar0_MYKEY\"\n"
+          + "  echo \"$env.someVar1 HAS MYKEY=$env.someVar1_MYKEY\"\n"
+          + "  echo \"$env.someVar2 HAS MYKEY=$env.someVar2_MYKEY\"\n"
+          + "}",
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForCompletion(b1);
+
+    // Variable should have been filled
+    j.assertLogContains("resource1 HAS MYKEY=MYVAL1", b1);
+    j.assertLogContains("resource2 HAS MYKEY=MYVAL2", b1);
+    j.assertLogContains("null HAS MYKEY=null", b1);
   }
 
   @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -971,7 +971,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  // @Issue("JENKINS-XXXXX")
+  //@Issue("JENKINS-XXXXX")
   public void reserveInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -998,7 +998,7 @@ public class LockStepTest extends LockStepTestBase {
                 + "    def res = "
                 + lmget
                 + ".reserve([lr], 'test2a')\n"
-                // + "    semaphore 'wait-inside'\n"
+                //+ "    semaphore 'wait-inside'\n"
                 + "    echo \"Locked resource cause 1-2a: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-2a: ${lr.getReservedBy()}\"\n"
                 + "    if (!res) {\n"
@@ -1027,15 +1027,15 @@ public class LockStepTest extends LockStepTestBase {
                 + "  sleep (5)\n"
                 // Note: the unlock attempt here might steal this resource
                 // from another parallel stage, so we don't do it:
-                // + "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
-                // + "  " + lmget + ".unlock([lr], null)\n"
-                // + "  sleep (5)\n"
+                //+ "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
+                //+ "  " + lmget + ".unlock([lr], null)\n"
+                //+ "  sleep (5)\n"
                 + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
                 + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
                 + "  sleep (5)\n"
                 + "  if (lr.getLockCause() == null) {\n"
                 + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by LRM methods\"\n"
-                // + "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
+                //+ "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
                 + "    if ("
                 + lmget
                 + ".reserve([lr], 'unstucker')) {\n"
@@ -1050,7 +1050,7 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
                 + "},\n"
                 + "p2: {\n"
-                // + "  semaphore 'wait-outside'\n"
+                //+ "  semaphore 'wait-outside'\n"
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
                 + "  lock(label: 'label1', variable: 'someVar2') {\n"
@@ -1110,8 +1110,8 @@ public class LockStepTest extends LockStepTestBase {
                 + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
                 + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
                 + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-                + "\necho \"Survived the test\"\n"
-                + "}", // timeout wrapper
+            + "\necho \"Survived the test\"\n"
+            + "}", // timeout wrapper
             false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
@@ -1151,8 +1151,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    // j.assertLogNotContains("Locked resource cause 2-2", b1);
-    // j.assertLogNotContains("Locked resource cause 2-3", b1);
+    //j.assertLogNotContains("Locked resource cause 2-2", b1);
+    //j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1160,14 +1160,14 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-      j.waitForMessage("Locked resource cause 1-6", b1);
-      j.assertLogContains("Locked resource cause 2-2", b1);
+        j.waitForMessage("Locked resource cause 1-6", b1);
+        j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-      sawBug2a = true;
+        sawBug2a = true;
       System.err.println(
           "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-      // System.err.println(t1.toString());
-      // throw t1;
+        //System.err.println(t1.toString());
+        // throw t1;
     }
     if (!sawBug2a) {
       System.err.println(
@@ -1183,8 +1183,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line :
         new String[] {
-          "Locked resource cause 1-5: null",
-          "LRM seems stuck; trying to reserve/unreserve",
+        "Locked resource cause 1-5: null",
+        "LRM seems stuck; trying to reserve/unreserve",
           "Secondary lock trick"
         }) {
       try {
@@ -1192,7 +1192,7 @@ public class LockStepTest extends LockStepTestBase {
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        // System.err.println(t2.toString());
+        //System.err.println(t2.toString());
         // throw t2;
       }
     }
@@ -1223,7 +1223,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  // @Issue("JENKINS-XXXXX")
+  //@Issue("JENKINS-XXXXX")
   public void setReservedByInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -1247,7 +1247,7 @@ public class LockStepTest extends LockStepTestBase {
                 + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
                 + "    lr.setReservedBy('test')\n"
-                // + "    semaphore 'wait-inside'\n"
+                //+ "    semaphore 'wait-inside'\n"
                 + "    echo \"Locked resource cause 1-2: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-2: ${lr.getReservedBy()}\"\n"
                 + "    echo \"Unlocking parallel closure 1\"\n"
@@ -1262,7 +1262,7 @@ public class LockStepTest extends LockStepTestBase {
                 // but does not help a queue get moving
                 // + "  echo \"Un-reserving Locked resource directly as `lr.reset()` and
                 // sleeping...\"\n"
-                // + "  lr.reset()\n"
+                //+ "  lr.reset()\n"
                 + "  echo \"Un-reserving Locked resource directly as `lr.recycle()` and sleeping...\"\n"
                 + "  lr.recycle()\n"
                 + "  sleep (5)\n"
@@ -1278,7 +1278,7 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
                 + "},\n"
                 + "p2: {\n"
-                // + "  semaphore 'wait-outside'\n"
+                //+ "  semaphore 'wait-outside'\n"
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
                 + "  lock(label: 'label1', variable: 'someVar2') {\n"
@@ -1304,8 +1304,8 @@ public class LockStepTest extends LockStepTestBase {
                 + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
                 + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
                 + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-                + "\necho \"Survived the test\"\n"
-                + "}", // timeout wrapper
+            + "\necho \"Survived the test\"\n"
+            + "}", // timeout wrapper
             false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
@@ -1345,8 +1345,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    // j.assertLogNotContains("Locked resource cause 2-2", b1);
-    // j.assertLogNotContains("Locked resource cause 2-3", b1);
+    //j.assertLogNotContains("Locked resource cause 2-2", b1);
+    //j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1354,14 +1354,14 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-      j.waitForMessage("Locked resource cause 1-6", b1);
-      j.assertLogContains("Locked resource cause 2-2", b1);
+        j.waitForMessage("Locked resource cause 1-6", b1);
+        j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-      sawBug2a = true;
+        sawBug2a = true;
       System.err.println(
           "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-      // System.err.println(t1.toString());
-      // throw t1;
+        //System.err.println(t1.toString());
+        // throw t1;
     }
     if (!sawBug2a) {
       System.err.println(
@@ -1377,8 +1377,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line :
         new String[] {
-          "Locked resource cause 1-5: null",
-          "LRM seems stuck; trying to reserve/unreserve",
+        "Locked resource cause 1-5: null",
+        "LRM seems stuck; trying to reserve/unreserve",
           "Secondary lock trick"
         }) {
       try {
@@ -1386,7 +1386,7 @@ public class LockStepTest extends LockStepTestBase {
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        // System.err.println(t2.toString());
+        //System.err.println(t2.toString());
         // throw t2;
       }
     }
@@ -1394,18 +1394,18 @@ public class LockStepTest extends LockStepTestBase {
       System.err.println("GOOD: Did not encounter Bug #2b " + "(LRM required un-stucking)!");
     }
 
-    /*
-        j.assertLogContains("Locked resource cause 1-5: null", b1);
-        j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
-        try {
-            j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
-            j.assertLogNotContains("Secondary lock trick", b1);
-        } catch (java.lang.AssertionError t2) {
-            System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
-            //System.err.println(t2.toString());
-            // throw t2;
-        }
-    */
+/*
+    j.assertLogContains("Locked resource cause 1-5: null", b1);
+    j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
+    try {
+        j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
+        j.assertLogNotContains("Secondary lock trick", b1);
+    } catch (java.lang.AssertionError t2) {
+        System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
+        //System.err.println(t2.toString());
+        // throw t2;
+    }
+*/
 
     j.waitForMessage("Locked resource cause 2-2", b1);
     j.assertLogContains("Locked resource cause 1-5", b1);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -833,9 +833,9 @@ public class LockStepTest extends LockStepTestBase {
     p.setDefinition(
       new CpsFlowDefinition(
         "lock(label: 'label1', variable: 'someVar', quantity: 2) {\n"
-          + "  echo \"VAR IS $env.someVar\"\n"
-          + "  echo \"VAR0 IS $env.someVar0\"\n"
-          + "  echo \"VAR1 IS $env.someVar1\"\n"
+          + "  echo \"VAR IS ${env.someVar.split(',').sort()}\"\n"
+          + "  echo \"VAR0or1 IS $env.someVar0\"\n"
+          + "  echo \"VAR0or1 IS $env.someVar1\"\n"
           + "  echo \"VAR2 IS $env.someVar2\"\n"
           + "}",
         true));
@@ -843,9 +843,9 @@ public class LockStepTest extends LockStepTestBase {
     j.waitForCompletion(b1);
 
     // Variable should have been filled
-    j.assertLogContains("VAR IS resource1,resource2", b1);
-    j.assertLogContains("VAR0 IS resource1", b1);
-    j.assertLogContains("VAR1 IS resource2", b1);
+    j.assertLogContains("VAR IS [resource1, resource2]", b1);
+    j.assertLogContains("VAR0or1 IS resource1", b1);
+    j.assertLogContains("VAR0or1 IS resource2", b1);
     j.assertLogContains("VAR2 IS null", b1);
   }
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -186,10 +186,7 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
         new CpsFlowDefinition(
-            "lock(label: 'label1') {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
+            "lock(label: 'label1') {\n" + "	semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
             true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
@@ -665,10 +662,7 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
         new CpsFlowDefinition(
-            "lock(label: 'label1') {\n"
-                + "	semaphore 'wait-inside-p3'\n"
-                + "}\n"
-                + "echo 'Finish'",
+            "lock(label: 'label1') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
             true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1] is locked, waiting...", b3);
@@ -719,10 +713,7 @@ public class LockStepTest extends LockStepTestBase {
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
         new CpsFlowDefinition(
-            "lock(label: 'label1') {\n"
-                + "	semaphore 'wait-inside-p3'\n"
-                + "}\n"
-                + "echo 'Finish'",
+            "lock(label: 'label1') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
             true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1] is locked, waiting...", b3);
@@ -980,7 +971,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  //@Issue("JENKINS-XXXXX")
+  // @Issue("JENKINS-XXXXX")
   public void reserveInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -999,11 +990,15 @@ public class LockStepTest extends LockStepTestBase {
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
                 + "    echo \"VAR IS $env.LOCK_NAME\"\n"
-                + "    lr = " + lmget + ".fromName(env.LOCK_NAME)\n"
+                + "    lr = "
+                + lmget
+                + ".fromName(env.LOCK_NAME)\n"
                 + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
-                + "    def res = " + lmget + ".reserve([lr], 'test2a')\n"
-                //+ "    semaphore 'wait-inside'\n"
+                + "    def res = "
+                + lmget
+                + ".reserve([lr], 'test2a')\n"
+                // + "    semaphore 'wait-inside'\n"
                 + "    echo \"Locked resource cause 1-2a: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-2a: ${lr.getReservedBy()}\"\n"
                 + "    if (!res) {\n"
@@ -1021,25 +1016,33 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource cause 1-4: ${lr.getLockCause()}\"\n"
                 + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
                 + "  echo \"Resetting Locked resource via LRM and sleeping ...\"\n"
-                + "  " + lmget + ".reset([lr])\n"
+                + "  "
+                + lmget
+                + ".reset([lr])\n"
                 + "  sleep (5)\n"
                 + "  echo \"Un-reserving Locked resource via LRM and sleeping...\"\n"
-                + "  " + lmget + ".unreserve([lr])\n"
+                + "  "
+                + lmget
+                + ".unreserve([lr])\n"
                 + "  sleep (5)\n"
                 // Note: the unlock attempt here might steal this resource
                 // from another parallel stage, so we don't do it:
-                //+ "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
-                //+ "  " + lmget + ".unlock([lr], null)\n"
-                //+ "  sleep (5)\n"
+                // + "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
+                // + "  " + lmget + ".unlock([lr], null)\n"
+                // + "  sleep (5)\n"
                 + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
                 + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
                 + "  sleep (5)\n"
                 + "  if (lr.getLockCause() == null) {\n"
                 + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by LRM methods\"\n"
-                //+ "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
-                + "    if (" + lmget + ".reserve([lr], 'unstucker')) {\n"
+                // + "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
+                + "    if ("
+                + lmget
+                + ".reserve([lr], 'unstucker')) {\n"
                 + "        echo \"Secondary lock trick\"\n"
-                + "        " + lmget + ".unreserve([lr])\n"
+                + "        "
+                + lmget
+                + ".unreserve([lr])\n"
                 + "    } else { echo \"Could not reserve by LRM methods as 'unstucker'\" }\n"
                 + "  }\n"
                 + "  sleep (5)\n"
@@ -1047,19 +1050,23 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
                 + "},\n"
                 + "p2: {\n"
-                //+ "  semaphore 'wait-outside'\n"
+                // + "  semaphore 'wait-outside'\n"
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
                 + "  lock(label: 'label1', variable: 'someVar2') {\n"
                 + "    echo \"VAR2 IS $env.someVar2\"\n"
-                + "    lr = " + lmget + ".fromName(env.someVar2)\n"
+                + "    lr = "
+                + lmget
+                + ".fromName(env.someVar2)\n"
                 + "    sleep (1)\n"
                 + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
                 + "    echo \"Setting (directly) and dropping (via LRM) a reservation on locked resource\"\n"
                 + "    lr.reserve('test2-1')\n"
                 + "    sleep (3)\n"
-                + "    " + lmget + ".unreserve([lr])\n"
+                + "    "
+                + lmget
+                + ".unreserve([lr])\n"
                 + "    echo \"Just sleeping...\"\n"
                 + "    sleep (20)\n"
                 + "    echo \"Setting (directly) a reservation on locked resource\"\n"
@@ -1070,7 +1077,9 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 2-3: ${lr.getReservedBy()}\"\n"
                 + "  sleep (5)\n"
                 + "  echo \"Recycling (via LRM) the reserved not-locked resource\"\n"
-                + "  " + lmget + ".recycle([lr])\n"
+                + "  "
+                + lmget
+                + ".recycle([lr])\n"
                 + "  sleep (5)\n"
                 + "  echo \"Locked resource cause 2-4: ${lr.getLockCause()}\"\n"
                 + "  echo \"Locked resource reservedBy 2-4: ${lr.getReservedBy()}\"\n"
@@ -1082,7 +1091,9 @@ public class LockStepTest extends LockStepTestBase {
                 + "  sleep 1\n"
                 + "  lock(label: 'label1', variable: 'someVar3') {\n"
                 + "    echo \"VAR3 IS $env.someVar3\"\n"
-                + "    lr = " + lmget + ".fromName(env.someVar3)\n"
+                + "    lr = "
+                + lmget
+                + ".fromName(env.someVar3)\n"
                 + "    echo \"Locked resource cause 3-2: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 3-2: ${lr.getReservedBy()}\"\n"
                 + "    echo \"Just sleeping...\"\n"
@@ -1099,8 +1110,8 @@ public class LockStepTest extends LockStepTestBase {
                 + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
                 + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
                 + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-            + "\necho \"Survived the test\"\n"
-            + "}", // timeout wrapper
+                + "\necho \"Survived the test\"\n"
+                + "}", // timeout wrapper
             false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
@@ -1129,8 +1140,9 @@ public class LockStepTest extends LockStepTestBase {
     // this line is noticed in log although it is there AFTER 1-4:
     j.assertLogNotContains("Locked resource cause 2-2", b1);
     j.assertLogNotContains("Locked resource cause 2-3", b1);
-    System.err.println("GOOD: Did not encounter Bug #1 " +
-        "(parallel p2 gets the lock on a still-reserved resource)!");
+    System.err.println(
+        "GOOD: Did not encounter Bug #1 "
+            + "(parallel p2 gets the lock on a still-reserved resource)!");
 
     j.waitForMessage("Locked resource cause 1-5", b1);
     // This line might not strictly be required,
@@ -1139,8 +1151,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    //j.assertLogNotContains("Locked resource cause 2-2", b1);
-    //j.assertLogNotContains("Locked resource cause 2-3", b1);
+    // j.assertLogNotContains("Locked resource cause 2-2", b1);
+    // j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1148,18 +1160,20 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-        j.waitForMessage("Locked resource cause 1-6", b1);
-        j.assertLogContains("Locked resource cause 2-2", b1);
+      j.waitForMessage("Locked resource cause 1-6", b1);
+      j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-        sawBug2a = true;
-        System.err.println("Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-        //System.err.println(t1.toString());
-        // throw t1;
+      sawBug2a = true;
+      System.err.println(
+          "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
+      // System.err.println(t1.toString());
+      // throw t1;
     }
     if (!sawBug2a) {
-        System.err.println("GOOD: Did not encounter Bug #2a " +
-            "(Parallel 2 did not start after Parallel 1 finished " +
-            "and resource later released)!");
+      System.err.println(
+          "GOOD: Did not encounter Bug #2a "
+              + "(Parallel 2 did not start after Parallel 1 finished "
+              + "and resource later released)!");
     }
 
     // If the bug is resolved, then by the time we get to 1-5
@@ -1167,23 +1181,23 @@ public class LockStepTest extends LockStepTestBase {
     // and so not locked by not-"null"; reservation should be away though
     boolean sawBug2b = false;
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
-    for (String line : new String[]{
-        "Locked resource cause 1-5: null",
-        "LRM seems stuck; trying to reserve/unreserve",
-        "Secondary lock trick"}
-    ) {
+    for (String line :
+        new String[] {
+          "Locked resource cause 1-5: null",
+          "LRM seems stuck; trying to reserve/unreserve",
+          "Secondary lock trick"
+        }) {
       try {
         j.assertLogNotContains(line, b1);
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        //System.err.println(t2.toString());
+        // System.err.println(t2.toString());
         // throw t2;
       }
     }
     if (!sawBug2b) {
-        System.err.println("GOOD: Did not encounter Bug #2b " +
-            "(LRM required un-stucking)!");
+      System.err.println("GOOD: Did not encounter Bug #2b " + "(LRM required un-stucking)!");
     }
 
     j.waitForMessage("Locked resource cause 2-2", b1);
@@ -1192,7 +1206,8 @@ public class LockStepTest extends LockStepTestBase {
 
     j.waitForMessage("Unlocking parallel closure 2", b1);
     j.assertLogNotContains("Locked resource cause 3-2", b1);
-    System.err.println("GOOD: lock#3 was NOT taken just after we un-locked closure 2 (keeping lock#2 reserved)");
+    System.err.println(
+        "GOOD: lock#3 was NOT taken just after we un-locked closure 2 (keeping lock#2 reserved)");
 
     // After 2-3 we lrm.recycle() the lock so it should
     // go to the next bidder
@@ -1208,7 +1223,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  //@Issue("JENKINS-XXXXX")
+  // @Issue("JENKINS-XXXXX")
   public void setReservedByInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -1226,11 +1241,13 @@ public class LockStepTest extends LockStepTestBase {
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
                 + "    echo \"VAR IS $env.LOCK_NAME\"\n"
-                + "    lr = " + lmget + ".fromName(env.LOCK_NAME)\n"
+                + "    lr = "
+                + lmget
+                + ".fromName(env.LOCK_NAME)\n"
                 + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
                 + "    lr.setReservedBy('test')\n"
-                //+ "    semaphore 'wait-inside'\n"
+                // + "    semaphore 'wait-inside'\n"
                 + "    echo \"Locked resource cause 1-2: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 1-2: ${lr.getReservedBy()}\"\n"
                 + "    echo \"Unlocking parallel closure 1\"\n"
@@ -1243,8 +1260,9 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
                 // Note: lr.reset() only nullifies the fields in LR instance
                 // but does not help a queue get moving
-                //+ "  echo \"Un-reserving Locked resource directly as `lr.reset()` and sleeping...\"\n"
-                //+ "  lr.reset()\n"
+                // + "  echo \"Un-reserving Locked resource directly as `lr.reset()` and
+                // sleeping...\"\n"
+                // + "  lr.reset()\n"
                 + "  echo \"Un-reserving Locked resource directly as `lr.recycle()` and sleeping...\"\n"
                 + "  lr.recycle()\n"
                 + "  sleep (5)\n"
@@ -1260,12 +1278,14 @@ public class LockStepTest extends LockStepTestBase {
                 + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
                 + "},\n"
                 + "p2: {\n"
-                //+ "  semaphore 'wait-outside'\n"
+                // + "  semaphore 'wait-outside'\n"
                 + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
                 + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
                 + "  lock(label: 'label1', variable: 'someVar2') {\n"
                 + "    echo \"VAR2 IS $env.someVar2\"\n"
-                + "    lr = " + lmget + ".fromName(env.someVar2)\n"
+                + "    lr = "
+                + lmget
+                + ".fromName(env.someVar2)\n"
                 + "    sleep (1)\n"
                 + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
                 + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
@@ -1284,8 +1304,8 @@ public class LockStepTest extends LockStepTestBase {
                 + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
                 + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
                 + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-            + "\necho \"Survived the test\"\n"
-            + "}", // timeout wrapper
+                + "\necho \"Survived the test\"\n"
+                + "}", // timeout wrapper
             false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
@@ -1314,8 +1334,9 @@ public class LockStepTest extends LockStepTestBase {
     // this line is noticed in log although it is there AFTER 1-4:
     j.assertLogNotContains("Locked resource cause 2-2", b1);
     j.assertLogNotContains("Locked resource cause 2-3", b1);
-    System.err.println("GOOD: Did not encounter Bug #1 " +
-        "(parallel p2 gets the lock on a still-reserved resource)!");
+    System.err.println(
+        "GOOD: Did not encounter Bug #1 "
+            + "(parallel p2 gets the lock on a still-reserved resource)!");
 
     j.waitForMessage("Locked resource cause 1-5", b1);
     // This line might not strictly be required,
@@ -1324,8 +1345,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    //j.assertLogNotContains("Locked resource cause 2-2", b1);
-    //j.assertLogNotContains("Locked resource cause 2-3", b1);
+    // j.assertLogNotContains("Locked resource cause 2-2", b1);
+    // j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1333,18 +1354,20 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-        j.waitForMessage("Locked resource cause 1-6", b1);
-        j.assertLogContains("Locked resource cause 2-2", b1);
+      j.waitForMessage("Locked resource cause 1-6", b1);
+      j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-        sawBug2a = true;
-        System.err.println("Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-        //System.err.println(t1.toString());
-        // throw t1;
+      sawBug2a = true;
+      System.err.println(
+          "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
+      // System.err.println(t1.toString());
+      // throw t1;
     }
     if (!sawBug2a) {
-        System.err.println("GOOD: Did not encounter Bug #2a " +
-            "(Parallel 2 did not start after Parallel 1 finished " +
-            "and resource later released)!");
+      System.err.println(
+          "GOOD: Did not encounter Bug #2a "
+              + "(Parallel 2 did not start after Parallel 1 finished "
+              + "and resource later released)!");
     }
 
     // If the bug is resolved, then by the time we get to 1-5
@@ -1352,37 +1375,37 @@ public class LockStepTest extends LockStepTestBase {
     // and so not locked by not-"null"; reservation should be away though
     boolean sawBug2b = false;
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
-    for (String line : new String[]{
-        "Locked resource cause 1-5: null",
-        "LRM seems stuck; trying to reserve/unreserve",
-        "Secondary lock trick"}
-    ) {
+    for (String line :
+        new String[] {
+          "Locked resource cause 1-5: null",
+          "LRM seems stuck; trying to reserve/unreserve",
+          "Secondary lock trick"
+        }) {
       try {
         j.assertLogNotContains(line, b1);
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        //System.err.println(t2.toString());
+        // System.err.println(t2.toString());
         // throw t2;
       }
     }
     if (!sawBug2b) {
-        System.err.println("GOOD: Did not encounter Bug #2b " +
-            "(LRM required un-stucking)!");
+      System.err.println("GOOD: Did not encounter Bug #2b " + "(LRM required un-stucking)!");
     }
 
-/*
-    j.assertLogContains("Locked resource cause 1-5: null", b1);
-    j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
-    try {
-        j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
-        j.assertLogNotContains("Secondary lock trick", b1);
-    } catch (java.lang.AssertionError t2) {
-        System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
-        //System.err.println(t2.toString());
-        // throw t2;
-    }
-*/
+    /*
+        j.assertLogContains("Locked resource cause 1-5: null", b1);
+        j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
+        try {
+            j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
+            j.assertLogNotContains("Secondary lock trick", b1);
+        } catch (java.lang.AssertionError t2) {
+            System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
+            //System.err.println(t2.toString());
+            // throw t2;
+        }
+    */
 
     j.waitForMessage("Locked resource cause 2-2", b1);
     j.assertLogContains("Locked resource cause 1-5", b1);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -1146,7 +1146,7 @@ public class LockStepTest extends LockStepTestBase {
     // to be un-reserved, resources already looping waiting
     // for it (after the fix for Bug #1) are not "notified".
     // Adding and removing the resource helps unblock this.
-    Boolean sawBug2a = false;
+    boolean sawBug2a = false;
     try {
         j.waitForMessage("Locked resource cause 1-6", b1);
         j.assertLogContains("Locked resource cause 2-2", b1);
@@ -1165,7 +1165,7 @@ public class LockStepTest extends LockStepTestBase {
     // If the bug is resolved, then by the time we get to 1-5
     // the resource should be taken by the other parallel stage
     // and so not locked by not-"null"; reservation should be away though
-    Boolean sawBug2b = false;
+    boolean sawBug2b = false;
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line : new String[]{
         "Locked resource cause 1-5: null",
@@ -1331,7 +1331,7 @@ public class LockStepTest extends LockStepTestBase {
     // to be un-reserved, resources already looping waiting
     // for it (after the fix for Bug #1) are not "notified".
     // Adding and removing the resource helps unblock this.
-    Boolean sawBug2a = false;
+    boolean sawBug2a = false;
     try {
         j.waitForMessage("Locked resource cause 1-6", b1);
         j.assertLogContains("Locked resource cause 2-2", b1);
@@ -1350,7 +1350,7 @@ public class LockStepTest extends LockStepTestBase {
     // If the bug is resolved, then by the time we get to 1-5
     // the resource should be taken by the other parallel stage
     // and so not locked by not-"null"; reservation should be away though
-    Boolean sawBug2b = false;
+    boolean sawBug2b = false;
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line : new String[]{
         "Locked resource cause 1-5: null",

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -34,8 +34,8 @@ public class LockStepTest extends LockStepTestBase {
   public void autoCreateResource() throws Exception {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	echo 'Resource locked'\n" + "}\n" + "echo 'Finish'", true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	echo 'Resource locked'\n" + "}\n" + "echo 'Finish'", true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.SUCCESS, b1);
@@ -48,8 +48,8 @@ public class LockStepTest extends LockStepTestBase {
   public void lockNothing() throws Exception {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock() {\n" + "  echo 'Nothing locked.'\n" + "}\n" + "echo 'Finish'", true));
+      new CpsFlowDefinition(
+        "lock() {\n" + "  echo 'Nothing locked.'\n" + "}\n" + "echo 'Finish'", true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.SUCCESS, b1);
@@ -61,12 +61,12 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'var') {\n"
-                + "	echo \"Resource locked: ${env.var}\"\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var') {\n"
+          + "	echo \"Resource locked: ${env.var}\"\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.SUCCESS, b1);
@@ -84,12 +84,12 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', quantity: 2) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', quantity: 2) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
@@ -131,12 +131,12 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', quantity: 2) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', quantity: 2) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
@@ -148,12 +148,12 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', quantity: 1) {\n"
-                + "	semaphore 'wait-inside-quantity1'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', quantity: 1) {\n"
+          + "	semaphore 'wait-inside-quantity1'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     // While 2 continues waiting, 3 can continue directly
     SemaphoreStep.waitForStart("wait-inside-quantity1/1", b3);
@@ -185,9 +185,9 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
+      new CpsFlowDefinition(
             "lock(label: 'label1') {\n" + "	semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
-            true));
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
@@ -196,12 +196,12 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', quantity: 2) {\n"
-                + "	semaphore 'wait-inside-quantity2'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', quantity: 2) {\n"
+          + "	semaphore 'wait-inside-quantity2'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     // Ensure that b2 reaches the lock before b3
     j.waitForMessage("[Label: label1, Quantity: 2] is locked, waiting...", b2);
@@ -210,12 +210,12 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', quantity: 1) {\n"
-                + "	semaphore 'wait-inside-quantity1'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', quantity: 1) {\n"
+          + "	semaphore 'wait-inside-quantity1'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1, Quantity: 1] is locked, waiting...", b3);
     j.waitForMessage("Found 0 available resource(s). Waiting for correct amount: 1.", b3);
@@ -247,9 +247,9 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
@@ -283,12 +283,12 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(resource: 'resource1', inversePrecedence: true) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(resource: 'resource1', inversePrecedence: true) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
@@ -321,18 +321,18 @@ public class LockStepTest extends LockStepTestBase {
   public void parallelLock() throws Exception {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "parallel a: {\n"
-                + "	semaphore 'before-a'\n"
-                + "	lock('resource1') {\n"
-                + "		semaphore 'inside-a'\n"
-                + "	}\n"
-                + "}, b: {\n"
-                + "	lock('resource1') {\n"
-                + "		semaphore 'wait-b'\n"
-                + "	}\n"
-                + "}\n",
-            true));
+      new CpsFlowDefinition(
+        "parallel a: {\n"
+          + "	semaphore 'before-a'\n"
+          + "	lock('resource1') {\n"
+          + "		semaphore 'inside-a'\n"
+          + "	}\n"
+          + "}, b: {\n"
+          + "	lock('resource1') {\n"
+          + "		semaphore 'wait-b'\n"
+          + "	}\n"
+          + "}\n",
+        true));
 
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-b/1", b1);
@@ -374,15 +374,15 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p1 = j.jenkins.createProject(WorkflowJob.class, "p");
     p1.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') { echo 'locked!'; semaphore 'wait-inside' }", true));
+      new CpsFlowDefinition(
+        "lock('resource1') { echo 'locked!'; semaphore 'wait-inside' }", true));
     WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
     j.waitForMessage("locked!", b1);
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
+      new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     // Make sure that b2 is blocked on b1's lock.
     j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
@@ -392,7 +392,7 @@ public class LockStepTest extends LockStepTestBase {
     // unlock.
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
+      new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
@@ -419,13 +419,13 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "retry(99) {\n"
-                + "    lock('resource1') {\n"
-                + "        semaphore('wait-inside')\n"
-                + "     }\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "retry(99) {\n"
+          + "    lock('resource1') {\n"
+          + "        semaphore('wait-inside')\n"
+          + "     }\n"
+          + "}",
+        true));
 
     JenkinsRule.WebClient wc = j.createWebClient();
 
@@ -434,7 +434,7 @@ public class LockStepTest extends LockStepTestBase {
       WorkflowRun rNext = p.scheduleBuild2(0).waitForStart();
       if (prevBuild != null) {
         j.waitForMessage(
-            "[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
+          "[resource1] is locked by " + prevBuild.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         TestHelpers.clickButton(wc, "unlock");
       }
@@ -460,15 +460,15 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource2");
     WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "j");
     job.setDefinition(
-        new CpsFlowDefinition(
-            "lock(resource: 'resource1') {\n"
-                + "    semaphore 'wait-inside-1'\n"
-                + "}\n"
-                + "lock(resource: 'resource2') { \n"
-                + "    echo 'Entering semaphore now'\n"
-                + "    semaphore 'wait-inside-2'\n"
-                + "}\n",
-            true));
+      new CpsFlowDefinition(
+        "lock(resource: 'resource1') {\n"
+          + "    semaphore 'wait-inside-1'\n"
+          + "}\n"
+          + "lock(resource: 'resource2') { \n"
+          + "    echo 'Entering semaphore now'\n"
+          + "    semaphore 'wait-inside-2'\n"
+          + "}\n",
+        true));
 
     List<WorkflowRun> nextRuns = new ArrayList<>();
 
@@ -477,7 +477,7 @@ public class LockStepTest extends LockStepTestBase {
       WorkflowRun rNext = job.scheduleBuild2(0).waitForStart();
       if (toUnlock != null) {
         j.waitForMessage(
-            "[resource1] is locked by " + toUnlock.getFullDisplayName() + ", waiting...", rNext);
+          "[resource1] is locked by " + toUnlock.getFullDisplayName() + ", waiting...", rNext);
         isPaused(rNext, 1, 1);
         SemaphoreStep.success("wait-inside-1/" + i, null);
       }
@@ -510,13 +510,13 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "retry(99) {\n"
-                + "    lock('resource1') {\n"
-                + "        semaphore('wait-inside')\n"
-                + "     }\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "retry(99) {\n"
+          + "    lock('resource1') {\n"
+          + "        semaphore('wait-inside')\n"
+          + "     }\n"
+          + "}",
+        true));
 
     WorkflowRun r = p.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource1] is locked, waiting...", r);
@@ -558,27 +558,27 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     final WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "import java.util.Random; \n"
-                + "Random random = new Random(0);\n"
-                + "lock(label: 'label1') {\n"
-                + "  echo 'Resource locked'\n"
-                + "  sleep random.nextInt(10)*100\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "import java.util.Random; \n"
+          + "Random random = new Random(0);\n"
+          + "lock(label: 'label1') {\n"
+          + "  echo 'Resource locked'\n"
+          + "  sleep random.nextInt(10)*100\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     final CyclicBarrier barrier = new CyclicBarrier(51);
     for (int i = 0; i < 50; i++) {
       Thread thread =
-          new Thread(
-              () -> {
-                try {
-                  barrier.await();
-                  p.scheduleBuild2(0).waitForStart();
-                } catch (Exception e) {
-                  System.err.println("Failed to start pipeline job");
-                }
-              });
+        new Thread(
+          () -> {
+            try {
+              barrier.await();
+              p.scheduleBuild2(0).waitForStart();
+            } catch (Exception e) {
+              System.err.println("Failed to start pipeline job");
+            }
+          });
       thread.start();
     }
     barrier.await();
@@ -590,29 +590,29 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResource("resource1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(resource: 'resource1', extra: [[resource: 'resource2']]) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(resource: 'resource1', extra: [[resource: 'resource2']]) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource2') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock('resource2') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource2] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
     isPaused(b3, 1, 1);
@@ -641,29 +641,29 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', extra: [[resource: 'resource1']]) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', extra: [[resource: 'resource1']]) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
+      new CpsFlowDefinition(
             "lock(label: 'label1') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
-            true));
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1] is locked, waiting...", b3);
     isPaused(b3, 1, 1);
@@ -692,29 +692,29 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource3", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', extra: [[resource: 'resource1']]) {\n"
-                + "	semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', extra: [[resource: 'resource1']]) {\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock('resource1') {\n" + "	semaphore 'wait-inside-p2'\n" + "}\n" + "echo 'Finish'",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
     isPaused(b2, 1, 1);
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
+      new CpsFlowDefinition(
             "lock(label: 'label1') {\n" + "	semaphore 'wait-inside-p3'\n" + "}\n" + "echo 'Finish'",
-            true));
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1] is locked, waiting...", b3);
     isPaused(b3, 1, 1);
@@ -747,29 +747,29 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource4", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(variable: 'var', extra: [[resource: 'resource4'], [resource: 'resource2'], "
-                + "[label: 'label1', quantity: 2]]) {\n"
-                + "  def lockedResources = env.var.split(',').sort()\n"
-                + "  echo \"Resources locked: ${lockedResources}\"\n"
-                + "  semaphore 'wait-inside'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(variable: 'var', extra: [[resource: 'resource4'], [resource: 'resource2'], "
+          + "[label: 'label1', quantity: 2]]) {\n"
+          + "  def lockedResources = env.var.split(',').sort()\n"
+          + "  echo \"Resources locked: ${lockedResources}\"\n"
+          + "  semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     // #1 should lock as few resources as possible
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'var', quantity: 3) {\n"
-                + "	def lockedResources = env.var.split(',').sort()\n"
-                + "	echo \"Resources locked: ${lockedResources}\"\n"
-                + "	semaphore 'wait-inside-quantity3'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var', quantity: 3) {\n"
+          + "	def lockedResources = env.var.split(',').sort()\n"
+          + "	echo \"Resources locked: ${lockedResources}\"\n"
+          + "	semaphore 'wait-inside-quantity3'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     j.waitForMessage("[Label: label1, Quantity: 3] is locked, waiting...", b2);
     j.waitForMessage("Found 2 available resource(s). Waiting for correct amount: 3.", b2);
@@ -777,14 +777,14 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
     p3.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'var', quantity: 2) {\n"
-                + "	def lockedResources = env.var.split(',').sort()\n"
-                + "	echo \"Resources locked: ${lockedResources}\"\n"
-                + "	semaphore 'wait-inside-quantity2'\n"
-                + "}\n"
-                + "echo 'Finish'",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'var', quantity: 2) {\n"
+          + "	def lockedResources = env.var.split(',').sort()\n"
+          + "	echo \"Resources locked: ${lockedResources}\"\n"
+          + "	semaphore 'wait-inside-quantity2'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
     WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
     // While 2 continues waiting, 3 can continue directly
     SemaphoreStep.waitForStart("wait-inside-quantity2/1", b3);
@@ -797,7 +797,7 @@ public class LockStepTest extends LockStepTestBase {
     // Unlock resources
     SemaphoreStep.success("wait-inside/1", null);
     j.waitForMessage(
-        "Lock released on resource [{resource4},{resource2},{Label: label1, Quantity: 2}]", b1);
+      "Lock released on resource [{resource4},{resource2},{Label: label1, Quantity: 2}]", b1);
     j.assertLogContains("Resources locked: [resource2, resource4]", b1);
     isPaused(b1, 1, 0);
 
@@ -869,22 +869,22 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'someVar') {\n"
-                + "  semaphore 'wait-inside'\n"
-                + "  echo \"VAR IS $env.someVar\"\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar') {\n"
+          + "  semaphore 'wait-inside'\n"
+          + "  echo \"VAR IS $env.someVar\"\n"
+          + "}",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-inside/1", b1);
 
     WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
     p2.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'someVar2') {\n"
-                + "  echo \"VAR2 IS $env.someVar2\"\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar2') {\n"
+          + "  echo \"VAR2 IS $env.someVar2\"\n"
+          + "}",
+        true));
     WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
     j.waitForMessage("is locked, waiting...", b2);
     isPaused(b2, 1, 1);
@@ -910,20 +910,20 @@ public class LockStepTest extends LockStepTestBase {
     LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "parallel p1: {\n"
-                + "  lock(label: 'label1', variable: 'someVar') {\n"
-                + "    semaphore 'wait-inside'\n"
-                + "    echo \"VAR IS $env.someVar\"\n"
-                + "  }\n"
-                + "},\n"
-                + "p2: {\n"
-                + "  semaphore 'wait-outside'\n"
-                + "  lock(label: 'label1', variable: 'someVar2') {\n"
-                + "    echo \"VAR2 IS $env.someVar2\"\n"
-                + "  }\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "parallel p1: {\n"
+          + "  lock(label: 'label1', variable: 'someVar') {\n"
+          + "    semaphore 'wait-inside'\n"
+          + "    echo \"VAR IS $env.someVar\"\n"
+          + "  }\n"
+          + "},\n"
+          + "p2: {\n"
+          + "  semaphore 'wait-outside'\n"
+          + "  lock(label: 'label1', variable: 'someVar2') {\n"
+          + "    echo \"VAR2 IS $env.someVar2\"\n"
+          + "  }\n"
+          + "}",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     SemaphoreStep.waitForStart("wait-outside/1", b1);
     SemaphoreStep.waitForStart("wait-inside/1", b1);
@@ -955,11 +955,11 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(label: 'label1', variable: 'someVar') {\n"
-                + "  echo \"VAR IS $env.someVar\"\n"
-                + "}",
-            true));
+      new CpsFlowDefinition(
+        "lock(label: 'label1', variable: 'someVar') {\n"
+          + "  echo \"VAR IS $env.someVar\"\n"
+          + "}",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
     j.waitForMessage("is locked, waiting...", b1);
@@ -971,7 +971,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  //@Issue("JENKINS-XXXXX")
+  // @Issue("JENKINS-XXXXX")
   public void reserveInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -984,135 +984,135 @@ public class LockStepTest extends LockStepTestBase {
     String lmget = "org.jenkins.plugins.lockableresources.LockableResourcesManager.get()";
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "reserveInsideLockHonoured");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "timeout(2) {\n"
-                + "parallel p1: {\n"
-                + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
-                + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
-                + "    echo \"VAR IS $env.LOCK_NAME\"\n"
+      new CpsFlowDefinition(
+        "timeout(2) {\n"
+          + "parallel p1: {\n"
+          + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
+          + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
+          + "    echo \"VAR IS $env.LOCK_NAME\"\n"
                 + "    lr = "
                 + lmget
                 + ".fromName(env.LOCK_NAME)\n"
-                + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
+          + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
                 + "    def res = "
                 + lmget
                 + ".reserve([lr], 'test2a')\n"
-                //+ "    semaphore 'wait-inside'\n"
-                + "    echo \"Locked resource cause 1-2a: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 1-2a: ${lr.getReservedBy()}\"\n"
-                + "    if (!res) {\n"
-                + "        echo \"LockableResourcesManager did not reserve an already locked resource; hack it!\"\n"
-                + "        lr.setReservedBy('test2b')\n"
-                + "        echo \"Locked resource cause 1-2b: ${lr.getLockCause()}\"\n"
-                + "        echo \"Locked resource reservedBy 1-2b: ${lr.getReservedBy()}\"\n"
-                + "    }\n"
-                + "    echo \"Unlocking parallel closure 1\"\n"
-                + "  }\n"
-                + "  echo \"Locked resource cause 1-3 (after unlock): ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-3: ${lr.getReservedBy()}\"\n"
-                + "  echo \"Ended locked parallel closure 1 with resource reserved, sleeping...\"\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-4: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
-                + "  echo \"Resetting Locked resource via LRM and sleeping ...\"\n"
+          //+ "    semaphore 'wait-inside'\n"
+          + "    echo \"Locked resource cause 1-2a: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 1-2a: ${lr.getReservedBy()}\"\n"
+          + "    if (!res) {\n"
+          + "        echo \"LockableResourcesManager did not reserve an already locked resource; hack it!\"\n"
+          + "        lr.setReservedBy('test2b')\n"
+          + "        echo \"Locked resource cause 1-2b: ${lr.getLockCause()}\"\n"
+          + "        echo \"Locked resource reservedBy 1-2b: ${lr.getReservedBy()}\"\n"
+          + "    }\n"
+          + "    echo \"Unlocking parallel closure 1\"\n"
+          + "  }\n"
+          + "  echo \"Locked resource cause 1-3 (after unlock): ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-3: ${lr.getReservedBy()}\"\n"
+          + "  echo \"Ended locked parallel closure 1 with resource reserved, sleeping...\"\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-4: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
+          + "  echo \"Resetting Locked resource via LRM and sleeping ...\"\n"
                 + "  "
                 + lmget
                 + ".reset([lr])\n"
-                + "  sleep (5)\n"
-                + "  echo \"Un-reserving Locked resource via LRM and sleeping...\"\n"
+          + "  sleep (5)\n"
+          + "  echo \"Un-reserving Locked resource via LRM and sleeping...\"\n"
                 + "  "
                 + lmget
                 + ".unreserve([lr])\n"
-                + "  sleep (5)\n"
-                // Note: the unlock attempt here might steal this resource
-                // from another parallel stage, so we don't do it:
-                //+ "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
-                //+ "  " + lmget + ".unlock([lr], null)\n"
-                //+ "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
-                + "  sleep (5)\n"
-                + "  if (lr.getLockCause() == null) {\n"
-                + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by LRM methods\"\n"
-                //+ "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
+          + "  sleep (5)\n"
+          // Note: the unlock attempt here might steal this resource
+          // from another parallel stage, so we don't do it:
+          //+ "  echo \"Un-locking Locked resource via LRM and sleeping...\"\n"
+          //+ "  " + lmget + ".unlock([lr], null)\n"
+          //+ "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
+          + "  sleep (5)\n"
+          + "  if (lr.getLockCause() == null) {\n"
+          + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by LRM methods\"\n"
+          //+ "    lock(label: 'label1') { echo \"Secondary lock trick\" }\n"
                 + "    if ("
                 + lmget
                 + ".reserve([lr], 'unstucker')) {\n"
-                + "        echo \"Secondary lock trick\"\n"
+          + "        echo \"Secondary lock trick\"\n"
                 + "        "
                 + lmget
                 + ".unreserve([lr])\n"
-                + "    } else { echo \"Could not reserve by LRM methods as 'unstucker'\" }\n"
-                + "  }\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-6: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
-                + "},\n"
-                + "p2: {\n"
-                //+ "  semaphore 'wait-outside'\n"
-                + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
-                + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
-                + "  lock(label: 'label1', variable: 'someVar2') {\n"
-                + "    echo \"VAR2 IS $env.someVar2\"\n"
+          + "    } else { echo \"Could not reserve by LRM methods as 'unstucker'\" }\n"
+          + "  }\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-6: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
+          + "},\n"
+          + "p2: {\n"
+          //+ "  semaphore 'wait-outside'\n"
+          + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
+          + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
+          + "  lock(label: 'label1', variable: 'someVar2') {\n"
+          + "    echo \"VAR2 IS $env.someVar2\"\n"
                 + "    lr = "
                 + lmget
                 + ".fromName(env.someVar2)\n"
-                + "    sleep (1)\n"
-                + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
-                + "    echo \"Setting (directly) and dropping (via LRM) a reservation on locked resource\"\n"
-                + "    lr.reserve('test2-1')\n"
-                + "    sleep (3)\n"
+          + "    sleep (1)\n"
+          + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
+          + "    echo \"Setting (directly) and dropping (via LRM) a reservation on locked resource\"\n"
+          + "    lr.reserve('test2-1')\n"
+          + "    sleep (3)\n"
                 + "    "
                 + lmget
                 + ".unreserve([lr])\n"
-                + "    echo \"Just sleeping...\"\n"
-                + "    sleep (20)\n"
-                + "    echo \"Setting (directly) a reservation on locked resource\"\n"
-                + "    lr.reserve('test2-2')\n"
-                + "    echo \"Unlocking parallel closure 2\"\n"
-                + "  }\n"
-                + "  echo \"Locked resource cause 2-3: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 2-3: ${lr.getReservedBy()}\"\n"
-                + "  sleep (5)\n"
-                + "  echo \"Recycling (via LRM) the reserved not-locked resource\"\n"
+          + "    echo \"Just sleeping...\"\n"
+          + "    sleep (20)\n"
+          + "    echo \"Setting (directly) a reservation on locked resource\"\n"
+          + "    lr.reserve('test2-2')\n"
+          + "    echo \"Unlocking parallel closure 2\"\n"
+          + "  }\n"
+          + "  echo \"Locked resource cause 2-3: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 2-3: ${lr.getReservedBy()}\"\n"
+          + "  sleep (5)\n"
+          + "  echo \"Recycling (via LRM) the reserved not-locked resource\"\n"
                 + "  "
                 + lmget
                 + ".recycle([lr])\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 2-4: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 2-4: ${lr.getReservedBy()}\"\n"
-                + "},\n"
-                // Test that reserve/unreserve in p2 did not "allow" p3 to kidnap the lock:
-                + "p3: {\n"
-                + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
-                + "  echo \"Locked resource cause 3-1: not locked yet\"\n"
-                + "  sleep 1\n"
-                + "  lock(label: 'label1', variable: 'someVar3') {\n"
-                + "    echo \"VAR3 IS $env.someVar3\"\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 2-4: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 2-4: ${lr.getReservedBy()}\"\n"
+          + "},\n"
+          // Test that reserve/unreserve in p2 did not "allow" p3 to kidnap the lock:
+          + "p3: {\n"
+          + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
+          + "  echo \"Locked resource cause 3-1: not locked yet\"\n"
+          + "  sleep 1\n"
+          + "  lock(label: 'label1', variable: 'someVar3') {\n"
+          + "    echo \"VAR3 IS $env.someVar3\"\n"
                 + "    lr = "
                 + lmget
                 + ".fromName(env.someVar3)\n"
-                + "    echo \"Locked resource cause 3-2: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 3-2: ${lr.getReservedBy()}\"\n"
-                + "    echo \"Just sleeping...\"\n"
-                + "    sleep (10)\n"
-                + "    echo \"Unlocking parallel closure 3\"\n"
-                + "  }\n"
-                + "  echo \"Locked resource cause 3-3: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 3-3: ${lr.getReservedBy()}\"\n"
-                + "},\n"
-                // Add some pressure to try for race conditions:
-                + "p4: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
-                + "p5: { sleep 2; lock(label: 'label1') { sleep 3 } },\n"
-                + "p6: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
-                + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
-                + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
-                + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-            + "\necho \"Survived the test\"\n"
-            + "}", // timeout wrapper
-            false));
+          + "    echo \"Locked resource cause 3-2: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 3-2: ${lr.getReservedBy()}\"\n"
+          + "    echo \"Just sleeping...\"\n"
+          + "    sleep (10)\n"
+          + "    echo \"Unlocking parallel closure 3\"\n"
+          + "  }\n"
+          + "  echo \"Locked resource cause 3-3: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 3-3: ${lr.getReservedBy()}\"\n"
+          + "},\n"
+          // Add some pressure to try for race conditions:
+          + "p4: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
+          + "p5: { sleep 2; lock(label: 'label1') { sleep 3 } },\n"
+          + "p6: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
+          + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
+          + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
+          + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
+          + "\necho \"Survived the test\"\n"
+          + "}", // timeout wrapper
+        false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
     j.waitForMessage("Locked resource cause 1-1", b1);
@@ -1151,8 +1151,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    //j.assertLogNotContains("Locked resource cause 2-2", b1);
-    //j.assertLogNotContains("Locked resource cause 2-3", b1);
+    // j.assertLogNotContains("Locked resource cause 2-2", b1);
+    // j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1160,14 +1160,14 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-        j.waitForMessage("Locked resource cause 1-6", b1);
-        j.assertLogContains("Locked resource cause 2-2", b1);
+      j.waitForMessage("Locked resource cause 1-6", b1);
+      j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-        sawBug2a = true;
+      sawBug2a = true;
       System.err.println(
           "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-        //System.err.println(t1.toString());
-        // throw t1;
+      //System.err.println(t1.toString());
+      // throw t1;
     }
     if (!sawBug2a) {
       System.err.println(
@@ -1183,8 +1183,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line :
         new String[] {
-        "Locked resource cause 1-5: null",
-        "LRM seems stuck; trying to reserve/unreserve",
+      "Locked resource cause 1-5: null",
+      "LRM seems stuck; trying to reserve/unreserve",
           "Secondary lock trick"
         }) {
       try {
@@ -1192,7 +1192,7 @@ public class LockStepTest extends LockStepTestBase {
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        //System.err.println(t2.toString());
+        // System.err.println(t2.toString());
         // throw t2;
       }
     }
@@ -1223,7 +1223,7 @@ public class LockStepTest extends LockStepTestBase {
   }
 
   @Test
-  //@Issue("JENKINS-XXXXX")
+  // @Issue("JENKINS-XXXXX")
   public void setReservedByInsideLockHonoured() throws Exception {
     // Use-case is a job keeping the resource reserved so it can use
     // it in other stages and free it later, not all in one closure
@@ -1235,78 +1235,78 @@ public class LockStepTest extends LockStepTestBase {
     String lmget = "org.jenkins.plugins.lockableresources.LockableResourcesManager.get()";
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "setReservedByInsideLockHonoured");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "timeout(2) {\n"
-                + "parallel p1: {\n"
-                + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
-                + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
-                + "    echo \"VAR IS $env.LOCK_NAME\"\n"
+      new CpsFlowDefinition(
+        "timeout(2) {\n"
+          + "parallel p1: {\n"
+          + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
+          + "  lock(label: 'label1', variable: 'LOCK_NAME') {\n"
+          + "    echo \"VAR IS $env.LOCK_NAME\"\n"
                 + "    lr = "
                 + lmget
                 + ".fromName(env.LOCK_NAME)\n"
-                + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
-                + "    lr.setReservedBy('test')\n"
-                //+ "    semaphore 'wait-inside'\n"
-                + "    echo \"Locked resource cause 1-2: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 1-2: ${lr.getReservedBy()}\"\n"
-                + "    echo \"Unlocking parallel closure 1\"\n"
-                + "  }\n"
-                + "  echo \"Locked resource cause 1-3 (after unlock): ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-3: ${lr.getReservedBy()}\"\n"
-                + "  echo \"Ended locked parallel closure 1 with resource reserved, sleeping...\"\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-4: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
-                // Note: lr.reset() only nullifies the fields in LR instance
-                // but does not help a queue get moving
+          + "    echo \"Locked resource cause 1-1: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 1-1: ${lr.getReservedBy()}\"\n"
+          + "    lr.setReservedBy('test')\n"
+          //+ "    semaphore 'wait-inside'\n"
+          + "    echo \"Locked resource cause 1-2: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 1-2: ${lr.getReservedBy()}\"\n"
+          + "    echo \"Unlocking parallel closure 1\"\n"
+          + "  }\n"
+          + "  echo \"Locked resource cause 1-3 (after unlock): ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-3: ${lr.getReservedBy()}\"\n"
+          + "  echo \"Ended locked parallel closure 1 with resource reserved, sleeping...\"\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-4: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-4: ${lr.getReservedBy()}\"\n"
+          // Note: lr.reset() only nullifies the fields in LR instance
+          // but does not help a queue get moving
                 // + "  echo \"Un-reserving Locked resource directly as `lr.reset()` and
                 // sleeping...\"\n"
-                //+ "  lr.reset()\n"
-                + "  echo \"Un-reserving Locked resource directly as `lr.recycle()` and sleeping...\"\n"
-                + "  lr.recycle()\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
-                + "  sleep (5)\n"
-                + "  if (lr.getLockCause() == null) {\n"
-                + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by lock step\"\n"
-                + "    lock(label: 'label1', skipIfLocked: true) { echo \"Secondary lock trick\" }\n"
-                + "  }\n"
-                + "  sleep (5)\n"
-                + "  echo \"Locked resource cause 1-6: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
-                + "},\n"
-                + "p2: {\n"
-                //+ "  semaphore 'wait-outside'\n"
-                + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
-                + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
-                + "  lock(label: 'label1', variable: 'someVar2') {\n"
-                + "    echo \"VAR2 IS $env.someVar2\"\n"
+          //+ "  lr.reset()\n"
+          + "  echo \"Un-reserving Locked resource directly as `lr.recycle()` and sleeping...\"\n"
+          + "  lr.recycle()\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-5: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-5: ${lr.getReservedBy()}\"\n"
+          + "  sleep (5)\n"
+          + "  if (lr.getLockCause() == null) {\n"
+          + "    echo \"LRM seems stuck; trying to reserve/unreserve this resource by lock step\"\n"
+          + "    lock(label: 'label1', skipIfLocked: true) { echo \"Secondary lock trick\" }\n"
+          + "  }\n"
+          + "  sleep (5)\n"
+          + "  echo \"Locked resource cause 1-6: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 1-6: ${lr.getReservedBy()}\"\n"
+          + "},\n"
+          + "p2: {\n"
+          //+ "  semaphore 'wait-outside'\n"
+          + "  org.jenkins.plugins.lockableresources.LockableResource lr = null\n"
+          + "  echo \"Locked resource cause 2-1: not locked yet\"\n"
+          + "  lock(label: 'label1', variable: 'someVar2') {\n"
+          + "    echo \"VAR2 IS $env.someVar2\"\n"
                 + "    lr = "
                 + lmget
                 + ".fromName(env.someVar2)\n"
-                + "    sleep (1)\n"
-                + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
-                + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
-                + "    echo \"Just sleeping...\"\n"
-                + "    sleep (20)\n"
-                + "    echo \"Unlocking parallel closure 2\"\n"
-                + "  }\n"
-                + "  echo \"Locked resource cause 2-3: ${lr.getLockCause()}\"\n"
-                + "  echo \"Locked resource reservedBy 2-3: ${lr.getReservedBy()}\"\n"
-                + "},\n"
-                // Add some pressure to try for race conditions:
-                + "p3: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
-                + "p4: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
-                + "p5: { sleep 2; lock(label: 'label1') { sleep 3 } },\n"
-                + "p6: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
-                + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
-                + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
-                + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
-            + "\necho \"Survived the test\"\n"
-            + "}", // timeout wrapper
-            false));
+          + "    sleep (1)\n"
+          + "    echo \"Locked resource cause 2-2: ${lr.getLockCause()}\"\n"
+          + "    echo \"Locked resource reservedBy 2-2: ${lr.getReservedBy()}\"\n"
+          + "    echo \"Just sleeping...\"\n"
+          + "    sleep (20)\n"
+          + "    echo \"Unlocking parallel closure 2\"\n"
+          + "  }\n"
+          + "  echo \"Locked resource cause 2-3: ${lr.getLockCause()}\"\n"
+          + "  echo \"Locked resource reservedBy 2-3: ${lr.getReservedBy()}\"\n"
+          + "},\n"
+          // Add some pressure to try for race conditions:
+          + "p3: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
+          + "p4: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
+          + "p5: { sleep 2; lock(label: 'label1') { sleep 3 } },\n"
+          + "p6: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
+          + "p7: { sleep 2; lock(label: 'label1') { sleep 1 } },\n"
+          + "p8: { sleep 2; lock(label: 'label1') { sleep 2 } },\n"
+          + "p9: { sleep 2; lock(label: 'label1') { sleep 1 } }\n"
+          + "\necho \"Survived the test\"\n"
+          + "}", // timeout wrapper
+        false));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 
     j.waitForMessage("Locked resource cause 1-1", b1);
@@ -1345,8 +1345,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource cause 2-1", b1);
     // Here the other parallel stage may have already started
     // (we try to recycle the resource between 1-4 and 1-5):
-    //j.assertLogNotContains("Locked resource cause 2-2", b1);
-    //j.assertLogNotContains("Locked resource cause 2-3", b1);
+    // j.assertLogNotContains("Locked resource cause 2-2", b1);
+    // j.assertLogNotContains("Locked resource cause 2-3", b1);
 
     // Bug #2 happens here: even after the resource is known
     // to be un-reserved, resources already looping waiting
@@ -1354,14 +1354,14 @@ public class LockStepTest extends LockStepTestBase {
     // Adding and removing the resource helps unblock this.
     boolean sawBug2a = false;
     try {
-        j.waitForMessage("Locked resource cause 1-6", b1);
-        j.assertLogContains("Locked resource cause 2-2", b1);
+      j.waitForMessage("Locked resource cause 1-6", b1);
+      j.assertLogContains("Locked resource cause 2-2", b1);
     } catch (java.lang.AssertionError t1) {
-        sawBug2a = true;
+      sawBug2a = true;
       System.err.println(
           "Bug #2a (Parallel 2 did not start after Parallel 1 finished and resource later released) currently tolerated");
-        //System.err.println(t1.toString());
-        // throw t1;
+      //System.err.println(t1.toString());
+      // throw t1;
     }
     if (!sawBug2a) {
       System.err.println(
@@ -1377,8 +1377,8 @@ public class LockStepTest extends LockStepTestBase {
     j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
     for (String line :
         new String[] {
-        "Locked resource cause 1-5: null",
-        "LRM seems stuck; trying to reserve/unreserve",
+      "Locked resource cause 1-5: null",
+      "LRM seems stuck; trying to reserve/unreserve",
           "Secondary lock trick"
         }) {
       try {
@@ -1386,7 +1386,7 @@ public class LockStepTest extends LockStepTestBase {
       } catch (java.lang.AssertionError t2) {
         sawBug2b = true;
         System.err.println("Bug #2b (LRM required un-stucking) currently tolerated: " + line);
-        //System.err.println(t2.toString());
+        // System.err.println(t2.toString());
         // throw t2;
       }
     }
@@ -1394,18 +1394,18 @@ public class LockStepTest extends LockStepTestBase {
       System.err.println("GOOD: Did not encounter Bug #2b " + "(LRM required un-stucking)!");
     }
 
-/*
-    j.assertLogContains("Locked resource cause 1-5: null", b1);
-    j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
-    try {
-        j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
-        j.assertLogNotContains("Secondary lock trick", b1);
-    } catch (java.lang.AssertionError t2) {
-        System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
-        //System.err.println(t2.toString());
-        // throw t2;
-    }
-*/
+    /*
+        j.assertLogContains("Locked resource cause 1-5: null", b1);
+        j.assertLogContains("Locked resource reservedBy 1-5: null", b1);
+        try {
+            j.assertLogNotContains("LRM seems stuck; trying to reserve/unreserve", b1);
+            j.assertLogNotContains("Secondary lock trick", b1);
+        } catch (java.lang.AssertionError t2) {
+            System.err.println("Bug #2b (LRM required un-stucking) currently tolerated");
+            //System.err.println(t2.toString());
+            // throw t2;
+        }
+    */
 
     j.waitForMessage("Locked resource cause 2-2", b1);
     j.assertLogContains("Locked resource cause 1-5", b1);
@@ -1437,9 +1437,9 @@ public class LockStepTest extends LockStepTestBase {
 
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
-        new CpsFlowDefinition(
-            "lock(resource: 'resource1', skipIfLocked: true) {\n" + "  echo 'Running body'\n" + "}",
-            true));
+      new CpsFlowDefinition(
+        "lock(resource: 'resource1', skipIfLocked: true) {\n" + "  echo 'Running body'\n" + "}",
+        true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
     j.waitForCompletion(b1);
     j.assertBuildStatus(Result.SUCCESS, b1);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
@@ -18,137 +18,137 @@ public class LockStepWithRestartTest extends LockStepTestBase {
   @Test
   public void lockOrderRestart() throws Throwable {
     sessions.then(
-        j -> {
-          LockableResourcesManager.get().createResource("resource1");
-          WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-          p.setDefinition(
-              new CpsFlowDefinition(
-                  "lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
-                  true));
-          WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-          SemaphoreStep.waitForStart("wait-inside/1", b1);
-          WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
-          // Ensure that b2 reaches the lock before b3
-          j.waitForMessage(
-              "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
-          isPaused(b2, 1, 1);
-          WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
-          // Both 2 and 3 are waiting for locking resource1
+      j -> {
+        LockableResourcesManager.get().createResource("resource1");
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(
+          new CpsFlowDefinition(
+            "lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
+            true));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-inside/1", b1);
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+        // Ensure that b2 reaches the lock before b3
+        j.waitForMessage(
+          "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b2);
+        isPaused(b2, 1, 1);
+        WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+        // Both 2 and 3 are waiting for locking resource1
 
-          j.waitForMessage(
-              "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
-          isPaused(b3, 1, 1);
-        });
+        j.waitForMessage(
+          "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
+        isPaused(b3, 1, 1);
+      });
 
     sessions.then(
-        j -> {
-          WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
-          WorkflowRun b1 = p.getBuildByNumber(1);
-          WorkflowRun b2 = p.getBuildByNumber(2);
-          WorkflowRun b3 = p.getBuildByNumber(3);
+      j -> {
+        WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
+        WorkflowRun b1 = p.getBuildByNumber(1);
+        WorkflowRun b2 = p.getBuildByNumber(2);
+        WorkflowRun b3 = p.getBuildByNumber(3);
 
-          // Unlock resource1
-          SemaphoreStep.success("wait-inside/1", null);
-          j.waitForMessage("Lock released on resource [resource1]", b1);
-          isPaused(b1, 1, 0);
+        // Unlock resource1
+        SemaphoreStep.success("wait-inside/1", null);
+        j.waitForMessage("Lock released on resource [resource1]", b1);
+        isPaused(b1, 1, 0);
 
-          j.waitForMessage("Lock acquired on [resource1]", b2);
-          isPaused(b2, 1, 0);
-          j.assertLogContains(
-              "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
-          isPaused(b3, 1, 1);
-          SemaphoreStep.success("wait-inside/2", null);
-          SemaphoreStep.waitForStart("wait-inside/3", b3);
-          j.assertLogContains("Lock acquired on [resource1]", b3);
-          SemaphoreStep.success("wait-inside/3", null);
-          j.waitForMessage("Finish", b3);
-          isPaused(b3, 1, 0);
-        });
+        j.waitForMessage("Lock acquired on [resource1]", b2);
+        isPaused(b2, 1, 0);
+        j.assertLogContains(
+          "[resource1] is locked by " + b1.getFullDisplayName() + ", waiting...", b3);
+        isPaused(b3, 1, 1);
+        SemaphoreStep.success("wait-inside/2", null);
+        SemaphoreStep.waitForStart("wait-inside/3", b3);
+        j.assertLogContains("Lock acquired on [resource1]", b3);
+        SemaphoreStep.success("wait-inside/3", null);
+        j.waitForMessage("Finish", b3);
+        isPaused(b3, 1, 0);
+      });
   }
 
   @Test
   public void interoperabilityOnRestart() throws Throwable {
     sessions.then(
-        j -> {
-          LockableResourcesManager.get().createResource("resource1");
-          WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-          p.setDefinition(
-              new CpsFlowDefinition(
-                  "lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
-                  true));
-          WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-          SemaphoreStep.waitForStart("wait-inside/1", b1);
-          isPaused(b1, 1, 0);
+      j -> {
+        LockableResourcesManager.get().createResource("resource1");
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(
+          new CpsFlowDefinition(
+            "lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}\n" + "echo 'Finish'",
+            true));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-inside/1", b1);
+        isPaused(b1, 1, 0);
 
-          FreeStyleProject f = j.createFreeStyleProject("f");
-          f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
+        FreeStyleProject f = j.createFreeStyleProject("f");
+        f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
 
-          f.scheduleBuild2(0);
-          TestHelpers.waitForQueue(j.jenkins, f);
-        });
+        f.scheduleBuild2(0);
+        TestHelpers.waitForQueue(j.jenkins, f);
+      });
 
     sessions.then(
-        j -> {
-          WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
-          FreeStyleProject f = j.jenkins.getItemByFullName("f", FreeStyleProject.class);
-          WorkflowRun b1 = p.getBuildByNumber(1);
+      j -> {
+        WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
+        FreeStyleProject f = j.jenkins.getItemByFullName("f", FreeStyleProject.class);
+        WorkflowRun b1 = p.getBuildByNumber(1);
 
-          // Unlock resource1
-          SemaphoreStep.success("wait-inside/1", null);
-          j.waitForMessage("Lock released on resource [resource1]", b1);
-          isPaused(b1, 1, 0);
+        // Unlock resource1
+        SemaphoreStep.success("wait-inside/1", null);
+        j.waitForMessage("Lock released on resource [resource1]", b1);
+        isPaused(b1, 1, 0);
 
-          FreeStyleBuild fb1;
-          System.out.print("Waiting for freestyle #1 to start building");
-          while ((fb1 = f.getBuildByNumber(1)) == null) {
-            Thread.sleep(250);
-            System.out.print('.');
-          }
-          System.out.println();
+        FreeStyleBuild fb1;
+        System.out.print("Waiting for freestyle #1 to start building");
+        while ((fb1 = f.getBuildByNumber(1)) == null) {
+          Thread.sleep(250);
+          System.out.print('.');
+        }
+        System.out.println();
 
-          j.waitForMessage("acquired lock on [resource1]", fb1);
-        });
+        j.waitForMessage("acquired lock on [resource1]", fb1);
+      });
   }
 
   @Test
   public void testReserveOverRestart() throws Throwable {
     sessions.then(
-        j -> {
-          LockableResourcesManager manager = LockableResourcesManager.get();
-          manager.createResource("resource1");
-          manager.reserve(Collections.singletonList(manager.fromName("resource1")), "user");
+      j -> {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.createResource("resource1");
+        manager.reserve(Collections.singletonList(manager.fromName("resource1")), "user");
 
-          WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-          p.setDefinition(
-              new CpsFlowDefinition(
-                  "lock('resource1') {\n" + "  echo 'inside'\n" + "}\n" + "echo 'Finish'", true));
-          WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-          j.waitForMessage("[resource1] is locked, waiting...", b1);
-          isPaused(b1, 1, 1);
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(
+          new CpsFlowDefinition(
+            "lock('resource1') {\n" + "  echo 'inside'\n" + "}\n" + "echo 'Finish'", true));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("[resource1] is locked, waiting...", b1);
+        isPaused(b1, 1, 1);
 
-          FreeStyleProject f = j.createFreeStyleProject("f");
-          f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
+        FreeStyleProject f = j.createFreeStyleProject("f");
+        f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
 
-          f.scheduleBuild2(0);
-          TestHelpers.waitForQueue(j.jenkins, f);
-        });
+        f.scheduleBuild2(0);
+        TestHelpers.waitForQueue(j.jenkins, f);
+      });
 
     sessions.then(
-        j -> {
-          WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
-          FreeStyleProject f = j.jenkins.getItemByFullName("f", FreeStyleProject.class);
-          WorkflowRun b1 = p.getBuildByNumber(1);
+      j -> {
+        WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
+        FreeStyleProject f = j.jenkins.getItemByFullName("f", FreeStyleProject.class);
+        WorkflowRun b1 = p.getBuildByNumber(1);
 
-          LockableResourcesManager manager = LockableResourcesManager.get();
-          manager.createResource("resource1");
-          manager.unreserve(Collections.singletonList(manager.fromName("resource1")));
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.createResource("resource1");
+        manager.unreserve(Collections.singletonList(manager.fromName("resource1")));
 
-          j.waitForMessage("Lock released on resource [resource1]", b1);
-          isPaused(b1, 1, 0);
-          j.waitForMessage("Finish", b1);
-          isPaused(b1, 1, 0);
+        j.waitForMessage("Lock released on resource [resource1]", b1);
+        isPaused(b1, 1, 0);
+        j.waitForMessage("Finish", b1);
+        isPaused(b1, 1, 0);
 
-          j.waitUntilNoActivity();
-        });
+        j.waitUntilNoActivity();
+      });
   }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceApiTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceApiTest.java
@@ -38,9 +38,9 @@ public class LockableResourceApiTest {
   public void apiUsageHttpGet() {
     JenkinsRule.WebClient wc = j.createWebClient();
     FailingHttpStatusCodeException e =
-        assertThrows(
-            FailingHttpStatusCodeException.class,
-            () -> wc.goTo("lockable-resources/reserve?resource=resource1"));
+      assertThrows(
+        FailingHttpStatusCodeException.class,
+        () -> wc.goTo("lockable-resources/reserve?resource=resource1"));
     assertThat(e.getStatusCode(), is(405));
   }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
@@ -19,23 +19,23 @@ public class LockableResourceManagerTest {
     r.setLabels("some-label");
 
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckResourceNames("resource1", null, true).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckResourceNames("resource1", null, true).getMessage());
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckResourceNames("resource1", "some-label", false).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckResourceNames("resource1", "some-label", false).getMessage());
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckResourceNames("resource1", "some-label", true).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckResourceNames("resource1", "some-label", true).getMessage());
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckLabelName("some-label", "resource1", false).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckLabelName("some-label", "resource1", false).getMessage());
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckLabelName("some-label", null, true).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckLabelName("some-label", null, true).getMessage());
     assertEquals(
-        "Only label, groovy expression, or resources can be defined, not more than one.",
-        d.doCheckLabelName("some-label", "resource1", true).getMessage());
+      "Only label, groovy expression, or resources can be defined, not more than one.",
+      d.doCheckLabelName("some-label", "resource1", true).getMessage());
 
     assertEquals(FormValidation.ok(), d.doCheckResourceNames("resource1", null, false));
     assertEquals(FormValidation.ok(), d.doCheckLabelName("some-label", null, false));

--- a/src/test/java/org/jenkins/plugins/lockableresources/TestHelpers.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/TestHelpers.java
@@ -30,13 +30,13 @@ public final class TestHelpers {
   private TestHelpers() {}
 
   public static void waitForQueue(Jenkins jenkins, FreeStyleProject job)
-      throws InterruptedException {
+    throws InterruptedException {
     waitForQueue(jenkins, job, Queue.Item.class);
   }
 
   /** Schedule a build and make sure it has been added to Jenkins' queue. */
   public static void waitForQueue(Jenkins jenkins, FreeStyleProject job, Class<?> itemType)
-      throws InterruptedException {
+    throws InterruptedException {
     System.out.print("Waiting for job to be queued...");
     int waitTime = 0;
     while (!itemType.isInstance(jenkins.getQueue().getItem(job)) && waitTime < MAX_WAIT) {
@@ -54,17 +54,17 @@ public final class TestHelpers {
    * the API returns sane values while running other tests.
    */
   public static JSONObject getResourceFromApi(
-      JenkinsRule rule, String resourceName, boolean isLocked) throws IOException {
+    JenkinsRule rule, String resourceName, boolean isLocked) throws IOException {
     JSONObject data = getApiData(rule);
     JSONArray resources = data.getJSONArray("resources");
     assertThat(resources, is(not(nullValue())));
     JSONObject res =
-        (JSONObject)
-            resources.stream()
-                .filter(e -> resourceName.equals(((JSONObject) e).getString("name")))
-                .findAny()
-                .orElseThrow(
-                    () -> new AssertionError("Could not find '" + resourceName + "' in API."));
+      (JSONObject)
+        resources.stream()
+          .filter(e -> resourceName.equals(((JSONObject) e).getString("name")))
+          .findAny()
+          .orElseThrow(
+            () -> new AssertionError("Could not find '" + resourceName + "' in API."));
     assertThat(res, hasEntry("locked", isLocked));
     return res;
   }


### PR DESCRIPTION
This is pretty much https://github.com/jenkinsci/lockable-resources-plugin/pull/20 updated for HEAD - most of the credits go to @McFoggy

I recommend reviewing this _after_ https://github.com/jenkinsci/lockable-resources-plugin/pull/294 since it will simplify the complexity of this PR. https://github.com/jenkinsci/lockable-resources-plugin/pull/294 adds an environment variable for each acquired locks when unlocking multiple ones, and this PR builds on this change.

The lock properties can be set on the lock definition in the System Configuration;
When setting a `variable`, the name of the variable is used as a prefix to also set an environment variable for each of the lockable resource's properties. For example:

```groovy
lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
  // comma separated names of all acquired locks
  echo env.LOCKED_RESOURCE

  // first lock
  echo env.LOCKED_RESOURCE0
  echo env.LOCKED_RESOURCE0_PROP_ABC

  // second lock
  echo env.LOCKED_RESOURCE1
  echo env.LOCKED_RESOURCE0_PROP_ABC
}
```

We plan on using these properties to store information such as the IP, URL or an account to use with the lockable resource obtained.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
