### PR TITLE
Use synchronized to make the plugin thread safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,32 @@ To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockable
 System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
 ```
 
-note: When the node has been deleted, during the lockable-resource is locked / reserved / queued, then the lockable-resource will be NOT deleted.
+> *Note:* When the node has been deleted, during the lockable-resource is locked / reserved / queued, then the lockable-resource will be NOT deleted.
 
 ----
+
+## Improve performance
+
+To be safe thread over all jobs and resources, need to be all operations synchronized.
+This might lead to slow down you jobs. The jenkins self, has low CPU usage, but your jobs are very slow. Why?
+
+The most time are spend to write the lockable-resources states into local file system. This is important to get the correct state after Jenkins reboots.
+
+To eliminate this saving time has been added a property *SYSTEM_PROPERTY_DISABLE_SAVE*
+
++ The best way is to use it with JCaC plugin. So you are sure, you have still correct
+resources on the Jenkins start.
++ When you set pipeline durability level to *PERFORMANCE_OPTIMIZED* it makes also sense to set this property to true.
+
+> *Note:* Keep in mind, that you will lost all your manual changes!
+
+> *Note:* This option is experimental. It has been tested in many scenarios, but no body know.
+
+To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockableresources.SYSTEM_PROPERTY_DISABLE_SAVE=true` or run this groovy code.
+
+```groovy
+System.setProperty("org.jenkins.plugins.lockableresources.SYSTEM_PROPERTY_DISABLE_SAVE", "true");
+```
 
 ## Configuration as Code
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -20,9 +20,9 @@ import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 /**
- * This class migrates "active" queuedContexts from LockableResource to LockableResourcesManager
- *
- * @deprecated Migration code for field introduced in 1.8 (since 1.11)
+ * Sometimes after re-starts (jenkins crashed or what ever) are resources still
+ * locked by build, but the build is no more running.
+ * This script will 'unlock' all resource assigned to dead builds
  */
 @Deprecated
 @ExcludeFromJacocoGeneratedReport

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -50,7 +50,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     List<LockableResourcesStruct> resourceHolderList = new ArrayList<>();
 
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    synchronized(lrm) {
+    synchronized (lrm) {
       for (LockStepResource resource : step.getResources()) {
         List<String> resources = new ArrayList<>();
         if (resource.resource != null) {
@@ -193,7 +193,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
     @Override
     protected void finished(StepContext context) throws Exception {
       LockableResourcesManager lrm = LockableResourcesManager.get();
-      synchronized(lrm) {
+      synchronized (lrm) {
         lrm.unlockNames(this.resourceNames, context.get(Run.class), this.inversePrecedence);
       }
       context
@@ -208,7 +208,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
   public void stop(@NonNull Throwable cause) {
     LockableResourcesManager lrm = LockableResourcesManager.get();
     boolean cleaned = false;
-    synchronized(lrm) {
+    synchronized (lrm) {
       cleaned = lrm.unqueueContext(getContext());
     }
     if (!cleaned) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -13,6 +13,8 @@ import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.AncestorInPath;
@@ -30,6 +32,8 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
   public String label = null;
 
   public int quantity = 0;
+
+  private static final Logger LOGGER = Logger.getLogger(LockStepResource.class.getName());
 
   LockStepResource(@Nullable String resource, @Nullable String label, int quantity) {
     this.resource = resource;
@@ -91,12 +95,15 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
     if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
       throw new IllegalArgumentException(Messages.error_labelAndNameSpecified());
     }
+
+    LOGGER.finest("validate:: get LRM");
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    synchronized(lrm) {
-      if (label != null && !lrm.isValidLabel( label ) ) {
-        throw new IllegalArgumentException(Messages.error_labelDoesNotExist(label));
-      }
+    LOGGER.finest("validate:: validate label");
+    if (label != null && !lrm.isValidLabel( label ) ) {
+      throw new IllegalArgumentException(Messages.error_labelDoesNotExist(label));
     }
+    LOGGER.finest("validate:: validate label done");
+
     if (resourceSelectStrategy != null ) {
       try {
         ResourceSelectStrategy.valueOf(resourceSelectStrategy.toUpperCase(Locale.ENGLISH));
@@ -143,10 +150,8 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
         return FormValidation.error(Messages.error_labelOrNameMustBeSpecified());
       }
       LockableResourcesManager lrm = LockableResourcesManager.get();
-      synchronized(lrm) {
-        if (resourceLabel != null && !lrm.isValidLabel(resourceLabel)) {
-          return FormValidation.error(Messages.error_labelDoesNotExist(resourceLabel));
-        }
+      if (resourceLabel != null && !lrm.isValidLabel(resourceLabel)) {
+        return FormValidation.error(Messages.error_labelDoesNotExist(resourceLabel));
       }
       return FormValidation.ok();
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -91,8 +91,11 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
     if (label != null && !label.isEmpty() && resource !=  null && !resource.isEmpty()) {
       throw new IllegalArgumentException(Messages.error_labelAndNameSpecified());
     }
-    if (label != null && !LockableResourcesManager.get().isValidLabel( label ) ) {
-      throw new IllegalArgumentException(Messages.error_labelDoesNotExist(label));
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    synchronized(lrm) {
+      if (label != null && !lrm.isValidLabel( label ) ) {
+        throw new IllegalArgumentException(Messages.error_labelDoesNotExist(label));
+      }
     }
     if (resourceSelectStrategy != null ) {
       try {
@@ -139,8 +142,11 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
       if ((resourceLabel == null) && (resourceName == null)) {
         return FormValidation.error(Messages.error_labelOrNameMustBeSpecified());
       }
-      if (resourceLabel != null && !LockableResourcesManager.get().isValidLabel(resourceLabel)) {
-        return FormValidation.error(Messages.error_labelDoesNotExist(resourceLabel));
+      LockableResourcesManager lrm = LockableResourcesManager.get();
+      synchronized(lrm) {
+        if (resourceLabel != null && !lrm.isValidLabel(resourceLabel)) {
+          return FormValidation.error(Messages.error_labelDoesNotExist(resourceLabel));
+        }
       }
       return FormValidation.ok();
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -281,17 +281,17 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
       if (candidate == null || candidate.isEmpty()) {
         return false;
       }
-  
+
       if (labelsContain(candidate)) {
         return true;
       }
-  
+
       final Label labelExpression = Label.parseExpression(candidate);
       Set<LabelAtom> atomLabels = new HashSet<>();
       for(String label : this.getLabelsAsList()) {
         atomLabels.add(new LabelAtom(label));
       }
-  
+
       return labelExpression.matches(atomLabels);
     }
   }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -158,15 +158,11 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public boolean isNodeResource() {
-    synchronized (this.name) {
-      return isNode;
-    }
+    return isNode;
   }
 
   public void setNodeResource(boolean b) {
-    synchronized (this.name) {
-      isNode = b;
-    }
+    isNode = b;
   }
 
   @Exported
@@ -176,44 +172,32 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public String getDescription() {
-    synchronized (this.name) {
-      return description;
-    }
+    return description;
   }
 
   @DataBoundSetter
   public void setDescription(String description) {
-    synchronized (this.name) {
-      this.description = Util.fixNull(description);
-    }
+    this.description = Util.fixNull(description);
   }
 
   @Exported
   public String getNote() {
-    synchronized (this.name) {
-      return this.note;
-    }
+    return this.note;
   }
 
   @DataBoundSetter
   public void setNote(String note) {
-    synchronized (this.name) {
-      this.note = Util.fixNull(note);
-    }
+    this.note = Util.fixNull(note);
   }
 
   @DataBoundSetter
   public void setEphemeral(boolean ephemeral) {
-    synchronized (this.name) {
-      this.ephemeral = ephemeral;
-    }
+    this.ephemeral = ephemeral;
   }
 
   @Exported
   public boolean isEphemeral() {
-    synchronized (this.name) {
-      return ephemeral;
-    }
+    return ephemeral;
   }
 
   /** Use getLabelsAsList instead
@@ -223,12 +207,10 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @Deprecated
   @Exported
   public String getLabels() {
-    synchronized (this.name) {
-      if (this.labelsAsList == null) {
-        return "";
-      }
-      return String.join(" ", this.labelsAsList);
+    if (this.labelsAsList == null) {
+      return "";
     }
+    return String.join(" ", this.labelsAsList);
   }
 
   /** @deprecated no equivalent at the time.
@@ -240,15 +222,13 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   // @Deprecated can not be used, because of JCaC
   @DataBoundSetter
   public void setLabels(String labels) {
-    synchronized (this.name) {
-      // todo use label parser from Jenkins.Label to allow the same syntax
-      this.labelsAsList = new ArrayList<>();
-      for(String label : labels.split("\\s+")) {
-        if (label == null || label.isEmpty()) {
-          continue;
-        }
-        this.labelsAsList.add(label);
+    // todo use label parser from Jenkins.Label to allow the same syntax
+    this.labelsAsList = new ArrayList<>();
+    for(String label : labels.split("\\s+")) {
+      if (label == null || label.isEmpty()) {
+        continue;
       }
+      this.labelsAsList.add(label);
     }
   }
 
@@ -258,9 +238,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Exported
   public List<String> getLabelsAsList() {
-    synchronized (this.name) {
-      return this.labelsAsList;
-    }
+    return this.labelsAsList;
   }
 
   /**
@@ -270,30 +248,26 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Exported
   public boolean hasLabel(String labelToFind) {
-    synchronized (this.name) {
-      return this.labelsContain(labelToFind);
-    }
+    return this.labelsContain(labelToFind);
   }
 
   //----------------------------------------------------------------------------
   public boolean isValidLabel(String candidate, Map<String, Object> params) {
-    synchronized (this.name) {
-      if (candidate == null || candidate.isEmpty()) {
-        return false;
-      }
-
-      if (labelsContain(candidate)) {
-        return true;
-      }
-
-      final Label labelExpression = Label.parseExpression(candidate);
-      Set<LabelAtom> atomLabels = new HashSet<>();
-      for(String label : this.getLabelsAsList()) {
-        atomLabels.add(new LabelAtom(label));
-      }
-
-      return labelExpression.matches(atomLabels);
+    if (candidate == null || candidate.isEmpty()) {
+      return false;
     }
+
+    if (labelsContain(candidate)) {
+      return true;
+    }
+
+    final Label labelExpression = Label.parseExpression(candidate);
+    Set<LabelAtom> atomLabels = new HashSet<>();
+    for(String label : this.getLabelsAsList()) {
+      atomLabels.add(new LabelAtom(label));
+    }
+
+    return labelExpression.matches(atomLabels);
   }
 
   //----------------------------------------------------------------------------
@@ -303,23 +277,17 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * @return {@code true} if resource contains label *candidate*
    */
   private boolean labelsContain(String candidate) {
-    synchronized (this.name) {
-      return this.getLabelsAsList().contains(candidate);
-    }
+    return this.getLabelsAsList().contains(candidate);
   }
 
   @Exported
   public List<LockableResourceProperty> getProperties() {
-    synchronized (this.name) {
-      return properties;
-    }
+    return properties;
   }
 
   @DataBoundSetter
   public void setProperties(List<LockableResourceProperty> properties) {
-    synchronized (this.name) {
-      this.properties = (properties == null ? new ArrayList<>() : properties);
-    }
+    this.properties = (properties == null ? new ArrayList<>() : properties);
   }
 
   /**
@@ -335,67 +303,55 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   public boolean scriptMatches(
     @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
     throws ExecutionException {
-    synchronized (this.name) {
-      Binding binding = new Binding(params);
-      binding.setVariable("resourceName", name);
-      binding.setVariable("resourceDescription", description);
-      binding.setVariable("resourceLabels", this.getLabelsAsList());
-      binding.setVariable("resourceNote", note);
-      try {
-        Object result =
-          script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding, null);
-        if (LOGGER.isLoggable(Level.FINE)) {
-          LOGGER.fine(
-            "Checked resource "
-              + name
-              + " for "
-              + script.getScript()
-              + " with "
-              + binding
-              + " -> "
-              + result);
-        }
-        return (Boolean) result;
-      } catch (Exception e) {
-        throw new ExecutionException(
-          "Cannot get boolean result out of groovy expression. See system log for more info", e);
+    Binding binding = new Binding(params);
+    binding.setVariable("resourceName", name);
+    binding.setVariable("resourceDescription", description);
+    binding.setVariable("resourceLabels", this.getLabelsAsList());
+    binding.setVariable("resourceNote", note);
+    try {
+      Object result =
+        script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding, null);
+      if (LOGGER.isLoggable(Level.FINE)) {
+        LOGGER.fine(
+          "Checked resource "
+            + name
+            + " for "
+            + script.getScript()
+            + " with "
+            + binding
+            + " -> "
+            + result);
       }
+      return (Boolean) result;
+    } catch (Exception e) {
+      throw new ExecutionException(
+        "Cannot get boolean result out of groovy expression. See system log for more info", e);
     }
   }
 
   @Exported
   public Date getReservedTimestamp() {
-    synchronized (this.name) {
-      return reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
-    }
+    return reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
   }
 
   @DataBoundSetter
   public void setReservedTimestamp(final Date reservedTimestamp) {
-    synchronized (this.name) {
-      this.reservedTimestamp = reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
-    }
+    this.reservedTimestamp = reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
   }
 
   @Exported
   public String getReservedBy() {
-    synchronized (this.name) {
-      return reservedBy;
-    }
+    return reservedBy;
   }
 
   /** Return true when resource is free. False otherwise*/
   public boolean isFree() {
-    synchronized (this.name) {
-      return (!this.isLocked() && !this.isReserved() && !this.isQueued());
-    }
+    return (!this.isLocked() && !this.isReserved() && !this.isQueued());
   }
 
   @Exported
   public boolean isReserved() {
-    synchronized (this.name) {
-      return reservedBy != null;
-    }
+    return reservedBy != null;
   }
 
   @Restricted(NoExternalUse.class)
@@ -415,59 +371,45 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Restricted(NoExternalUse.class) // called by jelly
   public boolean isReservedByCurrentUser() {
-    synchronized (this.name) {
-      return (this.reservedBy != null && StringUtils.equals(getUserName(), this.reservedBy));
-    }
+    return (this.reservedBy != null && StringUtils.equals(getUserName(), this.reservedBy));
   }
 
   @Exported
   public String getReservedByEmail() {
-    synchronized (this.name) {
-      if (isReserved()) {
-        UserProperty email = null;
-        User user = Jenkins.get().getUser(reservedBy);
-        if (user != null) email = user.getProperty(UserProperty.class);
-        if (email != null) return email.getAddress();
-      }
-      return null;
+    if (isReserved()) {
+      UserProperty email = null;
+      User user = Jenkins.get().getUser(reservedBy);
+      if (user != null) email = user.getProperty(UserProperty.class);
+      if (email != null) return email.getAddress();
     }
+    return null;
   }
 
   public boolean isQueued() {
-    synchronized (this.name) {
-      this.validateQueuingTimeout();
-      return queueItemId != NOT_QUEUED;
-    }
+    this.validateQueuingTimeout();
+    return queueItemId != NOT_QUEUED;
   }
 
   // returns True if queued by any other task than the given one
   public boolean isQueued(long taskId) {
-    synchronized (this.name) {
-      this.validateQueuingTimeout();
-      return queueItemId != NOT_QUEUED && queueItemId != taskId;
-    }
+    this.validateQueuingTimeout();
+    return queueItemId != NOT_QUEUED && queueItemId != taskId;
   }
 
   public boolean isQueuedByTask(long taskId) {
-    synchronized (this.name) {
-      this.validateQueuingTimeout();
-      return queueItemId == taskId;
-    }
+    this.validateQueuingTimeout();
+    return queueItemId == taskId;
   }
 
   public void unqueue() {
-    synchronized (this.name) {
-      queueItemId = NOT_QUEUED;
-      queueItemProject = null;
-      queuingStarted = 0;
-    }
+    queueItemId = NOT_QUEUED;
+    queueItemProject = null;
+    queuingStarted = 0;
   }
 
   @Exported
   public boolean isLocked() {
-    synchronized (this.name) {
-      return getBuild() != null;
-    }
+    return getBuild() != null;
   }
 
   /**
@@ -477,142 +419,107 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @CheckForNull
   public String getLockCause() {
-    synchronized (this.name) {
-      final DateFormat format = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT);
-      final String timestamp = (reservedTimestamp == null ? "<unknown>" : format.format(reservedTimestamp));
-      if (isReserved()) {
-        return String.format("[%s] is reserved by %s at %s", name, reservedBy, timestamp);
-      }
-      if (isLocked()) {
-        return String.format("[%s] is locked by %s at %s", name, buildExternalizableId, timestamp);
-      }
-      return null;
+    final DateFormat format = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT);
+    final String timestamp = (reservedTimestamp == null ? "<unknown>" : format.format(reservedTimestamp));
+    if (isReserved()) {
+      return String.format("[%s] is reserved by %s at %s", name, reservedBy, timestamp);
     }
+    if (isLocked()) {
+      return String.format("[%s] is locked by %s at %s", name, buildExternalizableId, timestamp);
+    }
+    return null;
   }
 
   @WithBridgeMethods(value = AbstractBuild.class, adapterMethod = "getAbstractBuild")
   public Run<?, ?> getBuild() {
-    synchronized (this.name) {
-      if (build == null && buildExternalizableId != null) {
-        build = Run.fromExternalizableId(buildExternalizableId);
-      }
-      return build;
+    if (build == null && buildExternalizableId != null) {
+      build = Run.fromExternalizableId(buildExternalizableId);
     }
+    return build;
   }
 
   @Exported
   public String getBuildName() {
-    synchronized (this.name) {
-      if (getBuild() != null)
-        return getBuild().getFullDisplayName();
-      else
-        return null;
-    }
+    if (getBuild() != null) return getBuild().getFullDisplayName();
+    else return null;
   }
 
   public void setBuild(Run<?, ?> lockedBy) {
-    synchronized (this.name) {
-      this.build = lockedBy;
-      if (lockedBy != null) {
-        this.buildExternalizableId = lockedBy.getExternalizableId();
-        setReservedTimestamp(new Date());
-      } else {
-        this.buildExternalizableId = null;
-        setReservedTimestamp(null);
-      }
+    this.build = lockedBy;
+    if (lockedBy != null) {
+      this.buildExternalizableId = lockedBy.getExternalizableId();
+      setReservedTimestamp(new Date());
+    } else {
+      this.buildExternalizableId = null;
+      setReservedTimestamp(null);
     }
   }
 
   public Task getTask() {
-    synchronized (this.name) {
-      Item item = Queue.getInstance().getItem(queueItemId);
-      if (item != null) {
-        return item.task;
-      } else {
-        return null;
-      }
+    Item item = Queue.getInstance().getItem(queueItemId);
+    if (item != null) {
+      return item.task;
+    } else {
+      return null;
     }
   }
 
   public long getQueueItemId() {
-    synchronized (this.name) {
-      this.validateQueuingTimeout();
-      return queueItemId;
-    }
+    this.validateQueuingTimeout();
+    return queueItemId;
   }
 
   public String getQueueItemProject() {
-    synchronized (this.name) {
-      this.validateQueuingTimeout();
-      return this.queueItemProject;
-    }
+    this.validateQueuingTimeout();
+    return this.queueItemProject;
   }
 
   public void setQueued(long queueItemId) {
-    synchronized (this.name) {
-      this.queueItemId = queueItemId;
-      this.queuingStarted = System.currentTimeMillis() / 1000;
-    }
+    this.queueItemId = queueItemId;
+    this.queuingStarted = System.currentTimeMillis() / 1000;
   }
 
   public void setQueued(long queueItemId, String queueProjectName) {
-    synchronized (this.name) {
-      this.setQueued(queueItemId);
-      this.queueItemProject = queueProjectName;
-    }
+    this.setQueued(queueItemId);
+    this.queueItemProject = queueProjectName;
   }
 
   private void validateQueuingTimeout() {
-    synchronized (this.name) {
-      if (queuingStarted > 0) {
-        long now = System.currentTimeMillis() / 1000;
-        if (now - queuingStarted > QUEUE_TIMEOUT)
-          unqueue();
-      }
+    if (queuingStarted > 0) {
+      long now = System.currentTimeMillis() / 1000;
+      if (now - queuingStarted > QUEUE_TIMEOUT) unqueue();
     }
   }
 
   @DataBoundSetter
   public void setReservedBy(String userName) {
-    synchronized (this.name) {
-      this.reservedBy = Util.fixEmptyAndTrim(userName);
-    }
+    this.reservedBy = Util.fixEmptyAndTrim(userName);
   }
 
   public void setStolen() {
-    synchronized (this.name) {
-      this.stolen = true;
-    }
+    this.stolen = true;
   }
 
   @Exported
   public boolean isStolen() {
-    synchronized (this.name) {
-      return this.stolen;
-    }
+    return this.stolen;
   }
 
   public void reserve(String userName) {
-    synchronized (this.name) {
-      setReservedBy(userName);
-      setReservedTimestamp(new Date());
-    }
+    setReservedBy(userName);
+    setReservedTimestamp(new Date());
   }
 
   public void unReserve() {
-    synchronized (this.name) {
-      setReservedBy(null);
-      setReservedTimestamp(null);
-      this.stolen = false;
-    }
+    setReservedBy(null);
+    setReservedTimestamp(null);
+    this.stolen = false;
   }
 
   public void reset() {
-    synchronized (this.name) {
-      this.unReserve();
-      this.unqueue();
-      this.setBuild(null);
-    }
+    this.unReserve();
+    this.unqueue();
+    this.setBuild(null);
   }
 
   /**
@@ -620,11 +527,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * @param sourceResource resource with properties to copy from
    */
   public void copyUnconfigurableProperties(final LockableResource sourceResource) {
-    synchronized (this.name) {
-      if (sourceResource != null) {
-        setReservedTimestamp(sourceResource.getReservedTimestamp());
-        setNote(sourceResource.getNote());
-      }
+    if (sourceResource != null) {
+      setReservedTimestamp(sourceResource.getReservedTimestamp());
+      setNote(sourceResource.getNote());
     }
   }
 
@@ -635,15 +540,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * Just stick with unReserve() and close the closure, if needed.
    */
   public void recycle() {
-    synchronized (this.name) {
-      try {
-        List<LockableResource> resources = new ArrayList<>();
-        resources.add(this);
-        org.jenkins.plugins.lockableresources.LockableResourcesManager.get().
-          recycle(resources);
-      } catch (Exception e) {
-        this.reset();
+    try {
+      List<LockableResource> resources = new ArrayList<>();
+      resources.add(this);
+      LockableResourcesManager lrm =  org.jenkins.plugins.lockableresources.LockableResourcesManager.get();
+      synchronized(lrm) {
+        lrm.recycle(resources);
       }
+    } catch (Exception e) {
+      LOGGER.warning("Exception on recycle: " + e.toString());
+      this.reset();
     }
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -544,7 +544,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
       List<LockableResource> resources = new ArrayList<>();
       resources.add(this);
       LockableResourcesManager lrm =  org.jenkins.plugins.lockableresources.LockableResourcesManager.get();
-      synchronized(lrm) {
+      synchronized (lrm) {
         lrm.recycle(resources);
       }
     } catch (Exception e) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -103,9 +103,6 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   private transient boolean isNode = false;
 
-  // dummy object to synchronize getters and setters
-  private final Object lock = new Object();
-
   /**
    * Was used within the initial implementation of Pipeline functionality using {@link LockStep},
    * but became deprecated once several resources could be locked at once. See queuedContexts in
@@ -161,13 +158,13 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public boolean isNodeResource() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return isNode;
     }
   }
 
   public void setNodeResource(boolean b) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       isNode = b;
     }
   }
@@ -179,42 +176,42 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public String getDescription() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return description;
     }
   }
 
   @DataBoundSetter
   public void setDescription(String description) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.description = Util.fixNull(description);
     }
   }
 
   @Exported
   public String getNote() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return this.note;
     }
   }
 
   @DataBoundSetter
   public void setNote(String note) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.note = Util.fixNull(note);
     }
   }
 
   @DataBoundSetter
   public void setEphemeral(boolean ephemeral) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.ephemeral = ephemeral;
     }
   }
 
   @Exported
   public boolean isEphemeral() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return ephemeral;
     }
   }
@@ -226,7 +223,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @Deprecated
   @Exported
   public String getLabels() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (this.labelsAsList == null) {
         return "";
       }
@@ -243,7 +240,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   // @Deprecated can not be used, because of JCaC
   @DataBoundSetter
   public void setLabels(String labels) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       // todo use label parser from Jenkins.Label to allow the same syntax
       this.labelsAsList = new ArrayList<>();
       for(String label : labels.split("\\s+")) {
@@ -261,7 +258,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Exported
   public List<String> getLabelsAsList() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return this.labelsAsList;
     }
   }
@@ -273,14 +270,14 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Exported
   public boolean hasLabel(String labelToFind) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return this.labelsContain(labelToFind);
     }
   }
 
   //----------------------------------------------------------------------------
   public boolean isValidLabel(String candidate, Map<String, Object> params) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (candidate == null || candidate.isEmpty()) {
         return false;
       }
@@ -306,21 +303,21 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * @return {@code true} if resource contains label *candidate*
    */
   private boolean labelsContain(String candidate) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return this.getLabelsAsList().contains(candidate);
     }
   }
 
   @Exported
   public List<LockableResourceProperty> getProperties() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return properties;
     }
   }
 
   @DataBoundSetter
   public void setProperties(List<LockableResourceProperty> properties) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.properties = (properties == null ? new ArrayList<>() : properties);
     }
   }
@@ -338,7 +335,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   public boolean scriptMatches(
     @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
     throws ExecutionException {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       Binding binding = new Binding(params);
       binding.setVariable("resourceName", name);
       binding.setVariable("resourceDescription", description);
@@ -368,35 +365,35 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public Date getReservedTimestamp() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
     }
   }
 
   @DataBoundSetter
   public void setReservedTimestamp(final Date reservedTimestamp) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.reservedTimestamp = reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
     }
   }
 
   @Exported
   public String getReservedBy() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return reservedBy;
     }
   }
 
   /** Return true when resource is free. False otherwise*/
   public boolean isFree() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return (!this.isLocked() && !this.isReserved() && !this.isQueued());
     }
   }
 
   @Exported
   public boolean isReserved() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return reservedBy != null;
     }
   }
@@ -418,14 +415,14 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @Restricted(NoExternalUse.class) // called by jelly
   public boolean isReservedByCurrentUser() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return (this.reservedBy != null && StringUtils.equals(getUserName(), this.reservedBy));
     }
   }
 
   @Exported
   public String getReservedByEmail() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (isReserved()) {
         UserProperty email = null;
         User user = Jenkins.get().getUser(reservedBy);
@@ -437,7 +434,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public boolean isQueued() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.validateQueuingTimeout();
       return queueItemId != NOT_QUEUED;
     }
@@ -445,21 +442,21 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   // returns True if queued by any other task than the given one
   public boolean isQueued(long taskId) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.validateQueuingTimeout();
       return queueItemId != NOT_QUEUED && queueItemId != taskId;
     }
   }
 
   public boolean isQueuedByTask(long taskId) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.validateQueuingTimeout();
       return queueItemId == taskId;
     }
   }
 
   public void unqueue() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       queueItemId = NOT_QUEUED;
       queueItemProject = null;
       queuingStarted = 0;
