### PR TITLE
Remember search text in tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist> 
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
         class="jenkins-table jenkins-!-margin-bottom-4 data-table"
         id="lockable-resources-labels"
         isLoaded="true"
+        data-remember-search-text="true"
         data-columns-definition="[null, null, null, null]"
         data-table-configuration="{}"
       >

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
@@ -50,6 +50,7 @@ THE SOFTWARE.
       class="jenkins-table jenkins-!-margin-bottom-4 data-table"
       id="lockable-resources-queue"
       isLoaded="true"
+      data-remember-search-text="true"
       data-columns-definition="[null, null, null, null, null]"
       data-table-configuration="{}"
     >

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -34,11 +34,14 @@ THE SOFTWARE.
   <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
 
   <div class="table-responsive">
-    <table class="jenkins-table jenkins-!-margin-bottom-4 data-table"
-           id="lockable-resources"
-          isLoaded="true"
-          data-columns-definition="[null, null, null, null, null, null]"
-          data-table-configuration="{}">
+    <table
+      class="jenkins-table jenkins-!-margin-bottom-4 data-table"
+      id="lockable-resources"
+      data-remember-search-text="true"
+      isLoaded="true"
+      data-columns-definition="[null, null, null, null, null, null]"
+      data-table-configuration="{}"
+    >
       <colgroup>
         <!-- index -->
         <col class="col-width-0 text-end" />


### PR DESCRIPTION
fix #461

### Testing done

Currently tested manually and it works. You need to update https://plugins.jenkins.io/data-tables-api/ manually to last version. Changeing version in the pom does not helps (it will not build)

### Proposed upgrade guidelines

Update https://plugins.jenkins.io/data-tables-api/ to latest version manually in plugin manager page.

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~