### PR TITLE
Eliminate multiplicate code in LockableResourcesRootAction

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -43,6 +43,8 @@ import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -608,6 +610,19 @@ public class LockableResourcesManager extends GlobalConfiguration {
       }
     }
     save();
+  }
+
+  /** Returns names (IDs) of given *resources*.
+  */
+  @Restricted(NoExternalUse.class)
+  public static List<String> getResourcesNames(List<LockableResource> resources) {
+    List<String> resourceNames = new ArrayList<>();
+    if (resources != null) {
+      for (LockableResource resource : resources) {
+        resourceNames.add(resource.getName());
+      }
+    }
+    return resourceNames;
   }
 
   /** @see #getNextQueuedContext(List, List, boolean, QueuedContextStruct) */

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -164,15 +164,11 @@ public class LockableResourcesRootAction implements RootAction {
   {
     Jenkins.get().checkPermission(UNLOCK);
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     LockableResourcesManager.get().unlock(resources, null);
 
     rsp.forwardToPreviousPage(req);
@@ -184,19 +180,15 @@ public class LockableResourcesRootAction implements RootAction {
   {
     Jenkins.get().checkPermission(RESERVE);
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     String userName = getUserName();
     if (userName != null) {
       if (!LockableResourcesManager.get().reserve(resources, userName)) {
-        rsp.sendError(423, Messages.error_resourceAlreadyLocked(name));
+        rsp.sendError(423, Messages.error_resourceAlreadyLocked(LockableResourcesManager.getResourcesNames(resources)));
         return;
       }
     }
@@ -209,15 +201,11 @@ public class LockableResourcesRootAction implements RootAction {
   {
     Jenkins.get().checkPermission(STEAL);
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     String userName = getUserName();
     if (userName != null) {
       LockableResourcesManager.get().steal(resources, userName);
@@ -239,23 +227,21 @@ public class LockableResourcesRootAction implements RootAction {
       throw new AccessDeniedException3(Jenkins.getAuthentication2(), STEAL);
     }
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
-    if (userName.equals(r.getReservedBy())) {
-      // Can not achieve much by re-assigning the
-      // resource I already hold to myself again,
-      // that would just burn the compute resources.
-      // ...unless something catches the event? (TODO?)
-      return;
+    for (LockableResource resource : resources) {
+      if (userName.equals(resource.getReservedBy())) {
+        // Can not achieve much by re-assigning the
+        // resource I already hold to myself again,
+        // that would just burn the compute resources.
+        // ...unless something catches the event? (TODO?)
+        return;
+      }
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     LockableResourcesManager.get().reassign(resources, userName);
 
     rsp.forwardToPreviousPage(req);
@@ -267,22 +253,20 @@ public class LockableResourcesRootAction implements RootAction {
   {
     Jenkins.get().checkPermission(RESERVE);
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
     String userName = getUserName();
-    if ((userName == null || !userName.equals(r.getReservedBy()))
-        && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
-    ) {
-      throw new AccessDeniedException3(Jenkins.getAuthentication2(), RESERVE);
+    for (LockableResource resource : resources) {
+      if ((userName == null || !userName.equals(resource.getReservedBy()))
+          && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+      ) {
+        throw new AccessDeniedException3(Jenkins.getAuthentication2(), RESERVE);
+      }
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     LockableResourcesManager.get().unreserve(resources);
 
     rsp.forwardToPreviousPage(req);
@@ -295,15 +279,11 @@ public class LockableResourcesRootAction implements RootAction {
     Jenkins.get().checkPermission(UNLOCK);
     // Should this also be permitted by "STEAL"?..
 
-    String name = req.getParameter("resource");
-    LockableResource r = LockableResourcesManager.get().fromName(name);
-    if (r == null) {
-      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+    List<LockableResource> resources = this.getResourcesFromRequest(req, rsp);
+    if (resources == null) {
       return;
     }
 
-    List<LockableResource> resources = new ArrayList<>();
-    resources.add(r);
     LockableResourcesManager.get().reset(resources);
 
     rsp.forwardToPreviousPage(req);
@@ -332,5 +312,21 @@ public class LockableResourcesRootAction implements RootAction {
 
       rsp.forwardToPreviousPage(req);
     }
+  }
+
+  private List<LockableResource> getResourcesFromRequest(final StaplerRequest req, final StaplerResponse rsp) throws IOException, ServletException {
+    // todo, when you try to improve the API to use multiple resources (a list instead of single one)
+    // this will be the best place to change it. Probably it will be enough to add a code piece here
+    // like req.getParameter("resources"); And split the content by some delimiter like ' ' (space)
+    String name = req.getParameter("resource");
+    LockableResource r = LockableResourcesManager.get().fromName(name);
+    if (r == null) {
+      rsp.sendError(404, Messages.error_resourceDoesNotExist(name));
+      return null;
+    }
+
+    List<LockableResource> resources = new ArrayList<>();
+    resources.add(r);
+    return resources;
   }
 }


### PR DESCRIPTION
One of multiple refactoring PRs.
This one will eliminate multiplicated code in LockableResourcesRootAction and also prepare it to improve the API to handle with multiple resources in one request.

### Testing done

Provide some manual tests. Automatic tests are OK (at my local node) I do not provide new automatic tests, because the lines shall be covered by 'legacy' tests as well.

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- ~~[ ] The Jira / Github issue, if it exists, is well-described.~~
  There is no extra issue for this changes
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