@@ -468,7 +465,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public boolean isLocked() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return getBuild() != null;
     }
   }
@@ -480,7 +477,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    */
   @CheckForNull
   public String getLockCause() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       final DateFormat format = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT);
       final String timestamp = (reservedTimestamp == null ? "<unknown>" : format.format(reservedTimestamp));
       if (isReserved()) {
@@ -495,7 +492,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @WithBridgeMethods(value = AbstractBuild.class, adapterMethod = "getAbstractBuild")
   public Run<?, ?> getBuild() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (build == null && buildExternalizableId != null) {
         build = Run.fromExternalizableId(buildExternalizableId);
       }
@@ -505,7 +502,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @Exported
   public String getBuildName() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (getBuild() != null)
         return getBuild().getFullDisplayName();
       else
@@ -514,7 +511,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public void setBuild(Run<?, ?> lockedBy) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.build = lockedBy;
       if (lockedBy != null) {
         this.buildExternalizableId = lockedBy.getExternalizableId();
@@ -527,7 +524,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public Task getTask() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       Item item = Queue.getInstance().getItem(queueItemId);
       if (item != null) {
         return item.task;
@@ -538,35 +535,35 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public long getQueueItemId() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.validateQueuingTimeout();
       return queueItemId;
     }
   }
 
   public String getQueueItemProject() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.validateQueuingTimeout();
       return this.queueItemProject;
     }
   }
 
   public void setQueued(long queueItemId) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.queueItemId = queueItemId;
       this.queuingStarted = System.currentTimeMillis() / 1000;
     }
   }
 
   public void setQueued(long queueItemId, String queueProjectName) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.setQueued(queueItemId);
       this.queueItemProject = queueProjectName;
     }
   }
 
   private void validateQueuingTimeout() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (queuingStarted > 0) {
         long now = System.currentTimeMillis() / 1000;
         if (now - queuingStarted > QUEUE_TIMEOUT)
@@ -577,33 +574,33 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   @DataBoundSetter
   public void setReservedBy(String userName) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.reservedBy = Util.fixEmptyAndTrim(userName);
     }
   }
 
   public void setStolen() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.stolen = true;
     }
   }
 
   @Exported
   public boolean isStolen() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       return this.stolen;
     }
   }
 
   public void reserve(String userName) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       setReservedBy(userName);
       setReservedTimestamp(new Date());
     }
   }
 
   public void unReserve() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       setReservedBy(null);
       setReservedTimestamp(null);
       this.stolen = false;
