### PR TITLE
Upgrade plugin parent POM from 4.59 to 4.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.59</version>
+    <version>4.60</version>
     <relativePath />
   </parent>
 
@@ -148,7 +148,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Supersedes #488. Adapts to https://github.com/mockito/mockito/pull/2945 by switching our dependency from `mockito-inline` to `mockito-core`.