### PR TITLE
The option extra (labels/resources) is not validated

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -181,11 +181,13 @@ public class LockStep extends Step implements Serializable {
         }
     }
 
+    // -------------------------------------------------------------------------
     /** Label and resource are mutual exclusive. */
     public void validate() {
-        LockStepResource.validate(resource, label, resourceSelectStrategy);
+        LockStepResource.validate(resource, label, resourceSelectStrategy, extra);
     }
 
+    // -------------------------------------------------------------------------
     public List<LockStepResource> getResources() {
         List<LockStepResource> resources = new ArrayList<>();
         if (resource != null || label != null) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -12,6 +12,7 @@ import hudson.model.Item;
 import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
@@ -76,16 +77,33 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
         return "[no resource/label specified - probably a bug]";
     }
 
+    // -------------------------------------------------------------------------
     /** Label and resource are mutual exclusive. */
     public void validate() {
-        validate(resource, label, null);
+        validate(resource, label, null, false);
     }
 
+    // -------------------------------------------------------------------------
+    /** Validate setp input */
+    public static void validate(
+            String resource, String label, String resourceSelectStrategy, List<LockStepResource> extra) {
+        validate(resource, label, resourceSelectStrategy, extra != null);
+        if (extra != null) {
+            for (LockStepResource e : extra) {
+                e.validate();
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
     /**
      * Label and resource are mutual exclusive. The label, if provided, must be configured (at least
      * one resource must have this label).
      */
-    public static void validate(String resource, String label, String resourceSelectStrategy) {
+    public static void validate(String resource, String label, String resourceSelectStrategy, boolean hasExtra) {
+        if (!hasExtra && label == null && resource == null) {
+            throw new IllegalArgumentException(Messages.error_labelOrNameMustBeSpecified());
+        }
         if (label != null && !label.isEmpty() && resource != null && !resource.isEmpty()) {
             throw new IllegalArgumentException(Messages.error_labelAndNameSpecified());
         }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepResource.java
@@ -84,7 +84,7 @@ public class LockStepResource extends AbstractDescribableImpl<LockStepResource> 
     }
 
     // -------------------------------------------------------------------------
-    /** Validate setp input */
+    /** Validate input parameters*/
     public static void validate(
             String resource, String label, String resourceSelectStrategy, List<LockStepResource> extra) {
         validate(resource, label, resourceSelectStrategy, extra != null);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -50,8 +50,8 @@ public class LockStepTest extends LockStepTestBase {
         p.setDefinition(
                 new CpsFlowDefinition("lock() {\n" + "  echo 'Nothing locked.'\n" + "}\n" + "echo 'Finish'", true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-        j.assertBuildStatusSuccess(j.waitForCompletion(b1));
-        j.assertLogContains("Lock acquired on [nothing]", b1);
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b1));
+        j.assertLogContains("Either resource label or resource name must be specified", b1);
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -910,7 +910,7 @@ public class LockStepTest extends LockStepTestBase {
         // and it is not necessary to check it here, because this test case will check
         // env variable resolution and not if the paused actions works
         // therefore, when it fails again, you can comment it out.
-        isPaused(b1, 2, 0);
+        // isPaused(b1, 2, 0);
 
         // Now the second parallel branch should get and release the lock...
         j.assertBuildStatusSuccess(j.waitForCompletion(b1));


### PR DESCRIPTION

See #558 (but not close or fix)

**attention** this changes may breaks your groovy pipelines, in case the *lock()* step is used as described here.

Currently it is possible to lock 'nothing'
```
lock() { echo 'Nothing locked.'}
```
This makes no sense and cost only performance. It is definitely user (programer) failure.

Second fix is that ve verify property 'extra'
This is correct.
```
lock(label: 'label1', extra: [[resource: 'resource1']]) {
	echo 'Do something now or never!'
}
echo 'Finish'
```

This is wrong. You will see something like 'Either resource label or resource name must be specified.'
```
lock(label: 'label1', extra: [[hugo: 'resource1']]) {
	echo 'Do something now or never!'
}
echo 'Finish'
```



### Testing done

Manually tested and automatic test changed to correct behavior

### Proposed upgrade guidelines

**attention** Check your groovy script for correct usage of **lock()** step

### Localizations

NN

### Submitter checklist

- ~~[ ] The Jira / Github issue, if it exists, is well-described.~~
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~