### PR TITLE
Allow to show ALL items in the tables

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -22,11 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+<j:jelly
+  xmlns:j="jelly:core"
+  xmlns:st="jelly:stapler">
   <j:set var="allLabels" value="${it.getLabelsList()}" />
   <j:if test="${allLabels.size() != 0}">
     <st:adjunct includes="io.jenkins.plugins.data-tables"/>
     <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
+
     <div class="table-responsive">
       <table
         class="jenkins-table jenkins-!-margin-bottom-4 data-table"
@@ -34,7 +37,14 @@ THE SOFTWARE.
         isLoaded="true"
         data-remember-search-text="true"
         data-columns-definition="[null, null, null, null]"
-        data-table-configuration="{}"
+        data-table-configuration='
+        {
+          "stateSave": true,
+          "lengthMenu": [
+            [10, 25, 50, 100, -1],
+            [10, 25, 50, 100, "${%table.settings.page.length.all}"]
+          ]
+        }'
       >
         <thead>
           <th>${%labels.table.column.labels}</th>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
@@ -25,3 +25,6 @@ labels.table.column.free=Free
 labels.table.column.assigned=Assigned resources
 labels.table.column.percentage=Free in %
 labels.free.tooltip={0} % free
+
+# Table settings
+table.settings.page.length.all=ALL

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
@@ -22,7 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+<j:jelly
+  xmlns:j="jelly:core"
+  xmlns:l="/lib/layout"
+  xmlns:st="jelly:stapler">
+  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
 
   <j:set var="queue" value="${it.getQueue()}"/>
 
@@ -52,7 +56,14 @@ THE SOFTWARE.
       isLoaded="true"
       data-remember-search-text="true"
       data-columns-definition="[null, null, null, null, null, null]"
-      data-table-configuration="{}"
+      data-table-configuration='
+      {
+        "stateSave": true,
+        "lengthMenu": [
+          [10, 25, 50, 100, -1],
+          [10, 25, 50, 100, "${%table.settings.page.length.all}"]
+        ]
+      }'
     >
       <thead>
         <th>${%queue.table.column.index}</th>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
@@ -60,3 +60,6 @@ groovy.code=!!!Groovy expression is currently not supported!!!
 type.resources=Resources
 type.label=Label
 type.groovy=Groovy expression
+
+# Table settings
+table.settings.page.length.all=ALL

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -52,8 +52,12 @@ THE SOFTWARE.
             { "targets": "properties", "visible": false }
         ],
         "order": [ 0, "asc" ],
-        "stateSave": true
-      }'
+        "stateSave": true,
+        "lengthMenu": [
+          [10, 25, 50, 100, -1],
+          [10, 25, 50, 100, "${%table.settings.page.length.all}"]
+        ]
+       }'
     >
       <colgroup>
         <!-- index -->

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -64,3 +64,6 @@ Giving it away to currently logged user indefinitely \
 (until that person, or some explicit scripted action, decides to release the resource).
 btn.editNote=Note
 btn.editNote.detail=Edit resource note.
+
+# Table settings
+table.settings.page.length.all=ALL


### PR DESCRIPTION
fix #483

### Testing done

Manual tests looks good
![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/0b9d48e4-e8cd-46b9-8cfe-263ea13ffa53)
![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/202791d6-366b-4ce2-859c-628df0ceb19d)
![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/b64588a7-a35d-428b-b5db-a49eb346f9de)


### Proposed upgrade guidelines

N/A

### Localizations

- [x] English

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- ~~[ ] There is automated testing or an explanation that explains why this change has no tests.~~
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- [x] Any localizations are transferred to *.properties files.
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

