### PR TITLE
Enable Jenkins node (agent) mirroring into lockable-resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,28 @@ More examples are [here](src/doc/examples/readme.md).
 
 ----
 
+## Node mirroring
+
+Lockable resources plugin allow to mirror nodes (agents) into lockable resources. This eliminate effort by re-creating resources on every node change.
+
+That means when you create new node, it will be also created new lockable-resource with the same name. When the node has been deleted, lockable-resource will be deleted too.
+
+Following properties are mirrored:
+
+- name.
+- labels. Please note, that labels still contains node-name self.
+- description.
+
+To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR=true` or run this groovy code.
+
+```groovy
+System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
+```
+
+note: When the node has been deleted, during the lockable-resource is locked / reserved / queued, then the lockable-resource will be NOT deleted.
+
+----
+
 ## Configuration as Code
 
 This plugin can be configured via

--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -34,7 +34,7 @@ public final class BackwardCompatibility {
   @Initializer(after = InitMilestone.JOB_LOADED)
   public static void compatibilityMigration() {
     List<LockableResource> resources = LockableResourcesManager.get().getResources();
-    LOG.log(Level.FINE, "lockable-resource-plugin compatibility migration task run for " + resources.size() + " resources");
+    LOG.log(Level.FINE, "lockable-resources-plugin compatibility migration task run for " + resources.size() + " resources");
     for (LockableResource resource : resources) {
       List<StepContext> queuedContexts = resource.getQueuedContexts();
       if (!queuedContexts.isEmpty()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -100,6 +100,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   private static final long serialVersionUID = 1L;
 
+  private transient boolean isNode = false;
+
   /**
    * Was used within the initial implementation of Pipeline functionality using {@link LockStep},
    * but became deprecated once several resources could be locked at once. See queuedContexts in
@@ -152,6 +154,14 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @ExcludeFromJacocoGeneratedReport
   public List<StepContext> getQueuedContexts() {
     return this.queuedContexts;
+  }
+
+  public boolean isNodeResource() {
+    return isNode;
+  }
+
+  public void setNodeResource(boolean b) {
+    isNode = b;
   }
 
   @Exported
@@ -321,6 +331,11 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @Exported
   public String getReservedBy() {
     return reservedBy;
+  }
+
+  /** Return true when resource is free. False otherwise*/
+  public boolean isFree() {
+    return (!this.isLocked() && !this.isReserved() && !this.isQueued());
   }
 
   @Exported

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -74,7 +74,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   public synchronized List<LockableResource> getDeclaredResources() {
     ArrayList<LockableResource> declaredResources = new ArrayList<>();
     for (LockableResource r : resources) {
-      if (!r.isEphemeral()) {
+      if (!r.isEphemeral() && !r.isNodeResource()) {
         declaredResources.add(r);
       }
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -48,6 +48,36 @@ public class NodesMirror extends ComputerListener {
     if (!isNodeMirrorEnabled()) {
       return;
     }
+
+    deleteExistingNodes();
+
+    for (Node n : Jenkins.get().getNodes()) {
+      mirrorNode(n);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  private static void deleteExistingNodes() {
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
+    while (resourceIterator.hasNext()) {
+      LockableResource resource = resourceIterator.next();
+      if (!resource.isNodeResource()) {
+        continue;
+      }
+      if (resource.isFree()) {
+        // we can remove this resource. Is newer used currently
+        resourceIterator.remove();
+      } else {
+        LOG.log(Level.FINE, "lockable-resources-plugin skip node deletion of: " + nodeResource.getName() + ". Reason: Currenty locked");
+      }
+    }
+  }
+    
+  private static void mirrorNodes() {
+    if (!isNodeMirrorEnabled()) {
+      return;
+    }
     LockableResourcesManager lrm = LockableResourcesManager.get();
     Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
     while (resourceIterator.hasNext()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
+import org.jenkins.plugins.lockableresources.util.Constants;
 
 //-----------------------------------------------------------------------------
 /** Mirror Jenkins nodes to lockable-resources
@@ -27,7 +28,7 @@ public class NodesMirror extends ComputerListener {
 
   //---------------------------------------------------------------------------
   private static boolean isNodeMirrorEnabled() {
-    return SystemProperties.getBoolean("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR");
+    return SystemProperties.getBoolean(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR);
   }
 
   //---------------------------------------------------------------------------
@@ -69,27 +70,8 @@ public class NodesMirror extends ComputerListener {
         // we can remove this resource. Is newer used currently
         resourceIterator.remove();
       } else {
-        LOG.log(Level.FINE, "lockable-resources-plugin skip node deletion of: " + nodeResource.getName() + ". Reason: Currenty locked");
+        LOG.log(Level.FINE, "lockable-resources-plugin skip node deletion of: " + resource.getName() + ". Reason: Currently locked");
       }
-    }
-  }
-    
-  private static void mirrorNodes() {
-    if (!isNodeMirrorEnabled()) {
-      return;
-    }
-    LockableResourcesManager lrm = LockableResourcesManager.get();
-    Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
-    while (resourceIterator.hasNext()) {
-      LockableResource resource = resourceIterator.next();
-      if (resource.isNodeResource() && resource.isFree()) {
-        // we can remove this resource. Is newer used currently
-        resourceIterator.remove();
-      }
-    }
-
-    for (Node n : Jenkins.get().getNodes()) {
-      mirrorNode(n);
     }
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -1,0 +1,87 @@
+
+
+package org.jenkins.plugins.lockableresources;
+
+
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.slaves.ComputerListener;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
+
+//-----------------------------------------------------------------------------
+/** Mirror Jenkins nodes to lockable-resources
+*/
+@Extension
+public class NodesMirror extends ComputerListener {
+
+  private static final Logger LOG = Logger.getLogger(NodesMirror.class.getName());
+
+  //---------------------------------------------------------------------------
+  private static boolean isNodeMirrorEnabled() {
+    return SystemProperties.getBoolean("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR");
+  }
+
+  //---------------------------------------------------------------------------
+  @Initializer(after = InitMilestone.JOB_LOADED)
+  public static void createNodeResources() {
+    LOG.log(Level.FINE, "lockable-resources-plugin configure node resources");
+    mirrorNodes();
+  }
+
+  //---------------------------------------------------------------------------
+  @Override
+  public final void onConfigurationChange() {
+    mirrorNodes();
+  }
+
+  //---------------------------------------------------------------------------
+  private static void mirrorNodes() {
+    if (!isNodeMirrorEnabled()) {
+      return;
+    }
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
+    while (resourceIterator.hasNext()) {
+      LockableResource resource = resourceIterator.next();
+      if (resource.isNodeResource() && resource.isFree()) {
+        // we can remove this resource. Is newer used currently
+        resourceIterator.remove();
+      }
+    }
+
+    for (Node n : Jenkins.get().getNodes()) {
+      mirrorNode(n);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  private static void mirrorNode(Node node) {
+    if (node == null) {
+      return;
+    }
+
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    LockableResource nodeResource = lrm.fromName(node.getNodeName());
+    boolean exist = nodeResource != null;
+    if (!exist) {
+      nodeResource = new LockableResource(node.getNodeName());
+    }
+    nodeResource.setLabels(node.getAssignedLabels().stream().map(Object::toString).collect(Collectors.joining(" ")));
+    nodeResource.setNodeResource(true);
+    nodeResource.setEphemeral(false);
+    nodeResource.setDescription(node.getNodeDescription());
+    LOG.log(Level.FINE, "lockable-resources-plugin add node-resource: " + nodeResource.getName());
+    if (!exist) {
+      lrm.getResources().add(nodeResource);
+    }
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
@@ -1,0 +1,6 @@
+
+package org.jenkins.plugins.lockableresources.util;
+
+public class Constants {
+  public static final String SYSTEM_PROPERTY_ENABLE_NODE_MIRROR = "org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR";
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -20,7 +21,7 @@ public class NodesMirrorTest {
 
   @Test
   public void mirror_few_nodes() throws Exception {
-    System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
+    System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
 
     j.createSlave("FirstAgent", "label label2", null);
     j.createSlave("SecondAgent", null, null);

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -1,0 +1,82 @@
+package org.jenkins.plugins.lockableresources;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class NodesMirrorTest {
+
+  @Rule public final JenkinsRule j = new JenkinsRule();
+
+  @Test
+  public void mirror_few_nodes() throws Exception {
+    System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
+
+    j.createSlave("FirstAgent", "label label2", null);
+    j.createSlave("SecondAgent", null, null);
+
+    // this is asynchronous operation, so wait until resources are created.
+    for(int i = 1; LockableResourcesManager.get().fromName("SecondAgent") != null && i <= 10; i++) {
+      Thread.sleep(100);
+    }
+
+    LockableResource firstAgent = LockableResourcesManager.get().fromName("FirstAgent");
+
+    assertEquals("FirstAgent", firstAgent.getName());
+    // ! jenkins add always the node name as a label
+    assertEquals("FirstAgent label label2", firstAgent.getLabels());
+
+    LockableResource secondAgent = LockableResourcesManager.get().fromName("SecondAgent");
+    assertEquals("SecondAgent", secondAgent.getName());
+    assertEquals("SecondAgent", secondAgent.getLabels());
+
+    // delete agent
+    j.jenkins.removeNode(j.jenkins.getNode("FirstAgent"));
+
+    for(int i = 1; LockableResourcesManager.get().fromName("FirstAgent") == null && i <= 10; i++) {
+      Thread.sleep(100);
+    }
+    assertNull(LockableResourcesManager.get().fromName("FirstAgent"));
+    assertNotNull(LockableResourcesManager.get().fromName("SecondAgent"));
+  }
+
+  @Test
+  public void mirror_locked_nodes() throws Exception {
+    System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
+
+    j.createSlave("FirstAgent", "label label2", null);
+    // this is asynchronous operation, so wait until resources has been created.
+    for(int i = 1; LockableResourcesManager.get().fromName("FirstAgent") != null && i <= 10; i++) {
+      Thread.sleep(100);
+    }
+    assertNotNull(LockableResourcesManager.get().fromName("FirstAgent"));
+
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        "lock(label: 'label && label2', variable : 'lockedNode') {\n"
+          + " echo 'wait for node: ' + env.lockedNode\n"
+          + "	semaphore 'wait-inside'\n"
+          + "}\n"
+          + "echo 'Finish'",
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+    j.waitForMessage("wait for node: FirstAgent", b1);
+    SemaphoreStep.waitForStart("wait-inside/1", b1);
+    j.jenkins.removeNode(j.jenkins.getNode("FirstAgent"));
+    SemaphoreStep.success("wait-inside/1", null);
+    // this resource is not removed, because it was locked.
+    Thread.sleep(1000);
+    assertNotNull(LockableResourcesManager.get().fromName("FirstAgent"));
+  }
+}


### PR DESCRIPTION
See also #455

Thic change allow to mirror Jenkins nodes (agents) into lockable resources.
Following properties are mirrored.
- name
- labels
- description

### Testing done

Automatic test added

### Proposed upgrade guidelines

N/A

### Localizations
NN

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
