### PR TITLE
Add 'reason' field in the lock() step

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -36,6 +36,8 @@ public class LockStep extends Step implements Serializable {
 
   @CheckForNull public String label = null;
 
+  @CheckForNull public String reason = null;
+
   public int quantity = 0;
 
   /** name of environment variable to store locked resources in */
@@ -62,6 +64,11 @@ public class LockStep extends Step implements Serializable {
   @DataBoundSetter
   public void setInversePrecedence(boolean inversePrecedence) {
     this.inversePrecedence = inversePrecedence;
+  }
+  
+  @DataBoundSetter
+  public void setReason(String reason) {
+    this.reason = reason;
   }
 
   @DataBoundSetter

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -28,13 +28,17 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
 
   @CheckForNull
   public String label = null;
+  
+  @CheckForNull
+  public String reason = null;
 
   public int quantity = 0;
 
-  LockStepResource(@Nullable String resource, @Nullable String label, int quantity) {
+  LockStepResource(@Nullable String resource, @Nullable String label, int quantity, String reason) {
     this.resource = resource;
     this.label = label;
     this.quantity = quantity;
+    this.reason = reason;
   }
 
   @DataBoundConstructor
@@ -48,6 +52,13 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
   public void setLabel(String label) {
     if (label != null && !label.isEmpty()) {
       this.label = label;
+    }
+  }
+
+  @DataBoundSetter
+  public void setReason(String reason) {
+    if (reason != null && !reason.isEmpty()) {
+      this.reason = reason;
     }
   }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -62,6 +62,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
 
   private final String name;
   private String description = "";
+  private String reason = "";
   /** @deprecated use labelsAsList instead due performance.
    */
   @Deprecated private transient String labels = null;
@@ -115,7 +116,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   /** @deprecated Use single-argument constructor instead (since 1.8) */
   @Deprecated
   @ExcludeFromJacocoGeneratedReport
-  public LockableResource(String name, String description, String labels, String reservedBy, String note) {
+  public LockableResource(String name, String description, String labels, String reservedBy, String note, String reason) {
     // todo throw exception, when the name is empty
     // todo check if the name contains only valid characters (no spaces, new lines ...)
     this.name = name;
@@ -123,6 +124,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     this.setLabels(labels);
     this.setReservedBy(reservedBy);
     this.setNote(note);
+    this.setReason(reason);
   }
 
   @DataBoundConstructor
@@ -178,6 +180,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
   @DataBoundSetter
   public void setDescription(String description) {
     this.description = Util.fixNull(description);
+  }
+
+  @DataBoundSetter
+  public void setReason(String reason) {
+    this.reason = Util.fixNull(reason);
+  }
+
+  @Exported
+  public String getReason() {
+    return this.reason;
   }
 
   @Exported
@@ -308,6 +320,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     binding.setVariable("resourceDescription", description);
     binding.setVariable("resourceLabels", this.getLabelsAsList());
     binding.setVariable("resourceNote", note);
+    binding.setVariable("resourceReason", reason);
     try {
       Object result =
         script.evaluate(Jenkins.get().getPluginManager().uberClassLoader, binding, null);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -103,6 +103,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         locked.setDescription(r.getDescription());
         locked.setLabels(r.getLabels());
         locked.setEphemeral(false);
+        locked.setReason(r.getReason());
         locked.setNote(r.getNote());
         mergedResources.add(locked);
         continue;
@@ -115,6 +116,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
       r.setDescription("");
       r.setLabels("");
       r.setNote("");
+      r.setReason("");
       r.setEphemeral(true);
       mergedResources.add(r);
     }

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -13,7 +13,7 @@
   <f:entry title="${%entry.variable.title}" field="variable">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%entry.reason.title}"field="reason">
+  <f:entry title="${%entry.reason.title}" field="reason">
     <f:textbox/>
   </f:entry>
   <f:entry field="inversePrecedence">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -13,6 +13,9 @@
   <f:entry title="${%entry.variable.title}" field="variable">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%entry.reason.title}"field="reason">
+    <f:textbox/>
+  </f:entry>
   <f:entry field="inversePrecedence">
     <f:checkbox title="${%entry.inversePrecedence.checkbox.title}"/>
   </f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.properties
@@ -24,6 +24,7 @@ entry.resource.title=Resource
 entry.label.title=Label
 entry.quantity.title=Quantity
 entry.variable.title=Result variable
+entry.reason.title=Reason
 entry.inversePrecedence.checkbox.title=Inverse precedence
 entry.inversePrecedence.skipIfLocked.title=Skip queue
 entry.resourceSelectStrategy.title=Strategy for resource selection

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -18,8 +18,8 @@
     <f:textbox/>
   </f:entry>
   <f:entry title="${%entry.reason.title}" field="reason">
-    <f:textbox>
-  <f:entry>
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%entry.labels.title}" field="labels">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -17,6 +17,9 @@
   <f:entry title="${%entry.description.title}" field="description">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%entry.reason.title}" field="reason">
