### PR TITLE
Fix resource not locked when previous job finishes when matched with label

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -293,13 +293,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       Long queueItemId = entry.getKey();
       List<LockableResource> candidates = entry.getValue();
       if (candidates != null && (candidates.size() == 0 || candidates.contains(candidate))) {
-        if (candidates.size() < 2) {
-          // Nothing is there, or would be after removing the one entry
-          cachedCandidates.invalidate(queueItemId);
-        } else {
-          // Reduce the referenced list
-          candidates.remove(candidate);
-        }
+        cachedCandidates.invalidate(queueItemId);
       }
     }
 


### PR DESCRIPTION
Fix an issue where resource would not be locked upon becoming free when using a label, but the job would still start.

The cause is this cache introduced to store the results of resource-matching scripts or labels, to avoid re-executing them too often. The previous behaviour was to remove the newly-freed resource from the candidates cache. But the next job would use the candidates cache without any further re-computation, so it would end up with that resource not being locked.

I don't think it's appropriate to modify the contents of the candidates cache, we don't know for what reason the candidates are included/excluded.

### Cache-purpose thoughts...

I don't even really see the need to invalidate the cache, but I kept that in to keep the previous behaviour, while still fixing my issue. I suppose it would help if you have a complex resource matching script that considers the availability of each resource when selecting its candidates. But this newly-freed resource is already in the proposed candidates, so shouldn't it be the other-way around, maybe other scripts which didn't select this resource now might want to? Along that line of thinking, maybe we should invalidate every entry in the candidate cache whenever something becomes free?

Anyway in this case, the worst outcome of wrong logic is a wait of up to 5 minutes for the cache to time out. I don't use resource matching scripts myself so not going to touch it.

### Testing done

I added a test to reproduce my use case, it fails without the code change, and passes with it.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transferred to *.properties files.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
