### PR TITLE
Add properties to readResolve() (Fixes #507)

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -136,6 +136,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource>
     if (queuedContexts == null) { // this field was added after the initial version if this class
       queuedContexts = new ArrayList<>();
     }
+    if (properties == null) {
+      properties = new ArrayList<>();
+    }
     this.repairLabels();
     return this;
   }


### PR DESCRIPTION
1156.v5e9f897ece02 introduced user-defined properties, but lacks backward compatibility.
This commit fixes NullPointerException when using resources created prior to 1156.v5e9f897ece02.

Fixes #507 