### PR TITLE
The resource index is mandatory to access the resource properties, even if only one resource was locked.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ lock(resource: 'staging-server', inversePrecedence: true) {
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
-  echo env.LOCKED_RESOURCE_PROP_ABC
+  echo env.LOCKED_RESOURCE0_PROP_ABC
 }
 ```
 


### PR DESCRIPTION
The resource index is mandatory to access the resource properties, even if only one resource was locked.