### PR TITLE
Add runtime attribute for locked resources and allow multiple locks

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -40,7 +40,7 @@ public final class BackwardCompatibility {
         for (StepContext queuedContext : queuedContexts) {
           List<String> resourcesNames = new ArrayList<>();
           resourcesNames.add(resource.getName());
-          LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
+          LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0, null);
           LockableResourcesManager.get().queueContext(queuedContext, Collections.singletonList(resourceHolder), resource.getName(), null);
         }
         queuedContexts.clear();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -29,6 +29,8 @@ public class LockStep extends Step implements Serializable {
 
   @CheckForNull public String label = null;
 
+  @CheckForNull public String attribute = null;
+
   public int quantity = 0;
 
   /** name of environment variable to store locked resources in */
@@ -64,6 +66,13 @@ public class LockStep extends Step implements Serializable {
   public void setLabel(String label) {
     if (label != null && !label.isEmpty()) {
       this.label = label;
+    }
+  }
+
+  @DataBoundSetter
+  public void setAttribute(String attribute) {
+    if (attribute != null && !attribute.isEmpty()) {
+      this.attribute = attribute;
     }
   }
 
@@ -129,8 +138,8 @@ public class LockStep extends Step implements Serializable {
       return getResources().stream()
         .map(res -> "{" + res.toString() + "}")
         .collect(Collectors.joining(","));
-    } else if (resource != null || label != null) {
-      return LockStepResource.toString(resource, label, quantity);
+    } else if (resource != null || label != null || attribute != null) {
+      return LockStepResource.toString(resource, label, quantity, attribute);
     } else {
       return "nothing";
     }
@@ -138,13 +147,13 @@ public class LockStep extends Step implements Serializable {
 
   /** Label and resource are mutual exclusive. */
   public void validate() {
-    LockStepResource.validate(resource, label, quantity);
+    LockStepResource.validate(resource, label, quantity, attribute);
   }
 
   public List<LockStepResource> getResources() {
     List<LockStepResource> resources = new ArrayList<>();
-    if (resource != null || label != null) {
-      resources.add(new LockStepResource(resource, label, quantity));
+    if (resource != null || label != null || attribute != null) {
+      resources.add(new LockStepResource(resource, label, quantity, attribute));
     }
 
     if (extra != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -56,7 +56,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
         resources.add(resource.resource);
       }
       resourceHolderList.add(
-        new LockableResourcesStruct(resources, resource.label, resource.quantity));
+        new LockableResourcesStruct(resources, resource.label, resource.quantity, resource.attribute));
     }
 
     // determine if there are enough resources available to proceed
@@ -66,13 +66,14 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     Run<?, ?> run = getContext().get(Run.class);
     if (available == null
       || !LockableResourcesManager.get()
-      .lock(
-        available,
-        run,
-        getContext(),
-        step.toString(),
-        step.variable,
-        step.inversePrecedence)) {
+        .lock(
+            available,
+            resourceHolderList,
+            run,
+            getContext(),
+            step.toString(),
+            step.variable,
+            step.inversePrecedence)) {
       // if the resource is known, we could output the active/blocking job/build
       LockableResource resource = LockableResourcesManager.get().fromName(step.resource);
       boolean buildNameKnown = resource != null && resource.getBuildName() != null;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -40,7 +40,6 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
   @Override
   public boolean start() throws Exception {
     step.validate();
-    LOGGER.warning("LockStepExecution start()");
     getContext().get(FlowNode.class).addAction(new PauseAction("Lock"));
     PrintStream logger = getContext().get(TaskListener.class).getLogger();
 
@@ -65,7 +64,6 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
       LockableResourcesManager.get()
         .checkResourcesAvailability(resourceHolderList, logger, null, step.skipIfLocked);
     Run<?, ?> run = getContext().get(Run.class);
-    LOGGER.warning("Trying to lock something for runid:"+run.getId()+" displayName"+run.getDisplayName()+" extId"+run.getExternalizableId());
     if (available == null
       || !LockableResourcesManager.get()
         .lock(
@@ -122,7 +120,6 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
       context.onFailure(e);
       return;
     }
-    LOGGER.warning("LockStepExecution proceed()");
     LOGGER.warning("Lock acquired on [" + resourceDescription + "] by " + r.getExternalizableId());
     try {
       PauseAction.endCurrentPause(node);
@@ -191,7 +188,6 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
   @Override
   public void stop(@NonNull Throwable cause) {
     boolean cleaned = LockableResourcesManager.get().unqueueContext(getContext());
-    LOGGER.warning("LockStepExecution stop()");
     if (!cleaned) {
       LOGGER.log(
         Level.WARNING,

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -22,12 +22,16 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
   @CheckForNull
   public String label = null;
 
+  @CheckForNull
+  public String attribute = null;
+
   public int quantity = 0;
 
-  LockStepResource(@Nullable String resource, @Nullable String label, int quantity) {
+  LockStepResource(@Nullable String resource, @Nullable String label, int quantity, @Nullable String attribute) {
     this.resource = resource;
     this.label = label;
     this.quantity = quantity;
+    this.attribute = attribute;
   }
 
   @DataBoundConstructor
@@ -51,11 +55,20 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 
   @Override
   public String toString() {
-    return toString(resource, label, quantity);
+    return toString(resource, label, quantity, attribute);
   }
 
-  public static String toString(String resource, String label, int quantity) {
-    // a label takes always priority
+  public static String toString(String resource, String label, int quantity, String attribute) {
+    //attribute is highest priority
+     if (attribute != null && quantity <= 1) {
+        if (label == null || "".equals(label)) {
+          return "Attribute: " + attribute;
+        } else {
+          return "Attribute: " + attribute + ", Label: " + label;
+        }
+     }
+
+    // a is second priority
     if (label != null) {
       if (quantity > 0) {
         return "Label: " + label + ", Quantity: " + quantity;
@@ -73,14 +86,14 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
    * Label and resource are mutual exclusive.
    */
   public void validate() {
-    validate(resource, label, quantity);
+    validate(resource, label, quantity, attribute);
   }
 
   /**
    * Label and resource are mutual exclusive.
    * The label, if provided, must be configured (at least one resource must have this label).
    */
-  public static void validate(String resource, String label, int quantity) {
+  public static void validate(String resource, String label, int quantity, String attribute) {
     if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
       throw new IllegalArgumentException("Label and resource name cannot be specified simultaneously.");
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -305,15 +305,6 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public boolean isLocked() {
-    if (builds != null) {
-      for (Run<?, ?> build : builds) {
-        LOGGER.warning("->id:" + build.getId() + " displayName:" + build.getDisplayName() + "extId" + build.getExternalizableId());
-      }
-    }else{
-      LOGGER.warning("builds = null");
-    }
-    LOGGER.warning("attrbutes:"+this.attributes);
-    LOGGER.warning("isLocked" + (getBuilds().size() > 0));
     return getBuilds().size() > 0;
   }
 
@@ -372,7 +363,6 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public void resetBuilds() {
-    LOGGER.warning("*******RESET BUILD*********");
     if (this.builds == null) { this.builds = new ArrayList<>(); }
       if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
       this.builds.clear();
@@ -380,62 +370,24 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public void setBuild(Run<?, ?> lockedBy) {
-    LOGGER.warning("*******SETBUILD*********");
     if (this.builds == null) { this.builds = new ArrayList<>(); }
     if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
-      LOGGER.warning("****");
-      LOGGER.warning("LockableResourceManager setBuild():" + lockedBy.getId() + " displayName:" + lockedBy.getDisplayName()+ " extId:" + lockedBy.getExternalizableId());
-      LOGGER.warning("****");
-      LOGGER.warning("builds before add:");
-      for (Run<?, ?> build : builds) {
-        LOGGER.warning("->build id:" + build.getId() + "build displayName:" + build.getDisplayName()+ " extId:" + build.getExternalizableId());
-      }
-
-      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
-      LOGGER.warning("====");
-
       this.builds.add(lockedBy);
       this.buildExternalizableIds.add(lockedBy.getExternalizableId());
       setReservedTimestamp(new Date());
-
-      LOGGER.warning("builds after add:");
-      for (Run<?, ?> build : builds) {
-        LOGGER.warning("-> id:" + build.getId() + " displayName:" + build.getDisplayName() + " extId:" + build.getExternalizableId());
-      }
-      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
-      LOGGER.warning("*****");
 
     }
   }
 
   public void popBuild(Run<?, ?> lockedBy) {
-    LOGGER.warning("*******POP BUILD*********");
     if (this.builds == null) { this.builds = new ArrayList<>(); }
     if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
 
-      LOGGER.warning("****");
-      LOGGER.warning("LockableResourceManager popBuild():" + lockedBy.getId() + " displayName:" + lockedBy.getDisplayName()+ " extId:" + lockedBy.getExternalizableId());
-      LOGGER.warning("****");
-      LOGGER.warning("builds before pop:");
-      for (Run<?, ?> build : builds) {
-        LOGGER.warning("->build id:" + build.getId() + "build displayName:" + build.getDisplayName()+ " extId:" + build.getExternalizableId());
-      }
-      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
-      LOGGER.warning("LockbleResourceManager attribute:" + attributes);
-      LOGGER.warning("====");
-
       this.buildExternalizableIds.remove(lockedBy.getExternalizableId());
       this.builds.remove(lockedBy);
 
-      LOGGER.warning("builds after pop:");
-      for (Run<?, ?> build : builds) {
-        LOGGER.warning("-> id:" + build.getId() + " displayName:" + build.getDisplayName() + " extId:" + build.getExternalizableId());
-      }
-      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
-      LOGGER.warning("LockbleResourceManager attribute:" + attributes);
-      LOGGER.warning("*****");
     }
     //remove attribute if there is nobody owning this resource
     if (this.builds.size() == 0){

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -205,6 +205,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   private List<String> makeAttributeList() {
+    if (this.attributes == null ){ this.attributes = ""; }
     return Arrays.asList(attributes.split("\\s+"));
   }
 
@@ -327,7 +328,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   public List<Run<?, ?>> getBuilds() {
     //transient variable was deleted during restart
     if (this.builds == null) { this.builds = new ArrayList<>(); }
-    if (builds.size() == 0 && buildExternalizableIds.size()!=0) {
+    if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
+    if (builds.size() == 0 && this.buildExternalizableIds.size()!=0) {
       for(String buildExternalizableId : buildExternalizableIds) {
         builds.add(Run.fromExternalizableId(buildExternalizableId));
       }
@@ -360,12 +362,14 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   public void resetBuilds() {
       if (this.builds == null) { this.builds = new ArrayList<>(); }
+      if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
       this.builds.clear();
       this.buildExternalizableIds.clear();
   }
 
   public void setBuild(Run<?, ?> lockedBy) {
     if (this.builds == null) { this.builds = new ArrayList<>(); }
+    if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
       this.builds.add(lockedBy);
       this.buildExternalizableIds.add(lockedBy.getExternalizableId());
@@ -375,13 +379,14 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   public void popBuild(Run<?, ?> lockedBy) {
     if (this.builds == null) { this.builds = new ArrayList<>(); }
+    if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
       this.buildExternalizableIds.remove(lockedBy.getExternalizableId());
       this.builds.remove(lockedBy);
     }
     //remove attribute if there is nobody owning this resource
     if (this.builds.size() == 0){
-      this.setAttributes(null);
+      this.setAttributes("");
     }
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -141,11 +141,13 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @DataBoundSetter
   public void setAttributes(String attributes) {
+    LOGGER.warning("LockbleResourceManager set attribute:" + attributes);
     this.attributes = attributes;
   }
 
   @DataBoundSetter
   public String getAttributes() {
+    LOGGER.warning("LockbleResourceManager set attribute:" + attributes);
     return this.attributes;
   }
 
@@ -303,6 +305,15 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public boolean isLocked() {
+    if (builds != null) {
+      for (Run<?, ?> build : builds) {
+        LOGGER.warning("->id:" + build.getId() + " displayName:" + build.getDisplayName() + "extId" + build.getExternalizableId());
+      }
+    }else{
+      LOGGER.warning("builds = null");
+    }
+    LOGGER.warning("attrbutes:"+this.attributes);
+    LOGGER.warning("isLocked" + (getBuilds().size() > 0));
     return getBuilds().size() > 0;
   }
 
@@ -361,28 +372,70 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public void resetBuilds() {
-      if (this.builds == null) { this.builds = new ArrayList<>(); }
+    LOGGER.warning("*******RESET BUILD*********");
+    if (this.builds == null) { this.builds = new ArrayList<>(); }
       if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
       this.builds.clear();
       this.buildExternalizableIds.clear();
   }
 
   public void setBuild(Run<?, ?> lockedBy) {
+    LOGGER.warning("*******SETBUILD*********");
     if (this.builds == null) { this.builds = new ArrayList<>(); }
     if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
+      LOGGER.warning("****");
+      LOGGER.warning("LockableResourceManager setBuild():" + lockedBy.getId() + " displayName:" + lockedBy.getDisplayName()+ " extId:" + lockedBy.getExternalizableId());
+      LOGGER.warning("****");
+      LOGGER.warning("builds before add:");
+      for (Run<?, ?> build : builds) {
+        LOGGER.warning("->build id:" + build.getId() + "build displayName:" + build.getDisplayName()+ " extId:" + build.getExternalizableId());
+      }
+
+      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
+      LOGGER.warning("====");
+
       this.builds.add(lockedBy);
       this.buildExternalizableIds.add(lockedBy.getExternalizableId());
       setReservedTimestamp(new Date());
+
+      LOGGER.warning("builds after add:");
+      for (Run<?, ?> build : builds) {
+        LOGGER.warning("-> id:" + build.getId() + " displayName:" + build.getDisplayName() + " extId:" + build.getExternalizableId());
+      }
+      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
+      LOGGER.warning("*****");
+
     }
   }
 
   public void popBuild(Run<?, ?> lockedBy) {
+    LOGGER.warning("*******POP BUILD*********");
     if (this.builds == null) { this.builds = new ArrayList<>(); }
     if (this.buildExternalizableIds == null) { this.buildExternalizableIds = new ArrayList<>(); }
     if (lockedBy != null) {
+
+      LOGGER.warning("****");
+      LOGGER.warning("LockableResourceManager popBuild():" + lockedBy.getId() + " displayName:" + lockedBy.getDisplayName()+ " extId:" + lockedBy.getExternalizableId());
+      LOGGER.warning("****");
+      LOGGER.warning("builds before pop:");
+      for (Run<?, ?> build : builds) {
+        LOGGER.warning("->build id:" + build.getId() + "build displayName:" + build.getDisplayName()+ " extId:" + build.getExternalizableId());
+      }
+      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
+      LOGGER.warning("LockbleResourceManager attribute:" + attributes);
+      LOGGER.warning("====");
+
       this.buildExternalizableIds.remove(lockedBy.getExternalizableId());
       this.builds.remove(lockedBy);
+
+      LOGGER.warning("builds after pop:");
+      for (Run<?, ?> build : builds) {
+        LOGGER.warning("-> id:" + build.getId() + " displayName:" + build.getDisplayName() + " extId:" + build.getExternalizableId());
+      }
+      LOGGER.warning("LockbleResourceManager setBuild() externalId:" + buildExternalizableIds);
+      LOGGER.warning("LockbleResourceManager attribute:" + attributes);
+      LOGGER.warning("*****");
     }
     //remove attribute if there is nobody owning this resource
     if (this.builds.size() == 0){

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -431,16 +431,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
     boolean inversePrecedence) {
     boolean needToWait = false;
 
-    if (build != null) {
-      LOGGER.warning("LockableresourceManager - lock() -> id:" + build.getId() + " displayName:" + build.getDisplayName()+ "extId"+build.getExternalizableId());
-    }
     for (LockableResource r : resources) {
       if (r.isReserved() || r.isLocked()) {
         needToWait = true;
         break;
       }
     }
-    LOGGER.warning("LockableresourceManager - lock() - needToWait?" + needToWait);
     if (resourceHolderList != null) {
       for (LockableResourcesStruct requiredResource : resourceHolderList) {
         if (requiredResource.attribute != null && !requiredResource.attribute.trim().isEmpty()) {
@@ -478,7 +474,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   private synchronized void freeResources(
     List<String> unlockResourceNames, @Nullable Run<?, ?> build) {
-    LOGGER.warning("===FREE RESOURCES==");
     for (String unlockResourceName : unlockResourceNames) {
       Iterator<LockableResource> resourceIterator = this.resources.iterator();
       while (resourceIterator.hasNext()) {
@@ -508,9 +503,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
     @Nullable List<LockableResource> resourcesToUnLock,
     @Nullable Run<?, ?> build,
     boolean inversePrecedence) {
-    if (build != null) {
-      LOGGER.warning("LockableresourceManager - unlock() ->build id:" + build.getId() + "build displayName:" + build.getDisplayName() + " extId:" + build.getExternalizableId());
-    }
 
     List<String> resourceNamesToUnLock = new ArrayList<>();
     if (resourcesToUnLock != null) {
@@ -526,15 +518,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
     @Nullable List<String> resourceNamesToUnLock,
     @Nullable Run<?, ?> build,
     boolean inversePrecedence) {
-    if (build != null) {
-      LOGGER.warning("LockableresourceManager - unlockName() -> id:" + build.getId() + " displayName:" + build.getDisplayName()+ " extId:" + build.getExternalizableId());
-    }
     // make sure there is a list of resource names to unlock
     if (resourceNamesToUnLock == null || resourceNamesToUnLock.isEmpty()) {
       return;
     }
-    LOGGER.warning("LockableresourceManager - unlockName() @@BALI00");
-    LOGGER.warning("LockableresourceManager - unlockName()"+resourceNamesToUnLock);
 
     // process as many contexts as possible
     List<String> remainingResourceNamesToUnLock = new ArrayList<>(resourceNamesToUnLock);
@@ -562,17 +549,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
       // It is guaranteed that there is an overlap between the two - the resources which are to be
       // reused.
       boolean needToWait = false;
-      LOGGER.warning("LockableresourceManager - unlockName() @@BALI0");
       for (LockableResource requiredResource : requiredResourceForNextContext) {
-        LOGGER.warning("LockableresourceManager - unlockName() @@BALI1");
-        LOGGER.warning("LockableresourceManager - required resource "+requiredResource);
         if (requiredResource.isStolen()) {
           needToWait = true;
           break;
         }
         if (!remainingResourceNamesToUnLock.contains(requiredResource.getName())) {
           if (requiredResource.isReserved() || requiredResource.isLocked()) {
-            LOGGER.warning("LockableresourceManager - unlockName() @@BALI2");
             needToWait = true;
             break;
           }
@@ -582,13 +565,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
       if (!needToWait) {
         // remove context from queue and process it
         unqueueContext(nextContext.getContext());
-        LOGGER.warning("LockableresourceManager - unlockName() @@BALI3");
         List<String> resourceNamesToLock = new ArrayList<>();
-        LOGGER.warning("LockableresourceManager requiredResourceForNextContext"+requiredResourceForNextContext);
         // lock all (old and new resources)
         for (LockableResource requiredResource : requiredResourceForNextContext) {
           try {
-            LOGGER.warning("LockableresourceManager - unlockName() @@BALI4");
             requiredResource.setBuild(nextContext.getContext().get(Run.class));
             requiredResource.popBuild(build);
             resourceNamesToLock.add(requiredResource.getName());
@@ -1056,17 +1036,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
         //case when some lock is about to be released
         if (lockedResourcesAboutToBeUnlocked != null
           ||  reservedResourcesAboutToBeUnreserved != null){
-          LOGGER.warning("@@BABi0 attrib"+requiredResourcesStruct.attribute+ "label"+requiredResourcesStruct.label + "requiredlist" + requiredResourcesStruct.required);
           lockableResouceCandidateList.addAll(getResourcesWithAttribute(requiredResourcesStruct.attribute, null));
 
           //if there this is the last build holding this resource
           List<LockableResource> allResources = getResources();
           for (LockableResource resource : allResources ){
-            LOGGER.warning("@@BABi1");
             if (lockedResourcesAboutToBeUnlocked.contains(resource.getName())){
-              LOGGER.warning("@@BABi2");
               if (resource.getBuilds().size() == 1){
-                LOGGER.warning("@@BABi3");
                 Set<LockableResource> resourceWithAttribute = new HashSet<>();
                 resource.setAttributes(requiredResourcesStruct.attribute);
                 resourceWithAttribute.add(resource);
@@ -1078,10 +1054,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
           if (lockableResouceCandidateList.size() > 0) {
             Set<LockableResource> resourceWithAttribute = new HashSet<>();
             resourceWithAttribute.add(lockableResouceCandidateList.get(0));
-            LOGGER.warning("@@BABi4");
             return resourceWithAttribute;
           } else {
-            LOGGER.warning("@@BABi5");
             return null;
           }
         }
@@ -1182,16 +1156,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
             // If the resource is not reserved (as checked above)
             // but listed for releasing in either category, select it
             if (listedUnlock || listedUnreserve) {
-              LOGGER.warning("@@ILAB1");
-
-//              for (LockableResourcesStruct originalRequiredResources : requiredResourcesStructList) {
-//                if (originalRequiredResources.attribute != null && !originalRequiredResources.attribute.isEmpty()){
-//                  if(candidate.getAttributes().equals(originalRequiredResources.attribute)){
-//
-//                  }
-//                }
-//              }
-
               selectedResourceList.add(candidate);
             }
           }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -29,6 +29,7 @@ public class LockableResourcesStruct implements Serializable {
   public String label;
   public String requiredVar;
   public String requiredNumber;
+  public String attribute;
 
   @CheckForNull private final SerializableSecureGroovyScript serializableResourceMatchScript;
 
@@ -66,17 +67,15 @@ public class LockableResourcesStruct implements Serializable {
    * @param resources Resources to be required
    */
   public LockableResourcesStruct(@Nullable List<String> resources) {
-    this(resources, null, 0);
+    this(resources, null, 0, null);
   }
 
-  public LockableResourcesStruct(
-    @Nullable List<String> resources, @Nullable String label, int quantity, String variable) {
-    this(resources, label, quantity);
+  public LockableResourcesStruct(@Nullable List<String> resources, @Nullable String label, int quantity, String variable, @Nullable String attribute) {
+    this(resources, label, quantity, attribute);
     requiredVar = variable;
   }
 
-  public LockableResourcesStruct(
-    @Nullable List<String> resources, @Nullable String label, int quantity) {
+  public LockableResourcesStruct(@Nullable List<String> resources, @Nullable String label, int quantity, @Nullable String attribute) {
     required = new ArrayList<>();
     if (resources != null) {
       for (String resource : resources) {
@@ -95,6 +94,11 @@ public class LockableResourcesStruct implements Serializable {
     this.requiredNumber = null;
     if (quantity > 0) {
       this.requiredNumber = String.valueOf(quantity);
+    }
+
+    this.attribute = attribute;
+    if (this.attribute == null) {
+      this.attribute = "";
     }
 
     // We do not support
@@ -131,7 +135,9 @@ public class LockableResourcesStruct implements Serializable {
       + ", Variable name: "
       + this.requiredVar
       + ", Number of resources: "
-      + this.requiredNumber;
+      + this.requiredNumber
+      + ", Attribute: "
+      + this.attribute;
   }
 
   private static final long serialVersionUID = 1L;

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -135,7 +135,7 @@ public class LockStepTest extends LockStepTestBase {
 
     LockableResource lr = LockableResourcesManager.get().fromName("resource1");
     assertNotNull(lr);
-    assertNull(lr.getAttributes());
+    assertEquals("", lr.getAttributes());
   }
 
   @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertNull;
 import java.util.Date;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 public class LockableResourceTest {
 
   LockableResource instance = new LockableResource("r1");
@@ -27,7 +29,8 @@ public class LockableResourceTest {
     assertFalse(instance.isQueued(0));
     assertFalse(instance.isQueuedByTask(1));
     assertFalse(instance.isLocked());
-    assertNull(instance.getBuild());
+    assertNotNull(instance.getBuilds());
+    assertEquals(0, instance.getBuilds().size());
     assertEquals(0, instance.getQueueItemId());
     assertNull(instance.getQueueItemProject());
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Added runtime attribute support for functionality https://github.com/jenkinsci/lockable-resources-plugin/issues/302

- Added attribute to resource Object
- Changed logic to return resource if it contains the needed attribute even if it's locked
- Changed build reference of Resource to list type List<Run<?,?>> from Run<?,?>
- Changed locked by externalID of resource to List<String> from String
- Adjusted methods to work with lists

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
