### PR TITLE
Ability to disable lock persistence on every step

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,32 @@ To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockable
 System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "true");
 ```
 
-note: When the node has been deleted, during the lockable-resource is locked / reserved / queued, then the lockable-resource will be NOT deleted.
+> *Note:* When the node has been deleted, during the lockable-resource is locked / reserved / queued, then the lockable-resource will be NOT deleted.
 
 ----
+
+## Improve performance
+
+To be safe thread over all jobs and resources, need to be all operations synchronized.
+This might lead to slow down your jobs. The jenkins self, has low CPU usage, but your jobs are very slow. Why?
+
+The most time are spend to write the lockable-resources states into local file system. This is important to get the correct state after Jenkins reboots.
+
+To eliminate this saving time has been added a property *DISABLE_SAVE*.
+
++ The best way is to use it with JCaC plugin. So you are sure, you have still correct
+resources on Jenkins start.
++ When you set pipeline durability level to *PERFORMANCE_OPTIMIZED*, it makes also sense to set this property to true.
+
+> *Note:* Keep in mind, that you will lost all your manual changes!
+
+> *Note:* This option is experimental. It has been tested in many scenarios, but no body know.
+
+To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockableresources.DISABLE_SAVE=true` or run this groovy code.
+
+```groovy
+System.setProperty("org.jenkins.plugins.lockableresources.DISABLE_SAVE", "true");
+```
 
 ## Configuration as Code
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1267,6 +1267,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   @Override
   public synchronized void save() {
+    if (SystemProperties.getBoolean(Constants.SYSTEM_PROPERTY_DISABLE_SAVE)) {
+      return;
+    }
+
     if (BulkChange.contains(this)) return;
 
     try {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -64,7 +64,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
   private List<QueuedContextStruct> queuedContexts = new ArrayList<>();
 
   // cache to enable / disable saving lockable-resources state
-  private boolean enableSave = null;
+  private int enableSave = -1;
 
   @SuppressFBWarnings(value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
                       justification = "Common Jenkins pattern to call method that can be overridden")
@@ -1272,14 +1272,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
   @Override
   public synchronized void save() {
-    if (enableSave == null)
+    if (enableSave == -1)
     {
       // read system property and chache it.
-      // disable == false means enable
-      enableSave = SystemProperties.getBoolean(Constants.SYSTEM_PROPERTY_DISABLE_SAVE) == false;
+      enableSave = SystemProperties.getBoolean(Constants.SYSTEM_PROPERTY_DISABLE_SAVE) ? 0 : 1;
     }
 
-    if (enableSave == false)
+    if (enableSave == 0)
       return; // savinig is disabled
 
     if (BulkChange.contains(this))

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesCandidatesStruct;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
+import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.accmod.Restricted;

--- a/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
@@ -2,5 +2,11 @@
 package org.jenkins.plugins.lockableresources.util;
 
 public class Constants {
+  /// Enable mirror nodes to lockable-resources
   public static final String SYSTEM_PROPERTY_ENABLE_NODE_MIRROR = "org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR";
+  /// Disable saving lockable resources states, properties ... into local file system.
+  /// This option makes the plugin much faster (everything is in cache) but
+  /// **Keep in mind, that you will lost all your manual changed properties**
+  /// The best way is to use it with JCaC plugin.
+  public static final String SYSTEM_PROPERTY_DISABLE_SAVE = "org.jenkins.plugins.lockableresources.DISABLE_SAVE";
 }


### PR DESCRIPTION
fix #338 

This changes allow to disable to save the lockable-resource status.
The most time spend in this plugin is by saving the state in the .xml config
This make no sense in case:
+ you use JCaC
+ or performance-optimized pipeline durability

Therefore it will be possible to disable it by set the system property

```groovy
System.setProperty("org.jenkins.plugins.lockableresources.DISABLE_SAVE", "true");
```

### Testing done

There are no automated test. I have simulate it on my own local instance and only LockStepHardKillTest.java tests has been failed. And this is exact, what shall happens here.

And we use it in my company for ~ 3 weeks and (exact as here) and does not find any side effects

### Proposed upgrade guidelines

N/A

### Localizations

N/A


### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- [x] Changes in the interface are documented

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
