### PR TITLE
Add column index to show resources the admin predefined order

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -37,9 +37,11 @@ THE SOFTWARE.
     <table class="jenkins-table jenkins-!-margin-bottom-4 data-table"
            id="lockable-resources"
           isLoaded="true"
-          data-columns-definition="[null, null, null, null, null]"
+          data-columns-definition="[null, null, null, null, null, null]"
           data-table-configuration="{}">
       <colgroup>
+        <!-- index -->
+        <col class="col-width-0 text-end" />
         <!-- resouce -->
         <col class="col-width-5 text-end" />
         <!-- status -->
@@ -52,6 +54,7 @@ THE SOFTWARE.
         <col action="col-width-1 text-end" />
       </colgroup>
       <thead>
+        <th>${%resources.table.column.index}</th>
         <th>${%resources.table.column.resource}</th>
         <th>${%resources.table.column.status}</th>
         <th>${%resources.table.column.timestamp}</th>
@@ -61,6 +64,11 @@ THE SOFTWARE.
       <tbody>
         <j:forEach var="resource" items="${it.resources}" indexVar="i">
           <tr data-resource-name="${resource.name}">
+            <!-- **************************************************************
+                 Index
+            -->
+            <td>${i + 1}</td>
+
             <!-- **************************************************************
                  Column with common resource data
             -->

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 #table resources
+resources.table.column.index=Index
 resources.table.column.resource=Resource
 resources.table.column.status=Status
 resources.table.column.labels=Labels

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_cs.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 #table resources
+resources.table.column.index=Index
 resources.table.column.resource=Zdroj
 resources.table.column.status=Stav
 resources.table.column.labels=Popisky

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_de.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 #table resources
+resources.table.column.index=Index
 resources.table.column.resource=Ressource
 resources.table.column.status=Status
 resources.table.column.labels=Labels

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_fr.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 #table resources
+resources.table.column.index=Index
 resources.table.column.resource=Ressource
 resources.table.column.status=Statut
 resources.table.column.labels=Libell\u00e9s

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_sk.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 #table resources
+resources.table.column.index=Index
 resources.table.column.resource=Zdroj
 resources.table.column.status=Stav
 resources.table.column.labels=\u0160t\u00edtky


### PR DESCRIPTION
Closes: #460

### Testing done

Manual tested and it looks good.

![image](https://user-images.githubusercontent.com/89339813/224172345-3378640f-1375-42c9-bed4-4a62cbc65578.png)


### Proposed upgrade guidelines

N/A

### Localizations

- [x] English
- [x] German
- [x] French
- [x] Slovak
- [x] Czech

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
