### PR TITLE
Maintain lock ordering when reporting in environment variables

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -9,6 +9,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     }
 
     // determine if there are enough resources available to proceed
-    Set<LockableResource> available =
+    LinkedHashSet<LockableResource> available =
       LockableResourcesManager.get()
         .checkResourcesAvailability(resourceHolderList, logger, null, step.skipIfLocked);
     Run<?, ?> run = getContext().get(Run.class);
@@ -99,7 +100,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
   }
 
   public static void proceed(
-    final List<String> resourcenames,
+    final List<String> resourceNames,
     StepContext context,
     String resourceDescription,
     final String variable,
@@ -124,7 +125,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
       BodyInvoker bodyInvoker =
         context
           .newBodyInvoker()
-          .withCallback(new Callback(resourcenames, resourceDescription, inversePrecedence));
+          .withCallback(new Callback(resourceNames, resourceDescription, inversePrecedence));
       if (variable != null && variable.length() > 0) {
         // set the variable for the duration of the block
         bodyInvoker.withContext(
@@ -136,10 +137,10 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
               @Override
               public void expand(@NonNull EnvVars env) {
                 final Map<String, String> variables = new HashMap<>();
-                final String resources = String.join(",", resourcenames);
+                final String resources = String.join(",", resourceNames);
                 variables.put(variable, resources);
-                for (int index = 0; index < resourcenames.size(); ++index) {
-                  variables.put(variable + index, resourcenames.get(index));
+                for (int index = 0; index < resourceNames.size(); ++index) {
+                  variables.put(variable + index, resourceNames.get(index));
                 }
                 LOGGER.finest("Setting "
                   + variables.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(", "))

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -9,10 +9,8 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -61,7 +59,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     }
 
     // determine if there are enough resources available to proceed
-    LinkedHashSet<LockableResource> available =
+    List<LockableResource> available =
       LockableResourcesManager.get()
         .checkResourcesAvailability(resourceHolderList, logger, null, step.skipIfLocked);
     Run<?, ?> run = getContext().get(Run.class);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -405,13 +406,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized boolean lock(
-    Set<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
+    LinkedHashSet<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
     return lock(resources, build, context, null, null, false);
   }
 
   /** Try to lock the resource and return true if locked. */
   public synchronized boolean lock(
-    Set<LockableResource> resources,
+    LinkedHashSet<LockableResource> resources,
     Run<?, ?> build,
     @Nullable StepContext context,
     @Nullable String logmessage,
@@ -927,7 +928,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
-  public synchronized Set<LockableResource> checkResourcesAvailability(
+  public synchronized LinkedHashSet<LockableResource> checkResourcesAvailability(
       List<LockableResourcesStruct> requiredResourcesList,
       @Nullable PrintStream logger,
       @Nullable List<String> lockedResourcesAboutToBeUnlocked,
@@ -956,7 +957,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
    * requiredResources and returns the necessary available resources. If not enough resources are
    * available, returns null.
    */
-  public synchronized Set<LockableResource> checkResourcesAvailability(
+  public synchronized LinkedHashSet<LockableResource> checkResourcesAvailability(
     List<LockableResourcesStruct> requiredResourcesList,
     @Nullable PrintStream logger,
     @Nullable List<String> lockedResourcesAboutToBeUnlocked,
@@ -1082,7 +1083,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     // Find remaining resources
-    Set<LockableResource> allSelected = new HashSet<>();
+    LinkedHashSet<LockableResource> allSelected = new LinkedHashSet<>();
 
     for (LockableResourcesCandidatesStruct requiredResources : requiredResourcesCandidatesList) {
       List<LockableResource> candidates = requiredResources.candidates;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -406,13 +406,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   public synchronized boolean lock(
-    LinkedHashSet<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
+    List<LockableResource> resources, Run<?, ?> build, @Nullable StepContext context) {
     return lock(resources, build, context, null, null, false);
   }
 
   /** Try to lock the resource and return true if locked. */
   public synchronized boolean lock(
-    LinkedHashSet<LockableResource> resources,
+    List<LockableResource> resources,
     Run<?, ?> build,
     @Nullable StepContext context,
     @Nullable String logmessage,
@@ -518,7 +518,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return;
       }
 
-      Set<LockableResource> requiredResourceForNextContext =
+      List<LockableResource> requiredResourceForNextContext =
         checkResourcesAvailability(
           nextContext.getResources(), null, remainingResourceNamesToUnLock);
 
@@ -799,7 +799,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     // remove context from queue and process it
-    Set<LockableResource> requiredResourceForNextContext =
+    List<LockableResource> requiredResourceForNextContext =
       checkResourcesAvailability(
         nextContext.getResources(), nextContextLogger,
         null, resourceNamesToUnreserve);
@@ -918,7 +918,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
-  public synchronized Set<LockableResource> checkResourcesAvailability(
+  public synchronized List<LockableResource> checkResourcesAvailability(
     List<LockableResourcesStruct> requiredResourcesList,
     @Nullable PrintStream logger,
     @Nullable List<String> lockedResourcesAboutToBeUnlocked) {
@@ -928,7 +928,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
-  public synchronized LinkedHashSet<LockableResource> checkResourcesAvailability(
+  public synchronized List<LockableResource> checkResourcesAvailability(
       List<LockableResourcesStruct> requiredResourcesList,
       @Nullable PrintStream logger,
       @Nullable List<String> lockedResourcesAboutToBeUnlocked,
@@ -938,7 +938,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   /** @see #checkResourcesAvailability(List, PrintStream, List, List, boolean) */
-  public synchronized Set<LockableResource> checkResourcesAvailability(
+  public synchronized List<LockableResource> checkResourcesAvailability(
     List<LockableResourcesStruct> requiredResourcesList,
     @Nullable PrintStream logger,
     @Nullable List<String> lockedResourcesAboutToBeUnlocked,
@@ -957,7 +957,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
    * requiredResources and returns the necessary available resources. If not enough resources are
    * available, returns null.
    */
-  public synchronized LinkedHashSet<LockableResource> checkResourcesAvailability(
+  public synchronized List<LockableResource> checkResourcesAvailability(
     List<LockableResourcesStruct> requiredResourcesList,
     @Nullable PrintStream logger,
     @Nullable List<String> lockedResourcesAboutToBeUnlocked,
@@ -1132,7 +1132,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       allSelected.addAll(selected);
     }
 
-    return allSelected;
+    return new ArrayList<>(allSelected);
   }
 
   /*

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -20,6 +20,7 @@ import hudson.model.listeners.RunListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -45,7 +46,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
     if (build instanceof AbstractBuild) {
       Job<?, ?> proj = Utils.getProject(build);
-      Set<LockableResource> required = new HashSet<>();
+      LinkedHashSet<LockableResource> required = new LinkedHashSet<>();
       if (proj != null) {
         LockableResourcesStruct resources = Utils.requiredResources(proj);
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -18,11 +18,8 @@ import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.LockableResource;
@@ -46,7 +43,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
     if (build instanceof AbstractBuild) {
       Job<?, ?> proj = Utils.getProject(build);
-      LinkedHashSet<LockableResource> required = new LinkedHashSet<>();
+      List<LockableResource> required = new ArrayList<>();
       if (proj != null) {
         LockableResourcesStruct resources = Utils.requiredResources(proj);
 
@@ -57,6 +54,9 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
           } else {
             required.addAll(resources.required);
           }
+
+          // make sure each entry is unique
+          required = new ArrayList<>(new LinkedHashSet<>(required));
 
           if (LockableResourcesManager.get().lock(required, build, null)) {
             build.addAction(LockedResourcesBuildAction

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -854,9 +854,11 @@ public class LockStepTest extends LockStepTestBase {
   //@Issue("JENKINS-XXXXX")
   public void locksInVariablesAreInTheRequestedOrder() throws Exception {
     List<String> extras = new ArrayList<>();
+    List<String> eachVar = new ArrayList<>();
     for (int i = 0; i < 100; ++i) {
       LockableResourcesManager.get().createResource("extra" + i);
       extras.add("[resource: 'extra" + i + "', quantity:1]");
+      eachVar.add("  echo \"VAR" + (i+1) + " IS ${env.var" + (i+1) + "}\"\n");
     }
     LockableResourcesManager.get().createResource("main");
 
@@ -867,6 +869,8 @@ public class LockStepTest extends LockStepTestBase {
           + extras.stream().collect(Collectors.joining(","))
           + "]) {\n"
           + "  echo \"VAR IS ${env.var}\"\n"
+          + "  echo \"VAR0 IS ${env.var0}\"\n"
+          + eachVar.stream().collect(Collectors.joining("\n"))
           + "}",
         true));
     WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -880,6 +884,12 @@ public class LockStepTest extends LockStepTestBase {
       + "extra57,extra58,extra59,extra60,extra61,extra62,extra63,extra64,extra65,extra66,extra67,extra68,extra69,extra70,extra71,"
       + "extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra80,extra81,extra82,extra83,extra84,extra85,extra86,"
       + "extra87,extra88,extra89,extra90,extra91,extra92,extra93,extra94,extra95,extra96,extra97,extra98,extra99", b1);
+
+    j.assertLogContains("VAR0 IS main", b1);
+    for (int i = 0; i < 100; ++i) {
+      j.assertLogContains("VAR" + (i+1) + " IS extra" + i, b1);
+    }
+
   }
 
   @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -873,10 +873,13 @@ public class LockStepTest extends LockStepTestBase {
     j.waitForCompletion(b1);
 
     // Variable should have been filled
-    j.assertLogContains("VAR IS main,extra0,extra1,extra2,extra3,extra4,extra5,extra6,extra7,extra8,extra9,extra10,extra11,extra12,extra13,extra14,extra15,extra16,extra17,extra18,extra19,extra20,extra21,extra22,extra23,extra24,\n"
-      + "extra25,extra26,extra27,extra28,extra29,extra30,extra31,extra32,extra33,extra34,extra35,extra36,extra37,extra38,extra39,extra40,extra41,extra42,extra43,extra44,extra45,extra46,extra47,extra48,extra49,ex\n"
-      + "tra50,extra51,extra52,extra53,extra54,extra55,extra56,extra57,extra58,extra59,extra60,extra61,extra62,extra63,extra64,extra65,extra66,extra67,extra68,extra69,extra70,extra71,extra72,extra73,extra74,extr\n"
-      + "a75,extra76,extra77,extra78,extra79,extra80,extra81,extra82,extra83,extra84,extra85,extra86,extra87,extra88,extra89,extra90,extra91,extra92,extra93,extra94,extra95,extra96,extra97,extra98,extra99", b1);
+    j.assertLogContains("VAR IS main,extra0,extra1,extra2,extra3,extra4,extra5,extra6,extra7,extra8,extra9,extra10,extra11,"
+      + "extra12,extra13,extra14,extra15,extra16,extra17,extra18,extra19,extra20,extra21,extra22,extra23,extra24,extra25,extra26,"
+      + "extra27,extra28,extra29,extra30,extra31,extra32,extra33,extra34,extra35,extra36,extra37,extra38,extra39,extra40,extra41,"
+      + "extra42,extra43,extra44,extra45,extra46,extra47,extra48,extra49,extra50,extra51,extra52,extra53,extra54,extra55,extra56,"
+      + "extra57,extra58,extra59,extra60,extra61,extra62,extra63,extra64,extra65,extra66,extra67,extra68,extra69,extra70,extra71,"
+      + "extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra80,extra81,extra82,extra83,extra84,extra85,extra86,"
+      + "extra87,extra88,extra89,extra90,extra91,extra92,extra93,extra94,extra95,extra96,extra97,extra98,extra99", b1);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/lockable-resources-plugin/issues/300 : The order of the locked resources in the environment variable does not match the order in the extra parameter

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
