### PR TITLE
Print detailed lock cause in build log

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,21 @@ To allow this behavior start jenkins with option `-Dorg.jenkins.plugins.lockable
 System.setProperty("org.jenkins.plugins.lockableresources.DISABLE_SAVE", "true");
 ```
 
+## Detailed lock cause
+
+Tle plugin step lock() will inform you in the build log detailed block cause. The size of cause depends on count of ordered resources and size of current queue. To eliminate big unreadable logs we limited the size. To see all cause change the properties as follow:
+
+```groovy
+System.setProperty("org.jenkins.plugins.lockableresources.PRINT_BLOCKED_RESOURCE", "-1");
+System.setProperty("org.jenkins.plugins.lockableresources.PRINT_QUEUE_INFO", "-1");
+```
+
+PRINT_BLOCKED_RESOURCE means how many of ordered resources are printed. Per default 2.
+PRINT_QUEUE_INFO how many queue items are printed. Per default 2.
+
+ 0 means disabled
+ -1 means all / unlimited.
+
 ## Configuration as Code
 
 This plugin can be configured via

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ System.setProperty("org.jenkins.plugins.lockableresources.PRINT_BLOCKED_RESOURCE
 System.setProperty("org.jenkins.plugins.lockableresources.PRINT_QUEUE_INFO", "-1");
 ```
 
-PRINT_BLOCKED_RESOURCE means how many of ordered resources are printed. Per default 2.
-PRINT_QUEUE_INFO how many queue items are printed. Per default 2.
+*PRINT_BLOCKED_RESOURCE* means how many of ordered resources are printed. Per default 2.
+*PRINT_QUEUE_INFO* how many queue items are printed. Per default 2.
 
  0 means disabled
  -1 means all / unlimited.

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import groovy.lang.Binding;
 import hudson.Extension;
 import hudson.Util;
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -450,6 +451,32 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
         }
         if (isLocked()) {
             return String.format("[%s] is locked by %s at %s", name, buildExternalizableId, timestamp);
+        }
+        return null;
+    }
+
+    /**
+     * Resolve the lock detailed cause for this resource.
+     * Note: this function is used in lock() step and not in the UI. Therefor
+     *       moving text into localization files does not make really sense.
+     *
+     * @return the lock cause or null if not locked
+     */
+    @CheckForNull
+    @Restricted(NoExternalUse.class)
+    public String getLockCauseDetail() {
+        if (this.isReserved()) {
+            User user = Jenkins.get().getUser(reservedBy);
+            String userText = user == null ? reservedBy : ModelHyperlinkNote.encodeTo(user);
+            return String.format("The resource [%s] is reserved by %s.", name, userText);
+        }
+        if (this.isLocked()) {
+            final DateFormat format = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT);
+            Date since = this.getReservedTimestamp();
+            final String timestamp = (since == null ? "<unknown>" : format.format(since));
+            return String.format(
+                    "The resource [%s] is locked by build %s since %s.",
+                    name, getBuild().getFullDisplayName() + " " + ModelHyperlinkNote.encodeTo(getBuild()), timestamp);
         }
         return null;
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -608,7 +608,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
                                         + "proceed with lock; this could be a legitimate state if the build waiting "
                                         + "for the lock was deleted or hard killed. More information is logged at "
                                         + "Level.FINE for debugging purposes.");
-                        unlockNames(remainingResourceNamesToUnLock, nextBuild, inversePrecedence);
+                        unlockNames(remainingResourceNamesToUnLock, null, inversePrecedence);
                         return;
                     } else {
                         requiredResource.setBuild(nextBuild);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -710,8 +710,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
                         // skip this one, for some reason there is no Run object for this context
                         orphan.add(entry);
                     } else if (run.getStartTimeInMillis() > newest) {
-                            newest = run.getStartTimeInMillis();
-                            newestEntry = entry;
+                        newest = run.getStartTimeInMillis();
+                        newestEntry = entry;
                     }
                 }
             }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.Util;
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
@@ -66,6 +67,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     // cache to enable / disable saving lockable-resources state
     private int enableSave = -1;
+
+    private static final int enabledBlockedCount =
+            SystemProperties.getInteger(Constants.SYSTEM_PROPERTY_PRINT_BLOCKED_RESOURCE, 2);
+    private static final int enabledCausesCount =
+            SystemProperties.getInteger(Constants.SYSTEM_PROPERTY_PRINT_QUEUE_INFO, 2);
 
     @SuppressFBWarnings(
             value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
@@ -593,21 +599,20 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
                 // lock all (old and new resources)
                 for (LockableResource requiredResource : requiredResourceForNextContext) {
-                    try {
-                        requiredResource.setBuild(nextContext.getContext().get(Run.class));
-                        resourcesToLock.put(requiredResource.getName(), requiredResource.getProperties());
-                    } catch (Exception e) {
+                    Run<?, ?> nextBuild = nextContext.getBuild();
+                    if (nextBuild == null) {
                         // skip this context, as the build cannot be retrieved (maybe it was deleted while
                         // running?)
-                        LOGGER.log(
-                                Level.WARNING,
+                        LOGGER.warning(
                                 "Skipping queued context for lock. Cannot get the Run object from the context to "
                                         + "proceed with lock; this could be a legitimate state if the build waiting "
                                         + "for the lock was deleted or hard killed. More information is logged at "
                                         + "Level.FINE for debugging purposes.");
-                        LOGGER.log(Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
-                        unlockNames(remainingResourceNamesToUnLock, build, inversePrecedence);
+                        unlockNames(remainingResourceNamesToUnLock, nextBuild, inversePrecedence);
                         return;
+                    } else {
+                        requiredResource.setBuild(nextBuild);
+                        resourcesToLock.put(requiredResource.getName(), requiredResource.getProperties());
                     }
                 }
 
@@ -699,15 +704,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 if (checkResourcesAvailability(
                                 entry.getResources(), null, resourceNamesToUnLock, resourceNamesToUnReserve)
                         != null) {
-                    try {
-                        Run<?, ?> run = entry.getContext().get(Run.class);
-                        if (run != null && run.getStartTimeInMillis() > newest) {
-                            newest = run.getStartTimeInMillis();
-                            newestEntry = entry;
-                        }
-                    } catch (IOException | InterruptedException e) {
+
+                    Run<?, ?> run = entry.getBuild();
+                    if (run == null) {
                         // skip this one, for some reason there is no Run object for this context
                         orphan.add(entry);
+                    } else if (run.getStartTimeInMillis() > newest) {
+                            newest = run.getStartTimeInMillis();
+                            newestEntry = entry;
                     }
                 }
             }
@@ -899,10 +903,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
             // lock all (old and new resources)
             for (LockableResource requiredResource : requiredResourceForNextContext) {
-                try {
-                    requiredResource.setBuild(nextContext.getContext().get(Run.class));
-                    resourcesToLock.put(requiredResource.getName(), requiredResource.getProperties());
-                } catch (Exception e) {
+                Run<?, ?> build = nextContext.getBuild();
+                if (build == null) {
                     // skip this context, as the build cannot be retrieved (maybe it was deleted while
                     // running?)
                     LOGGER.log(
@@ -911,8 +913,10 @@ public class LockableResourcesManager extends GlobalConfiguration {
                                     + "proceed with lock; this could be a legitimate state if the build waiting for "
                                     + "the lock was deleted or hard killed. More information is logged at "
                                     + "Level.FINE for debugging purposes.");
-                    LOGGER.log(Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
                     return;
+                } else {
+                    requiredResource.setBuild(build);
+                    resourcesToLock.put(requiredResource.getName(), requiredResource.getProperties());
                 }
             }
 
@@ -1213,11 +1217,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 // As soon as we know we can not fulfill the overall requirement
                 // (not enough of something from that list), we bail out quickly.
                 if (logger != null && !skipIfLocked) {
-                    logger.println("Found "
-                            + selected.size()
-                            + " available resource(s). Waiting for correct amount: "
-                            + requiredAmount
-                            + ".");
+
+                    String msg = "Found " + selected.size() + " available resource(s). Waiting for correct amount: "
+                            + requiredAmount + ".";
+
+                    if (enabledBlockedCount != 0) {
+                        msg += "\nBlocking causes: " + this.getCauses(candidates);
+                    }
+
+                    logger.println(msg);
                 }
                 return null;
             }
@@ -1226,6 +1234,79 @@ public class LockableResourcesManager extends GlobalConfiguration {
         }
 
         return allSelected;
+    }
+
+    // ---------------------------------------------------------------------------
+    // for debug purpose
+    private String getCauses(List<LockableResource> resources) {
+        StringBuffer buf = new StringBuffer();
+        int currentSize = 0;
+        for (LockableResource resource : resources) {
+            String cause = resource.getLockCauseDetail();
+            if (cause == null) continue; // means it is free, not blocked
+
+            currentSize++;
+            if (enabledBlockedCount > 0 && currentSize == enabledBlockedCount) {
+                buf.append("\n  ...");
+                break;
+            }
+            buf.append("\n  " + cause);
+
+            final String queueCause = getQueueCause(resource);
+            if (!queueCause.isEmpty()) {
+                buf.append(queueCause);
+            }
+        }
+        return buf.toString();
+    }
+
+    // ---------------------------------------------------------------------------
+    // for debug purpose
+    private String getQueueCause(final LockableResource resource) {
+        Map<Run<?, ?>, Integer> usage = new HashMap<Run<?, ?>, Integer>();
+
+        for (QueuedContextStruct entry : this.queuedContexts) {
+
+            Run<?, ?> build = entry.getBuild();
+            if (build == null) {
+                LOGGER.warning("Why we don`t have the build? " + entry);
+                continue;
+            }
+
+            int count = 0;
+            if (usage.containsKey(build)) {
+                count = usage.get(build);
+            }
+
+            for (LockableResourcesStruct _struct : entry.getResources()) {
+                if (_struct.isResourceRequired(resource)) {
+                    LOGGER.fine("found " + resource + " " + count);
+                    count++;
+                    break;
+                }
+            }
+
+            usage.put(build, count);
+        }
+
+        StringBuffer buf = new StringBuffer();
+        int currentSize = 0;
+        for (Map.Entry<Run<?, ?>, Integer> entry : usage.entrySet()) {
+            Run<?, ?> build = entry.getKey();
+            int count = entry.getValue();
+
+            if (build != null && count > 0) {
+                currentSize++;
+                buf.append("\n    Queued " + count + " time(s) by build " + " " + build.getFullDisplayName() + " "
+                        + ModelHyperlinkNote.encodeTo(build));
+
+                if (currentSize >= enabledCausesCount) {
+                    buf.append("\n    ...");
+                    break;
+                }
+            }
+        }
+        return buf.toString();
     }
 
     /*

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesStruct.java
@@ -90,6 +90,7 @@ public class LockableResourcesStruct implements Serializable {
         queuedAt = new Date().getTime();
         required = new ArrayList<>();
         if (resources != null) {
+            /// FIXME do we shall check here if resources.size() >= quantity
             for (String resource : resources) {
                 LockableResource r = LockableResourcesManager.get().fromName(resource);
                 if (r != null) {
@@ -156,5 +157,14 @@ public class LockableResourcesStruct implements Serializable {
     @Restricted(NoExternalUse.class) // used by jelly
     public boolean takeTooLong() {
         return (new Date().getTime() - this.queuedAt) > 3600000L;
+    }
+
+    /** Check if the *resource* is required by this struct / queue */
+    @Restricted(NoExternalUse.class)
+    public boolean isResourceRequired(final LockableResource resource) {
+        if (resource == null) {
+            return false;
+        }
+        return LockableResourcesManager.getResourcesNames(this.required).contains(resource.getName());
     }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -13,6 +13,8 @@ import hudson.model.Run;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -44,6 +46,8 @@ public class QueuedContextStruct implements Serializable {
      */
     private String variableName;
 
+    private static final Logger LOGGER = Logger.getLogger(QueuedContextStruct.class.getName());
+
     /*
      * Constructor for the QueuedContextStruct class.
      */
@@ -73,6 +77,7 @@ public class QueuedContextStruct implements Serializable {
             return this.getContext().get(Run.class);
         } catch (IOException | InterruptedException e) {
             // for some reason there is no Run object for this context
+            LOGGER.log(Level.FINE, "Cannot get the Run object from the context to proceed with lock", e);
             return null;
         }
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/util/Constants.java
@@ -9,4 +9,10 @@ public class Constants {
     /// **Keep in mind, that you will lost all your manual changed properties**
     /// The best way is to use it with JCaC plugin.
     public static final String SYSTEM_PROPERTY_DISABLE_SAVE = "org.jenkins.plugins.lockableresources.DISABLE_SAVE";
+    /// Enable to print lock causes. Keep in mind, that the log output may grove depends on count of
+    /// blocked resources.
+    public static final String SYSTEM_PROPERTY_PRINT_BLOCKED_RESOURCE =
+            "org.jenkins.plugins.lockableresources.PRINT_BLOCKED_RESOURCE";
+    public static final String SYSTEM_PROPERTY_PRINT_QUEUE_INFO =
+            "org.jenkins.plugins.lockableresources.PRINT_QUEUE_INFO";
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -947,8 +947,8 @@ public class LockStepTest extends LockStepTestBase {
     public void reserveInsideLockHonoured() throws Exception {
 
         // to see detailed lock causes
-        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_BLOCKED_RESOURCE, -1);
-        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_QUEUE_INFO, -1);
+        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_BLOCKED_RESOURCE, "-1");
+        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_QUEUE_INFO, "-1");
 
         // Use-case is a job keeping the resource reserved so it can use
         // it in other stages and free it later, not all in one closure

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 import java.util.logging.Logger;
 import net.sf.json.JSONObject;
+import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -944,6 +945,11 @@ public class LockStepTest extends LockStepTestBase {
     @Test
     // @Issue("JENKINS-XXXXX")
     public void reserveInsideLockHonoured() throws Exception {
+
+        // to see detailed lock causes
+        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_BLOCKED_RESOURCE, -1);
+        System.setProperty(Constants.SYSTEM_PROPERTY_PRINT_QUEUE_INFO, -1);
+
         // Use-case is a job keeping the resource reserved so it can use
         // it in other stages and free it later, not all in one closure
         // Variant: using the LockableResourcesManager to manipulate


### PR DESCRIPTION
fixed #591


### Testing done

The log output will be looks something like that. I also added the link to the build for faster navigation.
I did`t provide extra testcase for that. Just allow maximum print size in one test case to achieve all the lines.
I think it make no sense to create a  extra test case for that

![2023-12-01 17_10_15-lock-test #204 Console  Jenkins](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/6bff4e4c-4ccf-441d-bcd0-fc6a140a1f7d)


### Proposed upgrade guidelines

N/A

### Localizations

- [x] English

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

