### PR TITLE
NPE during the release of a lock

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -77,7 +77,12 @@ public class LockedResourcesBuildAction implements Action {
 
         for (String name : resourceNames) {
             LockableResource r = LockableResourcesManager.get().fromName(name);
-            action.add(new ResourcePOJO(r));
+            if (r != null) {
+                action.add(new ResourcePOJO(r));
+            } else {
+                // probably a ephemeral resource has been deleted
+                action.add(new ResourcePOJO(name, ""));
+            }
         }
     }
 
@@ -101,7 +106,11 @@ public class LockedResourcesBuildAction implements Action {
     @Restricted(NoExternalUse.class)
     public static LockedResourcesBuildAction fromResources(Collection<LockableResource> resources) {
         List<ResourcePOJO> resPojos = new ArrayList<>();
-        for (LockableResource r : resources) resPojos.add(new ResourcePOJO(r));
+        for (LockableResource r : resources) {
+            if (r != null) {
+                resPojos.add(new ResourcePOJO(r));
+            }
+        }
         return new LockedResourcesBuildAction(resPojos);
     }
 


### PR DESCRIPTION
fix #598


### Testing done

After analyzing the stack trace, found 2 possible was to get the exception.

+ ephemeral resource has been deleted, before we can update the build action
+ resource has been somehow deleted (concurrent action ?), before we can update the build action

Few manual tests are passed. Anyway, the changes handle possible NP, so it shall be fine now.

### Proposed upgrade guidelines

N/A

### Localizations

N/N

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~
