### PR TITLE
deactivate jdk8 in plugin test cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 ## Contributing
 
 If you want to contribute to this plugin, you probably will need a Jenkins plugin development
-environment. This basically means a current version of Java (Java 8 should probably be okay for now)
+environment. This basically means a current version of Java (Java 11 should probably be okay for now)
 and [Apache Maven]. See the [Jenkins Plugin Tutorial] for details.
 
 If you have the proper environment, typing:
@@ -11,7 +11,7 @@ If you have the proper environment, typing:
 
 should create a plugin as `target/*.hpi`, which you can install in your Jenkins instance. Running
 
-    $ mvn hpi:run -Djenkins.version=2.249.1
+    $ mvn hpi:run -Djenkins.version=2.361.1
 
 allows you to spin up a test Jenkins instance on [localhost] to test your
 local changes before committing.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,6 @@
  * https://github.com/jenkins-infra/pipeline-library/
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
-  // Jenkins version).
-  [ platform: 'linux', jdk: '8' ],
-
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
   [ platform: 'linux', jdk: '11', jenkins: '2.346.3' ],
   [ platform: 'windows', jdk: '11', jenkins: '2.346.3' ],

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   <properties>
     <revision>2.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -65,7 +65,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <version>1654.vcb_69d035fa_20</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
Fix #360 


### Proposed changelog entries

- Remove jdk8 support for plugin tests in Jenkinsfile