### PR TITLE
Fix resource index column

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -67,12 +67,12 @@ THE SOFTWARE.
         <th>${%resources.table.column.action}</th>
       </thead>
       <tbody>
-        <j:forEach var="resource" items="${it.resources}">
+        <j:forEach var="resource" items="${it.resources}" varStatus="idx">
           <tr data-resource-name="${resource.name}">
             <!-- **************************************************************
                  Index
             -->
-            <td>${i + 1}</td>
+            <td>${idx.index + 1}</td>
 
             <!-- **************************************************************
                  Column with common resource data


### PR DESCRIPTION
The number in cloumn index is allways 1
This PR will fix it

![image](https://github.com/mPokornyETM/lockable-resources-plugin/assets/89339813/0975be42-5e6d-4efe-b313-4833507bd2c3)
