### PR TITLE
Fixed a reverse label null check

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesCandidatesStruct;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
@@ -971,7 +972,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       // get possible resources
       int requiredAmount = 0; // 0 means all
       List<LockableResource> candidates = new ArrayList<>();
-      if (requiredResources.label != null && requiredResources.label.isEmpty()) {
+      if (StringUtils.isBlank(requiredResources.label)) {
         candidates.addAll(requiredResources.required);
       } else {
         candidates.addAll(getResourcesWithLabel(requiredResources.label, null));


### PR DESCRIPTION
I'm not sure what the impact of this really is - but the check is definitely reversed.

```
if (requiredResources.label != null && requiredResources.label.isEmpty())
```

should have been:

```
if (requiredResources.label == null || requiredResources.label.isEmpty())
```

But I fixed it with a `StringUtils.isBlank(requiredResources.label)`

I notice the plugin has a lot of `x == null || x.isEmpty()` or similar and would encourage to use `StringUtils.isBlank` and `StringUtils.isNotBlank` for these checks. They are far less error-prone and easier to read.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