+    <f:textbox>
+  <f:entry>
   <f:entry title="${%entry.labels.title}" field="labels">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.properties
@@ -23,6 +23,7 @@
 entry.name.title=Name
 entry.description.title=Description
 entry.labels.title=Labels
+entry.reason.title=Reason
 entry.reservedBy.title=Reserved by
 entry.properties.title=Properties
 entry.properties.add=Add Property

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/reasonForm.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/reasonForm.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
+  <j:set var="resource" value="${request.getParameter('resource')}"/>
+  <j:set var="resourceObject" value="${it.getResource(resource)}"/>
+  <j:set var="reason" value="${resourceObject.reason}"/>
+  <l:ajax>
+    <f:block>
+      <form action="saveReason?resource=${h.urlEncode(resource)}" method="post" style="flex-grow: 1;">
+        <div class="jenkins-!-padding-right-4">
+          <f:entry help="${app.markupFormatter.helpUrl}">
+            <f:textarea name="reason" value="${reason}"
+              codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+          </f:entry>
+        </div>
+        <div align="right">
+          <f:submit value="${%Save}"/>
+        </div>
+      </form>
+    </f:block>
+  </l:ajax>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -50,6 +50,8 @@ THE SOFTWARE.
         <col class="col-width-2 text-end" />
         <!-- timestamp -->
         <col class="col-width-1 text-end" />
+        <!-- reason -->
+        <col class="col-width-2 text-end" />
         <!-- labels -->
         <col class="col-width-5 text-end" />
         <!-- properties -->
@@ -62,6 +64,7 @@ THE SOFTWARE.
         <th>${%resources.table.column.resource}</th>
         <th>${%resources.table.column.status}</th>
         <th>${%resources.table.column.timestamp}</th>
+        <th>${%resources.table.column.reason}</th>
         <th>${%resources.table.column.labels}</th>
         <th>${%resources.table.column.properties}</th>
         <th>${%resources.table.column.action}</th>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -25,6 +25,7 @@ resources.table.column.index=Index
 resources.table.column.resource=Resource
 resources.table.column.status=Status
 resources.table.column.labels=Labels
+resources.table.column.reason=Reason
 resources.table.column.properties=Properties
 resources.table.column.timestamp=Timestamp
 resources.table.column.action=Action

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -42,3 +42,27 @@ function replaceNote(element, resourceName) {
   });
   return false;
 }
+
+function replaceReason(element, resourceName) {
+  var d = document.getElementById("reason-" + resourceName);
+  d.innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
+  fetch("reasonForm", {
+    method: "post",
+    headers: crumb.wrap({
+      "Content-Type": "application/x-www-form-urlencoded",
+    }),
+    body: new URLSearchParams({
+      resource: resourceName,
+    }),
+  }).then((rsp) => {
+      rsp.text().then((responseText) => {
+        d.innerHTML = responseText;
+        evalInnerHtmlScripts(responseText, function () {
+          Behaviour.applySubtree(d);
+          d.getElementsByTagName("TEXTAREA")[0].focus();
+        });
+        layoutUpdateCallback.call();
+      });
+  });
+  return false;
+}


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->
<!-- in case you work on github issue -->
resolves #426 
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done
Reason field in the settings page, when adding a Lockable Resource:
<img width="1424" alt="image" src="https://github.com/jenkinsci/lockable-resources-plugin/assets/81731284/13fbd2c3-73bf-4aeb-af13-a62d22286457">

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [x] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
