### PR TITLE
Use nav-tabs in the resources page

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -29,8 +29,29 @@
       </j:when>
       <j:otherwise>
         <div class="fluid-container">
-          <st:include page="tableResources/table"/>
-          <st:include page="tableLabels/table"/>
+          <!-- Nav tabs -->
+          <ul class="nav nav-tabs" id="lockable-resources-tab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="resources-tab" data-bs-toggle="tab" data-bs-target="#resources"
+                type="button" role="tab" aria-controls="resources" aria-selected="true">${%tab.resources}</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="labels-tab" data-bs-toggle="tab" data-bs-target="#labels" type="button"
+                role="tab" aria-controls="labels" aria-selected="false">${%tab.labels}</button>
+            </li>
+            <!-- more tabs like logs, queue can be added here -->
+          </ul>
+          <!-- Tab panes -->
+          <div class="tab-content">
+            <div class="tab-pane active jenkins-!-margin-top-1" id="resources" role="tabpanel" aria-labelledby="resources-tab">
+              <st:include page="tableResources/table"/>
+            </div>
+          </div>
+          <div class="tab-content">
+            <div class="tab-pane jenkins-!-margin-top-1" id="labels" role="tabpanel" aria-labelledby="labels-tab">
+              <st:include page="tableLabels/table"/>
+            </div>
+          </div>
         </div>
 
         <script type="text/javascript" src="${resURL}/plugin/data-tables-api/js/table.js"/>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.properties
@@ -22,6 +22,9 @@
 
 #headers
 header.resources=Lockable Resources
-#warnig resources not configured
+# tabs
+tab.resources=Resources
+tab.labels=Labels
+#warning resources not configured
 resources.not_configured=There are no resources configured at the moment.
 resources.configure.here=You can configure it <a href="{0}">here</a>.

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -26,7 +26,6 @@ THE SOFTWARE.
   <j:if test="${it.getNumberOfAllLabels() != 0}">
     <st:adjunct includes="io.jenkins.plugins.data-tables"/>
     <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
-    <h2 class="jenkins-!-padding-1">${%header.labels}</h2>
     <div class="table-responsive">
       <table
         class="jenkins-table jenkins-!-margin-bottom-4 data-table"

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-header.labels=Labels
-
 labels.table.column.labels=Labels
 labels.table.column.free=Free
 labels.table.column.assigned=Assigned resources


### PR DESCRIPTION
When you use many resources and many labels, the page /lockable-resources/ might have a long content. Scroll down after every refresh to see labels-status is not very user friendly.

This PR will provide a view in nav-tabs. It is also prepared for futured tabs like log and queues.

![image](https://user-images.githubusercontent.com/89339813/214712571-f83c9754-440e-41db-8404-99ccb0016d3c.png)

Many thx to Vandit Singh @Vandit1604 

### Testing done

Just few manual tests.
Used [Jenkins 2.361.4](https://www.jenkins.io/)

### Proposed upgrade guidelines

N/A

### Localizations

- [x] English
Other localizations shall be provide by Crowdin

### Submitter checklist

- ~~[ ] The Jira / Github issue, if it exists, is well-described.~~
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] Any localizations are transferred to *.properties files.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
