### PR TITLE
Free lockable-resource assigned to dead builds

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -1,0 +1,49 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright (c) 2016, Florian Hug. All rights reserved.             *
+ *                                                                     *
+ * This file is part of the Jenkins Lockable Resources Plugin and is   *
+ * published under the MIT license.                                    *
+ *                                                                     *
+ * See the "LICENSE.txt" file for more information.                    *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+package org.jenkins.plugins.lockableresources;
+
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+/**
+ * Sometimes after re-starts (jenkins crashed or what ever) are resources still
+ * locked by build, but the build is no more running.
+ * This script will 'unlock' all resource assigned to dead builds
+ */
+@Deprecated
+@ExcludeFromJacocoGeneratedReport
+public final class FreeDeadJobs {
+  private static final Logger LOG = Logger.getLogger(FreeDeadJobs.class.getName());
+
+  private FreeDeadJobs() {}
+
+  @Initializer(after = InitMilestone.JOB_LOADED)
+  public static void freePostMortemResources() {
+
+    LockableResourcesManager lrm = LockableResourcesManager.get();
+    synchronized (lrm) {
+      LOG.log(Level.FINE, "lockable-resources-plugin free post mortem task run");
+      for (LockableResource resource : lrm.getResources()) {
+        if (resource.getBuild() != null && !resource.getBuild().isInProgress()) {
+          LOG.log(Level.INFO, "lockable-resources-plugin reset resource " + resource.getName() +
+                              " due post mortem job: " + resource.getBuildName());
+          resource.recycle();
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -24,7 +24,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
  * locked by build, but the build is no more running.
  * This script will 'unlock' all resource assigned to dead builds
  */
-@Deprecated
 @ExcludeFromJacocoGeneratedReport
 public final class FreeDeadJobs {
   private static final Logger LOG = Logger.getLogger(FreeDeadJobs.class.getName());


### PR DESCRIPTION
#fix #500 

Sometimes after re-starts (jenkins crashed or what ever) are resources still locked by build, but the build is no more running.
This changes will 'unlock' all resource assigned to the dead builds


### Testing done

It is more or less not possible to simulate it.
We use this code in our Jenkins instance few weeks and it works
We reboot our instances once per week (or often) and after this changes we has the issue no more.
Therefore I thing it works as expected.

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
