### PR TITLE
Allow to use Jenkins label parser to allocate lockable-resources in more sophisticated way

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,10 @@
  */
 buildPlugin(useContainerAgent: true, configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '11', jenkins: '2.361.4' ],
-  [ platform: 'windows', jdk: '11', jenkins: '2.361.4' ],
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11'],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
-  [ platform: 'linux', jdk: '17', jenkins: '2.361.4' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.387.1' ],
 ])

--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ Detailed documentation can be found as part of the
 [Pipeline Steps](https://jenkins.io/doc/pipeline/steps/lockable-resources/)
 documentation.
 
+### Jenkins label parser allows sophisticated filtering
+
+```groovy
+lock(label: 'os:Windows && ALM', variable : 'someVar') {
+    echo 'os:Windows && ALM acquired by: ' + env.someVar;
+}
+
+lock(label: 'osDetail:Debian[11] && arm64', variable : 'someVar') {
+    echo 'osDetail:Debian[11] && arm64 acquired by: ' + env.someVar;
+}
+
+lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar') {
+    echo 'os:Windows || osDetail:Debian[11] acquired by: ' + env.someVar;
+}
+
+lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar', quantity : 100) {
+    echo 'os:Windows || osDetail:Debian[11] acquired by: ' + env.someVar;
+}
+```
+
 #### Multiple resource lock
 
 ```groovy
@@ -162,6 +182,7 @@ echo 'Finish'
 More examples are [here](src/doc/examples/readme.md).
 
 ----
+
 ## Configuration as Code
 
 This plugin can be configured via

--- a/README.md
+++ b/README.md
@@ -140,20 +140,16 @@ documentation.
 The plugin uses the Jenkins-internal label parser for filtering lockable resources. A full list of supported operators and syntax examples can be found in the [official documentation](https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#node-allocate-node).
 
 ```groovy
-lock(label: 'os:Windows && ALM', variable : 'someVar') {
-    echo 'os:Windows && ALM acquired by: ' + env.someVar;
+lock(label: 'labelA && labelB', variable : 'someVar') {
+    echo 'labelA && labelB acquired by: ' + env.someVar;
 }
 
-lock(label: 'osDetail:Debian[11] && arm64', variable : 'someVar') {
-    echo 'osDetail:Debian[11] && arm64 acquired by: ' + env.someVar;
+lock(label: 'labelA || labelB', variable : 'someVar') {
+    echo 'labelA || labelB acquired by: ' + env.someVar;
 }
 
-lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar') {
-    echo 'os:Windows || osDetail:Debian[11] acquired by: ' + env.someVar;
-}
-
-lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar', quantity : 100) {
-    echo 'os:Windows || osDetail:Debian[11] acquired by: ' + env.someVar;
+lock(label: 'labelA || labelB || labelC', variable : 'someVar', quantity : 100) {
+    echo 'labelA || labelB || labelC acquired by: ' + env.someVar;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ documentation.
 
 ### Jenkins label parser allows sophisticated filtering
 
+The plugin uses the Jenkins-internal label parser for filtering lockable resources. A full list of supported operators and syntax examples can be found in the [official documentation](https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#node-allocate-node).
+
 ```groovy
 lock(label: 'os:Windows && ALM', variable : 'someVar') {
     echo 'os:Windows && ALM acquired by: ' + env.someVar;

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist> 
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -242,6 +242,10 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   //----------------------------------------------------------------------------
   public boolean isValidLabel(String candidate, Map<String, Object> params) {
+    if (candidate == null || candidate.isEmpty()) {
+      return false;
+    }
+
     if (labelsContain(candidate)) {
       return true;
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -20,19 +20,23 @@ import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Label;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
 import hudson.model.Run;
 import hudson.model.User;
+import hudson.model.labels.LabelAtom;
 import hudson.tasks.Mailer.UserProperty;
 import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -236,10 +240,22 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     return this.labelsContain(labelToFind);
   }
 
+  //----------------------------------------------------------------------------
   public boolean isValidLabel(String candidate, Map<String, Object> params) {
-    return labelsContain(candidate);
+    if (labelsContain(candidate)) {
+      return true;
+    }
+
+    final Label labelExpression = Label.parseExpression(candidate);
+    Set<LabelAtom> atomLabels = new HashSet<>();
+    for(String label : this.getLabelsAsList()) {
+      atomLabels.add(new LabelAtom(label));
+    }
+
+    return labelExpression.matches(atomLabels);
   }
 
+  //----------------------------------------------------------------------------
   /**
    * Checks if the resource contain label *candidate*.
    * @param candidate Labels to find.

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -241,8 +241,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   //----------------------------------------------------------------------------
-  public boolean isValidLabel(String candidate, Map<String, Object> params) {
-    if (candidate == null || candidate.isEmpty()) {
+  public boolean isValidLabel(@NonNull String candidate, Map<String, Object> params) {
+    if (candidate.isEmpty()) {
       return false;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -241,8 +241,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   //----------------------------------------------------------------------------
-  public boolean isValidLabel(@NonNull String candidate, Map<String, Object> params) {
-    if (candidate.isEmpty()) {
+  public boolean isValidLabel(String candidate, Map<String, Object> params) {
+    if (candidate == null || candidate.isEmpty()) {
       return false;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -143,10 +143,22 @@ public class LockableResourcesManager extends GlobalConfiguration {
     return matching;
   }
 
+  //----------------------------------------------------------------------------
   public Boolean isValidLabel(String label) {
-    return this.getAllLabels().contains(label);
+    if (this.getAllLabels().contains(label))
+      return true;
+
+    final Map<String, Object> params = null;
+    for (LockableResource r : this.resources) {
+      if (r.isValidLabel(label, params)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
+  //----------------------------------------------------------------------------
   public Set<String> getAllLabels() {
     Set<String> labels = new HashSet<>();
     for (LockableResource r : this.resources) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -186,6 +186,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   public List<LockableResource> getResourcesWithLabel(String label, Map<String, Object> params) {
     List<LockableResource> found = new ArrayList<>();
+    if (label == null || label.isEmpty()) {
+      return found;
+    }
     for (LockableResource r : this.resources) {
       if (r.isValidLabel(label, params)) found.add(r);
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -144,7 +144,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
   }
 
   //----------------------------------------------------------------------------
-  public Boolean isValidLabel(String label) {
+  @SuppressFBWarnings(value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
+                      justification = "null value is checked correctly")
+  public Boolean isValidLabel(@Nullable String label) {
+    if (label == null || label.isEmpty()) {
+      return false;
+    }
     if (this.getAllLabels().contains(label))
       return true;
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -412,6 +412,13 @@ public class LockableResourcesRootActionTest extends LockStepTestBase {
     assertEquals("initial check", 2, action.getAssignedResourceAmount("resource-label-2"));
     assertEquals("initial check", 1, action.getAssignedResourceAmount("resource-label-3"));
 
+    // check label parsing
+    assertEquals("check after reservation", 3, action.getAssignedResourceAmount("resource-label-1"));
+    assertEquals("check after reservation", 1, action.getAssignedResourceAmount("resource-label-1 && resource-label-2 && resource-label-3"));
+    assertEquals("check after reservation", 2, action.getAssignedResourceAmount("resource-label-1 && resource-label-2"));
+    assertEquals("check after reservation", 2, action.getAssignedResourceAmount("resource-label-3 || resource-label-2"));
+
+
     // reserve one resource. Amount of assigned labels should change
     when(req.getParameter("resource")).thenReturn("resource-A");
     action.doReserve(req, rsp);


### PR DESCRIPTION
Allow to use jenkins label parser to allocate lockbale-resources in more sofisticate way.

Example:

```
lock(label: 'os:Windows && ALM', variable : 'someVar') {
    echo 'os:Windows && ALM ' + env.someVar;
}

lock(label: 'osDetail:Debian[11] && arm64', variable : 'someVar') {
    echo 'osDetail:Debian[11] && arm64 ' + env.someVar;
}

lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar') {
    echo 'os:Windows || osDetail:Debian[11] ' + env.someVar;
}

lock(label: 'os:Windows || osDetail:Debian[11]', variable : 'someVar', quantity : 100) {
    echo 'os:Windows || osDetail:Debian[11] ' + env.someVar;
}
```

fix #428
close #309
close #474 107

see #341
see #455


### Testing done

My local tests (exact with the example bellow) looks good.

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
~~- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
~~- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
~~- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
~~- [ ] For new APIs and extension points, there is a link to at least one consumer.~~
~~- [ ] Any localizations are transferred to *.properties files.~~
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
