### PR TITLE
Name and value of properties are missing on API

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -259,7 +259,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      * @param labelToFind Label to find.
      * @return {@code true} if this resource contains the label.
      */
-    @Exported
+    @Restricted(NoExternalUse.class)
     public boolean hasLabel(@CheckForNull String labelToFind) {
         return this.labelsContain(labelToFind);
     }
@@ -446,6 +446,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      * @return the lock cause or null if not locked
      */
     @CheckForNull
+    @Exported
     public String getLockCause() {
         final DateFormat format = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT);
         final String timestamp = (reservedTimestamp == null ? "<unknown>" : format.format(reservedTimestamp));

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourceProperty.java
@@ -8,7 +8,9 @@ import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
+@ExportedBean(defaultVisibility = 999)
 public class LockableResourceProperty extends AbstractDescribableImpl<LockableResourceProperty>
         implements Serializable {
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -77,12 +77,7 @@ public class LockedResourcesBuildAction implements Action {
 
         for (String name : resourceNames) {
             LockableResource r = LockableResourcesManager.get().fromName(name);
-            if (r != null) {
-                action.add(new ResourcePOJO(r));
-            } else {
-                // probably a ephemeral resource has been deleted
-                action.add(new ResourcePOJO(name, ""));
-            }
+            action.add(new ResourcePOJO(r));
         }
     }
 
@@ -106,11 +101,7 @@ public class LockedResourcesBuildAction implements Action {
     @Restricted(NoExternalUse.class)
     public static LockedResourcesBuildAction fromResources(Collection<LockableResource> resources) {
         List<ResourcePOJO> resPojos = new ArrayList<>();
-        for (LockableResource r : resources) {
-            if (r != null) {
-                resPojos.add(new ResourcePOJO(r));
-            }
-        }
+        for (LockableResource r : resources) resPojos.add(new ResourcePOJO(r));
         return new LockedResourcesBuildAction(resPojos);
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction.java
@@ -77,7 +77,12 @@ public class LockedResourcesBuildAction implements Action {
 
         for (String name : resourceNames) {
             LockableResource r = LockableResourcesManager.get().fromName(name);
-            action.add(new ResourcePOJO(r));
+            if (r != null) {
+                action.add(new ResourcePOJO(r));
+            } else {
+                // probably a ephemeral resource has been deleted
+                action.add(new ResourcePOJO(name, ""));
+            }
         }
     }
 
@@ -101,7 +106,11 @@ public class LockedResourcesBuildAction implements Action {
     @Restricted(NoExternalUse.class)
     public static LockedResourcesBuildAction fromResources(Collection<LockableResource> resources) {
         List<ResourcePOJO> resPojos = new ArrayList<>();
-        for (LockableResource r : resources) resPojos.add(new ResourcePOJO(r));
+        for (LockableResource r : resources) {
+            if (r != null) {
+                resPojos.add(new ResourcePOJO(r));
+            }
+        }
         return new LockedResourcesBuildAction(resPojos);
     }
 


### PR DESCRIPTION
fix #595

### Testing done

+ an ephemeral resource 'testing' try to lock reserved resoure 'res1'
+ the resource 'resource-with-properties' has 2 properties

![image](https://github.com/jenkinsci/lockable-resources-plugin/assets/89339813/9580d2ab-3806-4c3a-ac42-3bd6dc600f8c)


### Proposed upgrade guidelines

N/A

### Localizations

N/N

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- [x] For new APIs and extension points, there is a link to at least one consumer.
       see #595 
- ~~[ ] Any localizations are transferred to *.properties files.~~
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).
      currently only this PR. We have no documentation for API at themoment.