@@ -611,7 +608,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   }
 
   public void reset() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       this.unReserve();
       this.unqueue();
       this.setBuild(null);
@@ -623,7 +620,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * @param sourceResource resource with properties to copy from
    */
   public void copyUnconfigurableProperties(final LockableResource sourceResource) {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       if (sourceResource != null) {
         setReservedTimestamp(sourceResource.getReservedTimestamp());
         setNote(sourceResource.getNote());
@@ -638,7 +635,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
    * Just stick with unReserve() and close the closure, if needed.
    */
   public void recycle() {
-    synchronized (this.lock) {
+    synchronized (this.name) {
       try {
         List<LockableResource> resources = new ArrayList<>();
         resources.add(this);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -95,7 +95,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         if (!r.isLocked()) continue;
         lockedResources.put(r.getName(), r);
       }
-  
+
       // Removed from configuration locks became ephemeral.
       ArrayList<LockableResource> mergedResources = new ArrayList<>();
       Set<String> addedLocks = new HashSet<>();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1338,6 +1338,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   boolean enableSave = false;
   @Override
   public synchronized void save() {
+    // TODO this shall be configurable
     if (!enableSave) {
       return;
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -289,7 +289,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     String queueProjectName
   ) {
     for (LockableResource resource : resources) {
-      if (!resource.isFree()) {
+      if (resource.isReserved() || resource.isQueued(queueItemId) || resource.isLocked()) {
         return false;
       }
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -171,7 +171,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
       } else {
         List<String> wrongNames = new ArrayList<>();
         LockableResourcesManager lrm = LockableResourcesManager.get();
-        synchronized(lrm) {
+        synchronized (lrm) {
           for (String name : names.split("\\s+")) {
             boolean found = false;
             if (lrm.fromName(name) == null) {
@@ -207,13 +207,11 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
           Messages.error_labelAndNameOrGroovySpecified());
       } else {
         LockableResourcesManager lrm = LockableResourcesManager.get();
-        synchronized(lrm) {
-          if (lrm.isValidLabel(label)) {
-            return FormValidation.ok();
-          } else {
-            return FormValidation.error(
-              Messages.error_labelDoesNotExist(label));
-          }
+        if (lrm.isValidLabel(label)) {
+          return FormValidation.ok();
+        } else {
+          return FormValidation.error(
+            Messages.error_labelDoesNotExist(label));
         }
       }
     }
@@ -271,7 +269,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
       value = Util.fixEmptyAndTrim(value);
 
       LockableResourcesManager lrm = LockableResourcesManager.get();
-      synchronized(lrm) {
+      synchronized (lrm) {
         for (String l : lrm.getAllLabels())
           if (value != null && l.startsWith(value))
             c.add(l);
@@ -293,7 +291,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
 
       if (value != null) {
         LockableResourcesManager lrm = LockableResourcesManager.get();
-        synchronized(lrm) {
+        synchronized (lrm) {
           for (LockableResource r : lrm.getResources()) {
             if (r.getName().startsWith(value))
               c.add(r.getName());

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -104,13 +104,13 @@ public class LockableResourcesRootAction implements RootAction {
 
   @Exported
   public List<LockableResource> getResources() {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return new ArrayList<>(lrm.getResources());
     }
   }
 
   public LockableResource getResource(final String resourceName) {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return lrm.fromName(resourceName);
     }
   }
@@ -121,7 +121,7 @@ public class LockableResourcesRootAction implements RootAction {
    * @return Amount of free labels.
    */
   public int getFreeResourceAmount(String label) {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return lrm.getFreeResourceAmount(label);
     }
   }
@@ -148,7 +148,7 @@ public class LockableResourcesRootAction implements RootAction {
    * @return All possible labels.
    */
   public Set<String> getAllLabels() {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return new HashSet<>(lrm.getAllLabels());
     }
   }
@@ -156,7 +156,7 @@ public class LockableResourcesRootAction implements RootAction {
   
   public Set<AnLabel> getLabelsList() {
     Set<AnLabel> list = new HashSet<>();
-    synchronized(lrm) {
+    synchronized (lrm) {
       for(String label : lrm.getAllLabels()) {
         list.add(new AnLabel(label, lrm.getFreeResourceAmount(label), lrm.getResourcesWithLabel(label, null).size()));
       }
@@ -182,7 +182,7 @@ public class LockableResourcesRootAction implements RootAction {
    * @return Amount of all labels.
    */
   public int getNumberOfAllLabels() {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return lrm.getAllLabels().size();
     }
   }
@@ -196,7 +196,7 @@ public class LockableResourcesRootAction implements RootAction {
    */
   @Restricted(NoExternalUse.class)
   public int getAssignedResourceAmount(String label) {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return lrm.getResourcesWithLabel(label, null).size();
     }
   }
@@ -204,7 +204,7 @@ public class LockableResourcesRootAction implements RootAction {
   /** Returns current queue */
   @Restricted(NoExternalUse.class) // used by jelly
   public List<QueuedContextStruct> getCurrentQueuedContext() {
-    synchronized(lrm) {
+    synchronized (lrm) {
       return new ArrayList<>(lrm.getCurrentQueuedContext());
     }
   }
@@ -246,7 +246,7 @@ public class LockableResourcesRootAction implements RootAction {
       return;
     }
 
-    synchronized(lrm) {
+    synchronized (lrm) {
       lrm.unlock(resources, null);
     }
 
@@ -266,7 +266,7 @@ public class LockableResourcesRootAction implements RootAction {
 
     String userName = getUserName();
     if (userName != null) {
-      synchronized(lrm) {
+      synchronized (lrm) {
         if (!lrm.reserve(resources, userName)) {
           rsp.sendError(423, Messages.error_resourceAlreadyLocked(LockableResourcesManager.getResourcesNames(resources)));
           return;
@@ -289,7 +289,7 @@ public class LockableResourcesRootAction implements RootAction {
 
     String userName = getUserName();
     if (userName != null) {
-      synchronized(lrm) {
+      synchronized (lrm) {
         lrm.steal(resources, userName);
       }
     }
@@ -325,7 +325,7 @@ public class LockableResourcesRootAction implements RootAction {
       }
     }
 
-    synchronized(lrm) {
+    synchronized (lrm) {
       lrm.reassign(resources, userName);
     }
 
@@ -352,7 +352,7 @@ public class LockableResourcesRootAction implements RootAction {
       }
     }
 
-    synchronized(lrm) {
+    synchronized (lrm) {
       lrm.unreserve(resources);
     }
 
@@ -371,7 +371,7 @@ public class LockableResourcesRootAction implements RootAction {
       return;
     }
 
-    synchronized(lrm) {
+    synchronized (lrm) {
       lrm.reset(resources);
     }
 
@@ -397,7 +397,7 @@ public class LockableResourcesRootAction implements RootAction {
         resourceNote = req.getParameter("resourceNote");
       }
       resource.setNote(resourceNote);
-      synchronized(lrm) {
+      synchronized (lrm) {
         lrm.save();
       }
 
@@ -411,7 +411,7 @@ public class LockableResourcesRootAction implements RootAction {
     // like req.getParameter("resources"); And split the content by some delimiter like ' ' (space)
     String name = req.getParameter("resource");
     List<LockableResource> resources = new ArrayList<>();
-    synchronized(lrm) {
+    synchronized (lrm) {
       LockableResource r = lrm.fromName(name);
       if (r == null) {
         rsp.sendError(404, Messages.error_resourceDoesNotExist(name));

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -6,13 +6,16 @@ package org.jenkins.plugins.lockableresources;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.Extension;
+import hudson.model.labels.LabelAtom;
 import hudson.model.Node;
 import hudson.slaves.ComputerListener;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Set;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
@@ -60,17 +63,22 @@ public class NodesMirror extends ComputerListener {
   //---------------------------------------------------------------------------
   private static void deleteExistingNodes() {
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
-    while (resourceIterator.hasNext()) {
-      LockableResource resource = resourceIterator.next();
-      if (!resource.isNodeResource()) {
-        continue;
-      }
-      if (resource.isFree()) {
-        // we can remove this resource. Is newer used currently
+    synchronized (lrm) {
+      Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
+      while (resourceIterator.hasNext()) {
+        LockableResource resource = resourceIterator.next();
+        if (!resource.isNodeResource()) {
+          continue;
+        }
+        if (Jenkins.get().getNode(resource.getName()) != null) {
+          // the node exist, do not remove the resource
+          continue;
+        }
+        if (!resource.isFree()) {
+          // the resource is still used somewhere. Do not remove it
+          continue;
+        }
         resourceIterator.remove();
-      } else {
-        LOG.log(Level.FINE, "lockable-resources-plugin skip node deletion of: " + resource.getName() + ". Reason: Currently locked");
       }
     }
   }
@@ -82,18 +90,23 @@ public class NodesMirror extends ComputerListener {
     }
 
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    LockableResource nodeResource = lrm.fromName(node.getNodeName());
-    boolean exist = nodeResource != null;
-    if (!exist) {
-      nodeResource = new LockableResource(node.getNodeName());
-    }
-    nodeResource.setLabels(node.getAssignedLabels().stream().map(Object::toString).collect(Collectors.joining(" ")));
-    nodeResource.setNodeResource(true);
-    nodeResource.setEphemeral(false);
-    nodeResource.setDescription(node.getNodeDescription());
-    LOG.log(Level.FINE, "lockable-resources-plugin add node-resource: " + nodeResource.getName());
-    if (!exist) {
-      lrm.getResources().add(nodeResource);
+    synchronized (lrm) {
+      LockableResource nodeResource = lrm.fromName(node.getNodeName());
+      boolean exist = nodeResource != null;
+      if (!exist) {
+        nodeResource = new LockableResource(node.getNodeName());
+      }
+
+      Set<LabelAtom> assignedLabels = new HashSet<>(node.getAssignedLabels());
+      assignedLabels.remove(node.getSelfLabel());
+      nodeResource.setLabels(assignedLabels.stream().map(Object::toString).collect(Collectors.joining(" ")));
+      nodeResource.setNodeResource(true);
+      nodeResource.setEphemeral(false);
+      nodeResource.setDescription(node.getNodeDescription());
+      LOG.log(Level.FINE, "lockable-resources-plugin add node-resource: " + nodeResource.getName());
+      if (!exist) {
+        lrm.getResources().add(nodeResource);
+      }
     }
   }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -50,7 +50,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
       if (resources != null) {
         LockableResourcesManager lrm = LockableResourcesManager.get();
-        synchronized(lrm) {
+        synchronized (lrm) {
           if (resources.requiredNumber != null || !resources.label.isEmpty() || resources.getResourceMatchScript() != null) {
             required.addAll(lrm.
               getResourcesFromProject(proj.getFullName()));
@@ -110,7 +110,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
 
     // obviously project name cannot be obtained here
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    synchronized(lrm) {
+    synchronized (lrm) {
       List<LockableResource> required = lrm.getResourcesFromBuild(build);
       if (!required.isEmpty()) {
         lrm.unlock(required, build);
@@ -131,7 +131,7 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
       return;
 
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    synchronized(lrm) {
+    synchronized (lrm) {
       List<LockableResource> required = lrm.getResourcesFromBuild(build);
       if (!required.isEmpty()) {
         lrm.unlock(required, build);

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -135,14 +135,12 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     } else {
       LockableResourcesManager lrm = LockableResourcesManager.get();
-      synchronized (lrm) {
-        if (lrm.queue(resources.required, item.getId(), project.getFullDisplayName())) {
-          LOGGER.finest(project.getName() + " reserved resources " + resources.required);
-          return null;
-        } else {
-          LOGGER.finest(project.getName() + " waiting for resources " + resources.required);
-          return new BecauseResourcesLocked(resources);
-        }
+      if (lrm.queue(resources.required, item.getId(), project.getFullDisplayName())) {
+        LOGGER.finest(project.getName() + " reserved resources " + resources.required);
+        return null;
+      } else {
+        LOGGER.finest(project.getName() + " waiting for resources " + resources.required);
+        return new BecauseResourcesLocked(resources);
       }
     }
   }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -46,15 +46,17 @@ public class LockableResourcesStruct implements Serializable {
     queuedAt = new Date().getTime();
     required = new ArrayList<>();
 
-    LockableResourcesManager resourcesManager = LockableResourcesManager.get();
-    for (String name : property.getResources()) {
-      String resourceName = env.expand(name);
-      if (resourceName == null) {
-        continue;
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    synchronized(lrm) {
+      for (String name : property.getResources()) {
+        String resourceName = env.expand(name);
+        if (resourceName == null) {
+          continue;
+        }
+        lrm.createResource(resourceName);
+        LockableResource r = lrm.fromName(resourceName);
+        this.required.add(r);
       }
-      resourcesManager.createResource(resourceName);
-      LockableResource r = resourcesManager.fromName(resourceName);
-      this.required.add(r);
     }
 
     label = env.expand(property.getLabelName());
@@ -89,10 +91,13 @@ public class LockableResourcesStruct implements Serializable {
     queuedAt = new Date().getTime();
     required = new ArrayList<>();
     if (resources != null) {
-      for (String resource : resources) {
-        LockableResource r = LockableResourcesManager.get().fromName(resource);
-        if (r != null) {
-          this.required.add(r);
+      LockableResourcesManager lrm = LockableResourcesManager.get();
+      synchronized(lrm) {
+        for (String resource : resources) {
+          LockableResource r = lrm.fromName(resource);
+          if (r != null) {
+            this.required.add(r);
+          }
         }
       }
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -47,20 +47,26 @@ public class LockableResourcesStruct implements Serializable {
     required = new ArrayList<>();
 
     LockableResourcesManager lrm = LockableResourcesManager.get();
-    synchronized(lrm) {
+    synchronized (lrm) {
       for (String name : property.getResources()) {
         String resourceName = env.expand(name);
         if (resourceName == null) {
           continue;
         }
-        lrm.createResource(resourceName);
         LockableResource r = lrm.fromName(resourceName);
+        if (r == null) {
+          // looks like defensive code here. I hope this never happens
+          lrm.createResource(resourceName);
+          r = lrm.fromName(resourceName);
+        }
+
         this.required.add(r);
       }
     }
 
     label = env.expand(property.getLabelName());
-    if (label == null) label = "";
+    if (label == null)
+      label = "";
 
     resourceMatchScript = property.getResourceMatchScript();
     serializableResourceMatchScript = new SerializableSecureGroovyScript(resourceMatchScript);
@@ -68,7 +74,8 @@ public class LockableResourcesStruct implements Serializable {
     requiredVar = property.getResourceNamesVar();
 
     requiredNumber = property.getResourceNumber();
-    if (requiredNumber != null && requiredNumber.equals("0")) requiredNumber = null;
+    if (requiredNumber != null && requiredNumber.equals("0"))
+      requiredNumber = null;
   }
 
   /**
@@ -92,7 +99,7 @@ public class LockableResourcesStruct implements Serializable {
     required = new ArrayList<>();
     if (resources != null) {
       LockableResourcesManager lrm = LockableResourcesManager.get();
-      synchronized(lrm) {
+      synchronized (lrm) {
         for (String resource : resources) {
           LockableResource r = lrm.fromName(resource);
           if (r != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
@@ -2,5 +2,10 @@
 package org.jenkins.plugins.lockableresources.util;
 
 public class Constants {
+  /// Enable mirror nodes to lockable-resources
   public static final String SYSTEM_PROPERTY_ENABLE_NODE_MIRROR = "org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR";
+  /// Disable save lockable resources states, properties ... into local file system.
+  /// This option makes the plugin much faster (everything is in cache) but **Keep in mind, that you will lost all your manual changed properties**
+  /// The best way is to use it with JCaC plugin.
+  public static final String SYSTEM_PROPERTY_DISABLE_SAVE = "org.jenkins.plugins.lockableresources.DISABLE_SAVE";
 }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -23,7 +23,8 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <j:if test="${it.getNumberOfAllLabels() != 0}">
+  <j:set var="allLabels" value="${it.getLabelsList()}" />
+  <j:if test="${allLabels.size() != 0}">
     <st:adjunct includes="io.jenkins.plugins.data-tables"/>
     <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
     <div class="table-responsive">
@@ -42,18 +43,18 @@ THE SOFTWARE.
           <th>${%labels.table.column.percentage}</th>
         </thead>
         <tbody>
-          <j:forEach var="label" items="${it.getAllLabels()}">
+          <j:forEach var="label" items="${allLabels}">
             <j:set
               var="freeCount"
-              value="${it.getFreeResourceAmount(label)}"
+              value="${label.free}"
             />
             <j:set
               var="allCount"
-              value="${it.getAssignedResourceAmount(label)}"
+              value="${label.assigned}"
             />
             <j:set
               var="percentage"
-              value="${it.getFreeResourcePercentage(label)}"
+              value="${label.percentage}"
             />
             <j:choose>
               <j:when test="${percentage lt 5}">
@@ -73,8 +74,8 @@ THE SOFTWARE.
               <td>
                 <a
                   class="jenkins-table__link model-link"
-                  href="${rootURL}/label/${label}"
-                  >${label}<button
+                  href="${rootURL}/label/${label.name}"
+                  >${label.name}<button
                     class="jenkins-menu-dropdown-chevron"
                   ></button
                 ></a>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -67,12 +67,12 @@ THE SOFTWARE.
         <th>${%resources.table.column.action}</th>
       </thead>
       <tbody>
-        <j:forEach var="resource" items="${it.resources}">
+        <j:forEach var="resource" items="${it.resources}" varStatus="idx">
           <tr data-resource-name="${resource.name}">
             <!-- **************************************************************
                  Index
             -->
-            <td>${i + 1}</td>
+            <td>${idx.index + 1}</td>
 
             <!-- **************************************************************
                  Column with common resource data

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -40,21 +40,37 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestBuilder;
 
+
+import java.util.logging.Logger;
+
 public class FreeStyleProjectTest {
 
   @Rule public JenkinsRule j = new JenkinsRule();
+  private static final Logger LOGGER = Logger.getLogger(FreeStyleProjectTest.class.getName());
 
   @Test
   @Issue("JENKINS-34853")
   public void security170fix() throws Exception {
+    LOGGER.info("security170fix: start");
+    assertNull("create resources", null);
     LockableResourcesManager.get().createResource("resource1");
+    LOGGER.info("security170fix: resource da");
+    assertNotNull("resource created?", LockableResourcesManager.get().fromName("resource1"));
     FreeStyleProject p = j.createFreeStyleProject("p");
+    LOGGER.info("security170fix: project done");
+    assertNotNull("free style project created?", p);
     p.addProperty(new RequiredResourcesProperty("resource1", "resourceNameVar", null, null, null));
+    LOGGER.info("security170fix: p added");
     p.getBuildersList().add(new PrinterBuilder());
+    LOGGER.info("security170fix: printer added");
 
     FreeStyleBuild b1 = p.scheduleBuild2(0).get();
+    LOGGER.info("security170fix: build scheduled");
+    assertNotNull("free style build started?", b1);
     j.assertLogContains("resourceNameVar: resource1", b1);
+    LOGGER.info("security170fix: log dine");
     j.assertBuildStatus(Result.SUCCESS, b1);
+    LOGGER.info("security170fix: success");
   }
 
   @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -53,7 +53,7 @@ public class NodesMirrorTest {
 
   @Test
   public void mirror_locked_nodes() throws Exception {
-    System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
+    System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
 
     j.createSlave("FirstAgent", "label label2", null);
     // this is asynchronous operation, so wait until resources has been created.

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -34,12 +34,11 @@ public class NodesMirrorTest {
     LockableResource firstAgent = LockableResourcesManager.get().fromName("FirstAgent");
 
     assertEquals("FirstAgent", firstAgent.getName());
-    // ! jenkins add always the node name as a label
-    assertEquals("FirstAgent label label2", firstAgent.getLabels());
+    assertEquals("label label2", firstAgent.getLabels());
 
     LockableResource secondAgent = LockableResourcesManager.get().fromName("SecondAgent");
     assertEquals("SecondAgent", secondAgent.getName());
-    assertEquals("SecondAgent", secondAgent.getLabels());
+    assertEquals("", secondAgent.getLabels());
 
     // delete agent
     j.jenkins.removeNode(j.jenkins.getNode("FirstAgent"));

--- a/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
@@ -47,6 +47,7 @@ public class PressureTest extends LockStepTestBase {
   @Test
   public void pressure() throws Exception {
     System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
+    System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     LockableResourcesManager lm = LockableResourcesManager.get();
     final int resourcesCount = 30;
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
@@ -1,0 +1,129 @@
+package org.jenkins.plugins.lockableresources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+import com.google.common.collect.ImmutableMap;
+import hudson.Functions;
+import hudson.model.Result;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.concurrent.CyclicBarrier;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.WithPlugin;
+
+// import java.util.concurrent.TimeUnit;
+import org.junit.rules.Timeout;
+
+
+
+public class PressureTest extends LockStepTestBase {
+
+  private static final Logger LOGGER = Logger.getLogger(LockStepTest.class.getName());
+
+  @Rule public JenkinsRule j = new JenkinsRule();
+  @Rule public Timeout globalTimeout = Timeout.seconds(300);
+
+  /** Pressure test to lock resources via labels, resource name, ephemeral ...
+   *  It simulates big system with many chaotic locks. Hopefully it runs always good,
+   *  because any analysis here will be very hard.
+   */
+  @Test ()
+  public void pressure() throws Exception {
+    LockableResourcesManager lm = LockableResourcesManager.get();
+    final int resourcesCount = 30;
+
+    for(int i = 1; i <= resourcesCount; i++) {
+      lm.createResourceWithLabel("resourceA_" + Integer.toString(i), "label1 label2");
+      lm.createResourceWithLabel("resourceAA_" + Integer.toString(i), "label");
+      lm.createResourceWithLabel("resourceAAA_" + Integer.toString(i), "Label1");
+      lm.createResourceWithLabel("resourceAAAA_" + Integer.toString(i), "(=%/!(/)?$/ HH( RU))");
+    }
+
+    String pipeCode = "def stages = [:];\n";
+
+    pipeCode += "for(int i = 1; i <= " + resourcesCount + "; i++) {\n"
+             +  "  String stageName = 'stage_' + i;\n"
+             +  "  stages[stageName] = {\n"
+             +  "    echo 'my stage: ' + stageName;\n"
+             +  "    lock(label: 'label1 && label2', variable: 'someVar', quantity : 1) {\n"
+             +  "      echo \"VAR-1 IS $env.someVar\"\n"
+             +  "      echo 'stage locked: ' + stageName;\n"
+             +  "    }\n"
+             +  "    lock(label: 'label1 || label2', variable: 'someVar', quantity : 2, resourceSelectStrategy: 'random') {\n"
+             +  "      echo \"VAR-2 IS $env.someVar\"\n"
+             +  "    }\n"
+             +  "    lock(label: 'label2', variable: 'someVar') {\n"
+             +  "      echo \"VAR-3 IS $env.someVar\"\n"
+             +  "    }\n"
+             +  "    lock('resource_ephemeral_' + i) {\n"
+             +  "      echo \"VAR-3 IS $env.someVar\"\n"
+             +  "    }\n"
+             +  "    lock('resourceA_' + i) {\n"
+             +  "      echo \"VAR-3 IS $env.someVar\"\n"
+             +  "    }\n"
+             +  "  }\n"
+             +  "}\n";
+
+    pipeCode += "parallel stages;";
+
+    lm.reserve(Collections.singletonList(lm.fromName("resourceA_1")), "test");
+
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+      new CpsFlowDefinition(
+        pipeCode,
+        true));
+    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+
+    WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
+    p2.setDefinition(
+      new CpsFlowDefinition(
+        pipeCode,
+        true));
+    WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
+
+    WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
+    p3.setDefinition(
+      new CpsFlowDefinition(
+        pipeCode,
+        true));
+    WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
+
+
+    for(int i = 1; i <= resourcesCount; i++) {
+      lm.createResourceWithLabel("resourceB_" + Integer.toString(i), "label1");
+    }
+
+    j.waitForMessage("is locked, waiting...", b1);
+
+    for(int i = 1; i <= resourcesCount; i++) {
+      lm.createResourceWithLabel("resourceC_" + Integer.toString(i), "label1");
+    }
+
+    lm.unreserve(Collections.singletonList(lm.fromName("resourceA_1")));
+
+    for(int i = 1; i <= resourcesCount; i++) {
+      lm.createResourceWithLabel("resourceD_" + Integer.toString(i), "label1");
+    }
+
+    j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+    j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+    j.assertBuildStatusSuccess(j.waitForCompletion(b3));
+  }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
@@ -27,9 +27,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.WithPlugin;
-
-// import java.util.concurrent.TimeUnit;
-import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 
 
@@ -38,18 +36,18 @@ public class PressureTest extends LockStepTestBase {
   private static final Logger LOGGER = Logger.getLogger(LockStepTest.class.getName());
 
   @Rule public JenkinsRule j = new JenkinsRule();
-  @Rule public Timeout globalTimeout = Timeout.seconds(300);
 
   /** Pressure test to lock resources via labels, resource name, ephemeral ...
    *  It simulates big system with many chaotic locks. Hopefully it runs always good,
    *  because any analysis here will be very hard.
    */
   @Test
+  @WithTimeout(300)
   public void pressure() throws Exception {
     System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
     System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     LockableResourcesManager lm = LockableResourcesManager.get();
-    final int resourcesCount = 30;
+    final int resourcesCount = 100;
 
     for(int i = 1; i <= resourcesCount; i++) {
       lm.createResourceWithLabel("resourceA_" + Integer.toString(i), "label1 label2");

--- a/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.concurrent.CyclicBarrier;
 import net.sf.json.JSONObject;
+import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -43,8 +44,9 @@ public class PressureTest extends LockStepTestBase {
    *  It simulates big system with many chaotic locks. Hopefully it runs always good,
    *  because any analysis here will be very hard.
    */
-  @Test ()
+  @Test
   public void pressure() throws Exception {
+    System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
     LockableResourcesManager lm = LockableResourcesManager.get();
     final int resourcesCount = 30;
 
@@ -113,7 +115,9 @@ public class PressureTest extends LockStepTestBase {
     j.waitForMessage("is locked, waiting...", b1);
 
     for(int i = 1; i <= resourcesCount; i++) {
+      j.createSlave("AgentAAA_" + i, "label label2", null);
       lm.createResourceWithLabel("resourceC_" + Integer.toString(i), "label1");
+      j.createSlave("AGENT_BBB_" + i, null, null);
     }
 
     lm.unreserve(Collections.singletonList(lm.fromName("resourceA_1")));


### PR DESCRIPTION
fix #503 
fix #149 
close #151 


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
