### PR TITLE
Set correct Jenkins Version for Java 11 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,15 @@ and [Apache Maven]. See the [Jenkins Plugin Tutorial] for details.
 
 If you have the proper environment, typing:
 
-    $ mvn verify
+```
+    mvn verify
+```
 
 should create a plugin as `target/*.hpi`, which you can install in your Jenkins instance. Running
 
-    $ mvn hpi:run -Djenkins.version=2.361.1
+```
+    mvn hpi:run -Djenkins.version=2.361.1
+```
 
 allows you to spin up a test Jenkins instance on [localhost] to test your
 local changes before committing.
@@ -26,12 +30,26 @@ This plugin tries to migrate to [Google Java Code Style], please try to adhere t
 whenever adding new files or making big changes to existing files. If your IDE doesn't support
 this style, you can use the [fmt-maven-plugin], like this:
 
-    $ mvn fmt:format -DfilesNamePattern=ChangedFile\.java
+```
+    mvn fmt:format -DfilesNamePattern=ChangedFile\.java
+```
 
 to reformat Java code in the proper style.
 
 [Google Java Code Style]: https://google.github.io/styleguide/javaguide.html
 [fmt-maven-plugin]: https://github.com/coveo/fmt-maven-plugin
+
+## Code coverage
+
+Test coverage is a percentage measure of the degree to which the source code of a program is executed when a test is run. A program with high test coverage has more of its source code executed during testing, which suggests it has a lower chance of containing undetected software bugs compared to a program with low test coverage. The best way to improve code coverage is writing of automated tests.
+
+To get local liny-by-line coverage report execute this command
+
+```
+    mvn -Djenkins.version=2.361.1 -P enable-jacoco clean verify jacoco:report
+```
+
+The report is then located in *target/site/jacoco/index.html*.
 
 ## License
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,10 @@
  */
 buildPlugin(useContainerAgent: true, configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '11', jenkins: '2.346.3' ],
-  [ platform: 'windows', jdk: '11', jenkins: '2.346.3' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.361.1' ],
+  [ platform: 'windows', jdk: '11', jenkins: '2.361.1' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
-  [ platform: 'linux', jdk: '17', jenkins: '2.361.1' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.361.2' ],
 ])


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

After #383 are tests && build broken, due wrong Jenkins version. Thsi PR will fixed it && improve contributing section too.


### Testing done

We will see, when it build again.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Localizations

N /

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transfered to *.properties files.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
