### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -2,7 +2,7 @@
 // Copyright (c) 2020, Tobias Gruetzmacher
 
 function find_resource_name(element) {
-  var row = element.up('tr');
+  var row = element.closest('tr');
   var resourceName = row.getAttribute('data-resource-name');
   return resourceName;
 }
@@ -21,20 +21,24 @@ function resource_action(button, action) {
 
 function replaceNote(element, resourceName) {
   var d = document.getElementById("note-" + resourceName);
-  $(d).innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
-  new Ajax.Request(
-    "noteForm",
-    {
-      parameters: { resource: resourceName },
-      onComplete: function (x) {
-        d.innerHTML = x.responseText;
-        evalInnerHtmlScripts(x.responseText, function () {
+  d.innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
+  fetch("noteForm", {
+    method: "post",
+    headers: crumb.wrap({
+      "Content-Type": "application/x-www-form-urlencoded",
+    }),
+    body: new URLSearchParams({
+      resource: resourceName,
+    }),
+  }).then((rsp) => {
+      rsp.text().then((responseText) => {
+        d.innerHTML = responseText;
+        evalInnerHtmlScripts(responseText, function () {
           Behaviour.applySubtree(d);
           d.getElementsByTagName("TEXTAREA")[0].focus();
         });
         layoutUpdateCallback.call();
-      }
-    }
-  );
+      });
+  });
   return false;
 }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), went to the Lockable Resources page and added a note to an existing resource while stepping through the changed lines in the debugger. I verified the changed lines were executed successfully.