### PR TITLE
Inform user when resource-action was performed

### DIFF
--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -10,11 +10,13 @@ function find_resource_name(element) {
 function resource_action(button, action) {
   // TODO: Migrate to form:link after Jenkins 2.233 (for button-styled links)
   var form = document.createElement('form');
+  var resourceName = find_resource_name(button);
   form.setAttribute('method', 'POST');
-  form.setAttribute('action', action + "?resource=" + encodeURIComponent(find_resource_name(button)));
+  form.setAttribute('action', action + "?resource=" + encodeURIComponent(resourceName));
   crumb.appendToForm(form);
   document.body.appendChild(form);
   form.submit();
+  notificationBar.show(action + ' was successfully performed on ' + resourceName, notificationBar.SUCCESS);
 }
 
 function replaceNote(element, resourceName) {


### PR DESCRIPTION
Use notification bar, to inform user, when his action was done successfully.

### Testing done

![image](https://user-images.githubusercontent.com/89339813/217395903-cfa71039-7308-4666-b510-0527bf6282ba.png)


### Proposed upgrade guidelines

N/A

### Localizations

- [x] English

> note: no Idea hot can be correct localized in javascript code.

### Submitter checklist

- ~~[ ] The Jira / Github issue, if it exists, is well-described.~~
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- ~~[ ] There is automated testing or an explanation that explains why this change has no tests.~~
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
