### PR TITLE
Eliminate ConcurrentModificationException on plugin load (Jenkins startup)

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/BackwardCompatibility.java
@@ -33,22 +33,29 @@ public final class BackwardCompatibility {
 
     @Initializer(after = InitMilestone.JOB_LOADED)
     public static void compatibilityMigration() {
-        List<LockableResource> resources = LockableResourcesManager.get().getResources();
-        LOG.log(
-                Level.FINE,
-                "lockable-resources-plugin compatibility migration task run for " + resources.size() + " resources");
-        for (LockableResource resource : resources) {
-            List<StepContext> queuedContexts = resource.getQueuedContexts();
-            if (!queuedContexts.isEmpty()) {
-                for (StepContext queuedContext : queuedContexts) {
-                    List<String> resourcesNames = new ArrayList<>();
-                    resourcesNames.add(resource.getName());
-                    LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
-                    LockableResourcesManager.get()
-                            .queueContext(
-                                    queuedContext, Collections.singletonList(resourceHolder), resource.getName(), null);
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        synchronized (lrm.syncResources) {
+            List<LockableResource> resources = lrm.getResources();
+            LOG.log(
+                    Level.FINE,
+                    "lockable-resources-plugin compatibility migration task run for " + resources.size()
+                            + " resources");
+            for (LockableResource resource : resources) {
+                List<StepContext> queuedContexts = resource.getQueuedContexts();
+                if (!queuedContexts.isEmpty()) {
+                    for (StepContext queuedContext : queuedContexts) {
+                        List<String> resourcesNames = new ArrayList<>();
+                        resourcesNames.add(resource.getName());
+                        LockableResourcesStruct resourceHolder = new LockableResourcesStruct(resourcesNames, "", 0);
+                        LockableResourcesManager.get()
+                                .queueContext(
+                                        queuedContext,
+                                        Collections.singletonList(resourceHolder),
+                                        resource.getName(),
+                                        null);
+                    }
+                    queuedContexts.clear();
                 }
-                queuedContexts.clear();
             }
         }
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -28,7 +28,7 @@ public final class FreeDeadJobs {
     public static void freePostMortemResources() {
 
         LockableResourcesManager lrm = LockableResourcesManager.get();
-        synchronized (lrm) {
+        synchronized (lrm.syncResources) {
             LOG.log(Level.FINE, "lockable-resources-plugin free post mortem task run");
             for (LockableResource resource : lrm.getResources()) {
                 if (resource.getBuild() != null && !resource.getBuild().isInProgress()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -14,6 +14,7 @@ import static java.text.DateFormat.SHORT;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import groovy.lang.Binding;
 import hudson.Extension;
 import hudson.Util;
@@ -129,7 +130,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     @DataBoundConstructor
-    public LockableResource(String name) {
+    public LockableResource(@CheckForNull String name) {
         this.name = Util.fixNull(name);
         // todo throw exception, when the name is empty
         // todo check if the name contains only valid characters (no spaces, new lines ...)
@@ -184,7 +185,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     @DataBoundSetter
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         this.description = Util.fixNull(description);
     }
 
@@ -194,7 +195,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     @DataBoundSetter
-    public void setNote(String note) {
+    public void setNote(@Nullable String note) {
         this.note = Util.fixNull(note);
     }
 
@@ -229,7 +230,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      */
     // @Deprecated can not be used, because of JCaC
     @DataBoundSetter
-    public void setLabels(String labels) {
+    public void setLabels(@Nullable String labels) {
+        labels = Util.fixNull(labels);
         // todo use label parser from Jenkins.Label to allow the same syntax
         this.labelsAsList = new ArrayList<>();
         for (String label : labels.split("\\s+")) {
@@ -257,7 +259,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      * @return {@code true} if this resource contains the label.
      */
     @Exported
-    public boolean hasLabel(String labelToFind) {
+    public boolean hasLabel(@CheckForNull String labelToFind) {
         return this.labelsContain(labelToFind);
     }
 
@@ -277,8 +279,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      * https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#node-allocate-node).
      * Valid means that the resource contains the label or the Label-expression matched.
      */
-    public boolean isValidLabel(String candidate) {
-        if (candidate == null || candidate.isEmpty()) {
+    public boolean isValidLabel(@Nullable String candidate) {
+        candidate = Util.fixEmptyAndTrim(Util.fixNull(candidate));
+        if (candidate == null) {
             return false;
         }
 
@@ -312,7 +315,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     @DataBoundSetter
-    public void setProperties(List<LockableResourceProperty> properties) {
+    public void setProperties(@Nullable List<LockableResourceProperty> properties) {
         this.properties = (properties == null ? new ArrayList<>() : properties);
     }
 
@@ -358,7 +361,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     @DataBoundSetter
-    public void setReservedTimestamp(final Date reservedTimestamp) {
+    public void setReservedTimestamp(@Nullable final Date reservedTimestamp) {
         this.reservedTimestamp = reservedTimestamp == null ? null : new Date(reservedTimestamp.getTime());
     }
 
@@ -468,7 +471,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
         else return null;
     }
 
-    public void setBuild(Run<?, ?> lockedBy) {
+    public void setBuild(@Nullable Run<?, ?> lockedBy) {
         this.build = lockedBy;
         if (lockedBy != null) {
             this.buildExternalizableId = lockedBy.getExternalizableId();

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -218,7 +218,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
     @NonNull
     @Restricted(NoExternalUse.class)
     public List<LockableResource> getResourcesWithLabel(final String label) {
-        return _getResourcesWithLabel(label, this.getResources());
+        synchronized (this.syncResources) {
+            return _getResourcesWithLabel(label, this.getResources());
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -789,18 +789,17 @@ public class LockableResourcesManager extends GlobalConfiguration {
     @Restricted(NoExternalUse.class)
     public boolean addResource(@Nullable final LockableResource resource, final boolean doSave) {
 
+        if (resource == null || resource.getName() == null || resource.getName().isEmpty()) {
+            LOGGER.warning("Internal failure: We will add wrong resource: " + resource + getStack());
+            return false;
+        }
         synchronized (this.syncResources) {
-            if (resource == null
-                    || resource.getName() == null
-                    || resource.getName().isEmpty()) {
-                LOGGER.warning("Internal failure: We will add wrong resource: " + resource + getStack());
-                return false;
-            }
             if (this.resourceExist(resource.getName())) {
                 LOGGER.finest("We will add existing resource: " + resource + getStack());
                 return false;
             }
             this.resources.add(resource);
+            LOGGER.fine("Resource added : " + resource);
             if (doSave) {
                 this.save();
             }

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -6,7 +6,6 @@ import hudson.init.Initializer;
 import hudson.model.Node;
 import hudson.slaves.ComputerListener;
 import java.util.Iterator;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
@@ -18,7 +17,8 @@ import org.jenkins.plugins.lockableresources.util.Constants;
 @Extension
 public class NodesMirror extends ComputerListener {
 
-    private static final Logger LOG = Logger.getLogger(NodesMirror.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(NodesMirror.class.getName());
+    private static LockableResourcesManager lrm;
 
     // ---------------------------------------------------------------------------
     private static boolean isNodeMirrorEnabled() {
@@ -28,7 +28,7 @@ public class NodesMirror extends ComputerListener {
     // ---------------------------------------------------------------------------
     @Initializer(after = InitMilestone.JOB_LOADED)
     public static void createNodeResources() {
-        LOG.log(Level.FINE, "lockable-resources-plugin configure node resources");
+        LOGGER.info("lockable-resources-plugin: configure node resources");
         mirrorNodes();
     }
 
@@ -44,31 +44,37 @@ public class NodesMirror extends ComputerListener {
             return;
         }
 
-        deleteExistingNodes();
-
-        for (Node n : Jenkins.get().getNodes()) {
-            mirrorNode(n);
+        LOGGER.info("lockable-resources-plugin: start nodes mirroring");
+        lrm = LockableResourcesManager.get();
+        synchronized (lrm.syncResources) {
+            for (Node n : Jenkins.get().getNodes()) {
+                mirrorNode(n);
+            }
+            // please do not remove it, From time to time is necessary for developer debugs
+            // thx
+            // lrm.printResources();
+            deleteNotExistingNodes();
+            // lrm.printResources();
         }
+        LOGGER.info("lockable-resources-plugin: nodes mirroring finished");
     }
 
     // ---------------------------------------------------------------------------
-    private static void deleteExistingNodes() {
-        LockableResourcesManager lrm = LockableResourcesManager.get();
+    private static void deleteNotExistingNodes() {
         Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
         while (resourceIterator.hasNext()) {
             LockableResource resource = resourceIterator.next();
-            if (!resource.isNodeResource()) {
+            if (!resource.isNodeResource() || (Jenkins.get().getNode(resource.getName()) != null)) {
                 continue;
             }
             if (resource.isFree()) {
                 // we can remove this resource. Is newer used currently
+                LOGGER.config("lockable-resources-plugin: remove node resource '" + resource.getName() + "'.");
                 resourceIterator.remove();
             } else {
-                LOG.log(
-                        Level.FINE,
-                        "lockable-resources-plugin skip node deletion of: "
-                                + resource.getName()
-                                + ". Reason: Currently locked");
+                LOGGER.warning("lockable-resources-plugin: can not remove node-resource '"
+                        + resource.getName()
+                        + "'. The resource is currently used (not free).");
             }
         }
     }
@@ -79,20 +85,22 @@ public class NodesMirror extends ComputerListener {
             return;
         }
 
-        LockableResourcesManager lrm = LockableResourcesManager.get();
         LockableResource nodeResource = lrm.fromName(node.getNodeName());
         boolean exist = nodeResource != null;
         if (!exist) {
             nodeResource = new LockableResource(node.getNodeName());
+            LOGGER.config("lockable-resources-plugin: Node-resource '" + nodeResource.getName() + "' will be added.");
+        } else {
+            LOGGER.fine("lockable-resources-plugin: Node-resource '" + nodeResource.getName() + "' will be updated.");
         }
         nodeResource.setLabels(
                 node.getAssignedLabels().stream().map(Object::toString).collect(Collectors.joining(" ")));
         nodeResource.setNodeResource(true);
         nodeResource.setEphemeral(false);
         nodeResource.setDescription(node.getNodeDescription());
-        LOG.log(Level.FINE, "lockable-resources-plugin add node-resource: " + nodeResource.getName());
+
         if (!exist) {
-            lrm.getResources().add(nodeResource);
+            lrm.addResource(nodeResource);
         }
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -1,0 +1,119 @@
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Logger;
+import org.jenkins.plugins.lockableresources.util.Constants;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ConcurrentModificationExceptionTest {
+
+    private static final Logger LOGGER = Logger.getLogger(ConcurrentModificationExceptionTest.class.getName());
+
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void parallelTasksTest() throws Exception {
+        // disable save. Everything is saved into filesystem and it takes a while
+        // normally it is no problem, but we need to starts many tasks parallel
+        System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
+
+        // Do not mirror nodes now. We will allow it later in parallel tasks
+        System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "false");
+        LOGGER.info("add agents");
+        for (int i = 1; i <= 50; i++) j.createSlave("Agent_" + i, "label label2", null);
+        LOGGER.info("add agents done");
+
+        LockableResourcesManager LRM = LockableResourcesManager.get();
+
+        LOGGER.info("add resources");
+        for (int i = 1; i <= 1000; i++) LRM.createResourceWithLabel("resource_" + i, "label label2");
+        LOGGER.info("add resources done");
+
+        TimerTask taskBackwardCompatibility = new TimerTask() {
+            public void run() {
+                LOGGER.info("run BackwardCompatibility");
+                BackwardCompatibility.compatibilityMigration();
+                LOGGER.info("BackwardCompatibility done");
+            }
+        };
+        TimerTask taskFreeDeadJobs = new TimerTask() {
+            public void run() {
+                LOGGER.info("run FreeDeadJobs");
+                FreeDeadJobs.freePostMortemResources();
+                LOGGER.info("FreeDeadJobs done");
+            }
+        };
+        TimerTask taskNodesMirror = new TimerTask() {
+            public void run() {
+                System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
+                LOGGER.info("run NodesMirror");
+                NodesMirror.createNodeResources();
+                LOGGER.info("NodesMirror done");
+            }
+        };
+        TimerTask taskCreateAgents = new TimerTask() {
+            public void run() {
+                LOGGER.info("create extra slaves");
+                for (int i = 1; i <= 50; i++) {
+                    try {
+                        j.createSlave("ExtraAgent_" + i, "label label2", null);
+                        Thread.sleep(5);
+                    } catch (Exception error) {
+                        LOGGER.warning(error.toString());
+                    }
+                }
+                LOGGER.info("create extra slaves done");
+            }
+        };
+        TimerTask taskCreateResources = new TimerTask() {
+            public void run() {
+                LOGGER.info("create extra resources");
+                for (int i = 1; i <= 1000; i++) {
+
+                    try {
+                        if (LockableResourcesManager.get()
+                                .createResourceWithLabel("ExtraResource_" + i, "label label2"))
+                            LOGGER.info("ExtraResource_" + i + " added");
+                        assertNotNull(LockableResourcesManager.get().fromName("ExtraResource_" + i));
+                        Thread.sleep(10);
+                    } catch (Exception error) {
+                        LOGGER.warning(error.toString());
+                    }
+                }
+                LOGGER.info("create extra resources done");
+            }
+        };
+        long delay = 10L;
+        Timer timerCreateAgents = new Timer("CreateAgents");
+        timerCreateAgents.schedule(taskCreateAgents, delay);
+        Timer timerCreateResources = new Timer("CreateResources");
+        timerCreateResources.schedule(taskCreateResources, ++delay);
+        Timer timerBackwardCompatibility = new Timer("BackwardCompatibility");
+        timerBackwardCompatibility.schedule(taskBackwardCompatibility, ++delay);
+        Timer timerFreeDeadJobs = new Timer("FreeDeadJobs");
+        timerFreeDeadJobs.schedule(taskFreeDeadJobs, ++delay);
+        Timer timerNodesMirror = new Timer("NodesMirror");
+        timerNodesMirror.schedule(taskNodesMirror, ++delay);
+
+        // all the tasks are asynchronous operations, so wait until resources are created.
+        LOGGER.info("wait for resources");
+        for (int i = 1; i <= 100; i++) {
+            Thread.sleep(1000);
+            LOGGER.info("wait for resources " + i + " " + LRM.resourceExist("ExtraResource_1000") + " "
+                    + LRM.resourceExist("ExtraAgent_50") + " " + LRM.resourceExist("Agent_100"));
+            if (LRM.resourceExist("ExtraResource_1000")
+                    && LRM.resourceExist("ExtraAgent_50")
+                    && LRM.resourceExist("Agent_50")) break;
+        }
+
+        assertNotNull(LockableResourcesManager.get().fromName("ExtraResource_1000"));
+        assertNotNull(LockableResourcesManager.get().fromName("ExtraAgent_50"));
+        assertNotNull(LockableResourcesManager.get().fromName("Agent_50"));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -33,7 +33,7 @@ public class ConcurrentModificationExceptionTest {
         // Do not mirror nodes now. We will allow it later in parallel tasks
         System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "false");
         LOGGER.info("add agents");
-        for (int i = 1; i <= agentsCount; i++) j.createSlave("Agent_" + i, "label label2", null);
+        for (int i = 1; i <= agentsCount; i++) j.createSlave("Agent_" + i, "label label2 agent", null);
         LOGGER.info("add agents done");
 
         LockableResourcesManager LRM = LockableResourcesManager.get();
@@ -69,7 +69,7 @@ public class ConcurrentModificationExceptionTest {
                 LOGGER.info("create extra slaves");
                 for (int i = 1; i <= extraAgentsCount; i++) {
                     try {
-                        j.createSlave("ExtraAgent_" + i, "label label2", null);
+                        j.createSlave("ExtraAgent_" + i, "label label2 extra-agent", null);
                         Thread.sleep(5);
                         j.jenkins.removeNode(j.jenkins.getNode("ExtraAgent_" + i));
                         Thread.sleep(5);
@@ -114,12 +114,14 @@ public class ConcurrentModificationExceptionTest {
         LOGGER.info("wait for resources");
         for (int i = 1; i <= 100; i++) {
             Thread.sleep(500);
-            LOGGER.info("wait for resources " + i + " " + LRM.resourceExist("ExtraResource_" + extraResourcesCount)
-                    + " " + LRM.resourceExist("ExtraAgent_" + extraAgentsCount) + " "
-                    + LRM.resourceExist("Agent_" + agentsCount));
+            LOGGER.info("wait for resources " + i + " "
+                    + LRM.resourceExist("ExtraResource_" + extraResourcesCount)
+                    + " agent-extra: "
+                    + LRM.getResourcesWithLabel("agent-extra").size() + " != " + extraAgentsCount
+                    + " agent: " + LRM.getResourcesWithLabel("agent").size());
             if (LRM.resourceExist("ExtraResource_" + extraResourcesCount)
-                    && !LRM.resourceExist("ExtraAgent_" + extraAgentsCount)
-                    && LRM.resourceExist("Agent_" + agentsCount)) break;
+                    && LRM.getResourcesWithLabel("agent-extra").size() == 0
+                    && LRM.getResourcesWithLabel("agent").size() == agentsCount) break;
         }
 
         // normally is is bad idea to make so much assertions, but we need verify if all works fine

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.lockableresources;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import hudson.Functions;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
@@ -21,8 +22,8 @@ public class ConcurrentModificationExceptionTest {
     @Test
     public void parallelTasksTest() throws Exception {
 
-        final int agentsCount = 10;
-        final int extraAgentsCount = 20;
+        final int agentsCount = Functions.isWindows() ? 5 : 10;
+        final int extraAgentsCount = Functions.isWindows() ? 5 : 20;
         final int resourcesCount = 100;
         final int extraResourcesCount = 100;
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -22,9 +22,9 @@ public class ConcurrentModificationExceptionTest {
     public void parallelTasksTest() throws Exception {
 
         final int agentsCount = 10;
-        final int extraAgentsCount = 100;
-        final int resourcesCount = 500;
-        final int extraResourcesCount = 1000;
+        final int extraAgentsCount = 20;
+        final int resourcesCount = 100;
+        final int extraResourcesCount = 100;
 
         // disable save. Everything is saved into filesystem and it takes a while
         // normally it is no problem, but we need to starts many tasks parallel


### PR DESCRIPTION
fix #550 
partly implemented see #503 
fix #149 
close #151 


### Testing done

Added test src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java to simulate java.util.ConcurrentModificationException exception jenkins start

Result on current master branch

![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/0d79df90-af1c-4f96-b22d-5b8d9594a48a)

![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/dcf72783-aa54-4874-bb2a-baf3f63a939e)


vs this changes

![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/031ec10f-097b-4722-9ab0-bbf595c2786e)


As you can see, it is possible, that the plugin slow down perfomance now. But we are more safe.
java.util.ConcurrentModificationException is a no-go. Therfore lost of perfomance is not so strange

### Proposed upgrade guidelines

N/A

### Localizations

Logger messages are done english only

- [x] English
- ~~[ ] German~~
- ~~[ ] French~~
- ~~[ ] Slovak~~
- ~~[ ] Czech~~
- ~~[ ] ...~~

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- ~~[] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).~~
- [x] java code changes are tested by automated test.
