### PR TITLE
Fix broken docs links

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-label.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-label.html
@@ -8,7 +8,7 @@
   <p>
     See also
     <a href="https://github.com/jenkinsci/lockable-resources-plugin#multiple-resource-lock">examples</a> and
-    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipiline.md">Scripted vs declarative pipeline</a>
+    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipeline.md">Scripted vs declarative pipeline</a>
     .
   </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-variable.html
@@ -5,7 +5,7 @@
   <p>
     See also
     <a href="https://github.com/jenkinsci/lockable-resources-plugin#resolve-a-variable-configured-with-the-resource-name">examples</a> and
-    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipiline.md">Scripted vs declarative pipeline</a>
+    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipeline.md">Scripted vs declarative pipeline</a>
     .
   </p>
 </div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStepResource/help-label.html
@@ -8,7 +8,7 @@
   <p>
     See also
     <a href="https://github.com/jenkinsci/lockable-resources-plugin#multiple-resource-lock">examples</a> and
-    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipiline.md">Scripted vs declarative pipeline</a>
+    <a href="https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/scripted-vs-declarative-pipeline.md">Scripted vs declarative pipeline</a>
     .
   </p>
 </div>


### PR DESCRIPTION
## Fix broken documentation links

Fixes https://github.com/jenkins-infra/jenkins.io/issues/6186 by using the correct spelling of the word "pipeline" in the link.

Thanks to https://github.com/jjmastro for reporting the issue through the Jenkins documentation site.

### Testing done

* Confirmed that the link to "Scripted vs. declarative pipeline" at the bottom of https://www.jenkins.io/doc/pipeline/steps/lockable-resources/ is broken
* Confirmed that the replacement link inserted into the documentation page is now correct

The https://www.jenkins.io/doc/pipeline/steps/lockable-resources/ page won't be updated until the next release of the lockable resources plugin.

### Proposed upgrade guidelines

N/A

### Localizations

- [x] English
- [x] German
- [x] French
- [x] Slovak
- [x] Czech

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transferred to *.properties files.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
