### PR TITLE
Add child row for properties

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -35,12 +35,25 @@ THE SOFTWARE.
 
   <div class="table-responsive">
     <table
-      class="jenkins-table jenkins-!-margin-bottom-4"
+      class="jenkins-table jenkins-!-margin-bottom-4 data-table"
       id="lockable-resources"
       data-remember-search-text="true"
       isLoaded="true"
       data-columns-definition="[null, null, null, null, null, null, null]"
-      data-table-configuration="{}"
+      data-table-configuration='
+      {
+        "responsive": {
+          "details": {
+            "type": "column"
+          }
+        },
+        "columnDefs": [
+            { "targets": "index", "className": "dt-control" },
+            { "targets": "properties", "visible": false }
+        ],
+        "order": [ 0, "asc" ],
+        "stateSave": true
+      }'
     >
       <colgroup>
         <!-- index -->

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -30,11 +30,12 @@ THE SOFTWARE.
   xmlns:st="jelly:stapler"
   >
   <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+
   <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
 
   <div class="table-responsive">
     <table
-      class="jenkins-table jenkins-!-margin-bottom-4 data-table"
+      class="jenkins-table jenkins-!-margin-bottom-4"
       id="lockable-resources"
       data-remember-search-text="true"
       isLoaded="true"
@@ -58,13 +59,13 @@ THE SOFTWARE.
         <col action="col-width-1 text-end" />
       </colgroup>
       <thead>
-        <th>${%resources.table.column.index}</th>
-        <th>${%resources.table.column.resource}</th>
-        <th>${%resources.table.column.status}</th>
-        <th>${%resources.table.column.timestamp}</th>
-        <th>${%resources.table.column.labels}</th>
-        <th>${%resources.table.column.properties}</th>
-        <th>${%resources.table.column.action}</th>
+        <th data-class-name="index">${%resources.table.column.index}</th>
+        <th data-class-name="resource">${%resources.table.column.resource}</th>
+        <th data-class-name="status">${%resources.table.column.status}</th>
+        <th data-class-name="timestamp">${%resources.table.column.timestamp}</th>
+        <th data-class-name="labels">${%resources.table.column.labels}</th>
+        <th data-class-name="properties">${%resources.table.column.properties}</th>
+        <th data-class-name="action">${%resources.table.column.action}</th>
       </thead>
       <tbody>
         <j:forEach var="resource" items="${it.resources}" varStatus="idx">
@@ -320,4 +321,7 @@ THE SOFTWARE.
     </table>
   </div>
   <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"/>
+
+
+
 </j:jelly>

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -42,3 +42,59 @@ function replaceNote(element, resourceName) {
   });
   return false;
 }
+
+function format(d) {
+  // `d` is the original data object for the row
+  // show all the hidden columns in the child row
+  var hiddenRows = getHiddenColumns();
+  return hiddenRows.map(i => d[i]).join("<br>");
+}
+
+function getHiddenColumns() {
+    // returns the indexes of all hidden rows
+    var indexes = new Array();
+
+    resourceTable.columns().every( function () {
+        if (!this.visible())
+            indexes.push(this.index())
+    });
+
+    return indexes;
+}
+
+jQuery(document).ready(function() {
+  resourceTable = jQuery('#lockable-resources').DataTable( {
+    responsive: {
+        details: {
+            type: 'column'
+        }
+    },
+    columnDefs: [
+        // use columns names, as how they are defined in the <th> elements in jelly file
+        { targets: "index", className: 'dt-control' },
+        { targets: "properties", visible: false }
+    ],
+    order: [ 0, 'asc' ]
+  } );
+
+
+  // set visible in columnDefs instead
+  // resourceTable.column('properties:name').visible( false );
+
+  // Add event listener for opening and closing details
+  jQuery('#lockable-resources tbody').on('click', 'td.dt-control', function () {
+      var tr = jQuery(this).closest('tr');
+      var row = resourceTable.row(tr);
+
+      // child row example taken from https://datatables.net/examples/api/row_details.html
+      if (row.child.isShown()) {
+          // This row is already open - close it
+          row.child.hide();
+          tr.removeClass('shown');
+      } else {
+          // Open this row
+          row.child(format(row.data())).show();
+          tr.addClass('shown');
+      }
+  });
+} );

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -54,7 +54,7 @@ function getHiddenColumns() {
     // returns the indexes of all hidden rows
     var indexes = new Array();
 
-    resourceTable.columns().every( function () {
+    jQuery("#lockable-resources").DataTable().columns().every( function () {
         if (!this.visible())
             indexes.push(this.index())
     });
@@ -63,28 +63,10 @@ function getHiddenColumns() {
 }
 
 jQuery(document).ready(function() {
-  resourceTable = jQuery('#lockable-resources').DataTable( {
-    responsive: {
-        details: {
-            type: 'column'
-        }
-    },
-    columnDefs: [
-        // use columns names, as how they are defined in the <th> elements in jelly file
-        { targets: "index", className: 'dt-control' },
-        { targets: "properties", visible: false }
-    ],
-    order: [ 0, 'asc' ]
-  } );
-
-
-  // set visible in columnDefs instead
-  // resourceTable.column('properties:name').visible( false );
-
   // Add event listener for opening and closing details
   jQuery('#lockable-resources tbody').on('click', 'td.dt-control', function () {
       var tr = jQuery(this).closest('tr');
-      var row = resourceTable.row(tr);
+      var row = jQuery("#lockable-resources").DataTable().row(tr);
 
       // child row example taken from https://datatables.net/examples/api/row_details.html
       if (row.child.isShown()) {


### PR DESCRIPTION
- <del>move initalisation of datatables to javascript: as far as I can tell, there's no way to access the DataTables object that is created by the datatables-api-plugin, from the javascript file, so instead initialise datatables in javascript file.
- hide the properties column
- show all hidden columns in the child row: if multiple columns were to be hidden, their content would just be shown below each other in the child row.

<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->
<!-- See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX). -->
<!-- in case you work on github issue -->
See #534
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

- show child row of lockable resources with and without properties
- reserve/unreserve => search term, order and page size is remembered after the page reloads

The part below has been fixed:
<del>There is one problem, the search is not remembered. When I add "stateSave" to the initialisation of the datatables, that does not work. It looks like datatables-api-plugin is saving some things itself in local/session storage. From https://github.com/jenkinsci/data-tables-api-plugin/pull/356/files, I think I understand this is not needed anymore since Jenkins 2.406. But it does not work for me either with Jenkins 2.406.

<del>Mind you, I'm not a Java, Jenkins or web developer, so maybe it's not a good idea to bypass the datatables-api plugin and it should be done differently?

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
