### PR TITLE
doc: updated document to use label parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 #### Resolve a variable configured with the resource name
 
 ```groovy
-lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
+lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', resource: null) {
   echo env.LOCKED_RESOURCE
 }
 ```
@@ -81,7 +81,7 @@ lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
 When multiple locks are acquired, each will be assigned to a numbered variable:
 
 ```groovy
-lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
+lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2, resource:null) {
   // comma separated names of all acquired locks
   echo env.LOCKED_RESOURCE
 
@@ -108,7 +108,7 @@ documentation.
 #### Multiple resource lock
 
 ```groovy
-lock(label: 'label1', extra: [[resource: 'resource1']]) {
+lock(label: 'label1', extra: [[resource: 'resource1']], resource:null) {
 	echo 'Do something now or never!'
 }
 echo 'Finish'"
@@ -121,7 +121,8 @@ lock(
     [resource: 'resource4'],
     [resource: 'resource2'],
     [label: 'label1', quantity: 2]
-  ]
+  ],
+  resource: null
 ) {
   def lockedResources = env.var.split(',').sort()
   echo "Resources locked: ${lockedResources}"

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
@@ -5,7 +5,7 @@
   <p>
     e.g.:
     <pre>
-lock(label: 'label', variable: 'var') {
+lock(label: 'label', variable: 'var', resource:null) {
     echo "Resource locked: ${env.var}"
 }
 		</pre>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->
See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).
<!-- in case you work on github issue -->
See #413 
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
Be sure any localization files are moved to *.properties files.
Please describe here which language has been translated by you.
English text's are mandatory for new entries.
-->

- [ ] English
- [ ] Franc
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
