### PR TITLE
Eliminate ConcurrentModificationException by UI operations

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -76,9 +76,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
 
     /**
      * Track that a currently reserved resource was originally reserved for someone else, or locked
-     * for some other job, and explicitly taken away - e.g. for SUT post-mortems while a test job
-     * runs. Currently this does not track "who" it was taken from nor intend to give it back - just
-     * for bookkeeping and UI button naming. Cleared when the resource is unReserve'd.
+     * for some other job, and explicitly taken away - e.g. for SUT post-mortem while a test job runs.
+     * Currently this does not track "who" it was taken from nor intend to give it back - just for
+     * bookkeeping and UI button naming. Cleared when the resource is unReserve'd.
      */
     private boolean stolen = false;
 
@@ -372,6 +372,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     /** Return true when resource is free. False otherwise */
+    @Exported
     public boolean isFree() {
         return (!this.isLocked() && !this.isReserved() && !this.isQueued());
     }
@@ -565,8 +566,8 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     public void unReserve() {
-        setReservedBy(null);
-        setReservedTimestamp(null);
+        this.setReservedBy(null);
+        this.setReservedTimestamp(null);
         this.stolen = false;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResources.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResources.java
@@ -10,7 +10,6 @@ package org.jenkins.plugins.lockableresources;
 
 import hudson.Plugin;
 import hudson.model.Api;
-import java.util.Collections;
 import java.util.List;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -24,6 +23,6 @@ public class LockableResources extends Plugin {
 
     @Exported
     public List<LockableResource> getResources() {
-        return Collections.unmodifiableList(LockableResourcesManager.get().getResources());
+        return LockableResourcesManager.get().getReadOnlyResources();
     }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -719,7 +719,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return resourceNames;
     }
 
-    /** Returns names (IDs) off all existing resources (inc ephemeral) */
+    // ---------------------------------------------------------------------------
+    /** Returns names (IDs) off all existing resources (inclusive ephemeral) */
     @Restricted(NoExternalUse.class)
     public List<String> getAllResourcesNames() {
         synchronized (this.syncResources) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -227,9 +227,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     // ---------------------------------------------------------------------------
-    /** Get amount of free resources contained given *label* */
+    /** Get amount of free resources contained given *label*
+     *   This method is deprecated (no where used) and is not tested.
+     */
     @NonNull
     @Restricted(NoExternalUse.class)
+    @Deprecated
+    @ExcludeFromJacocoGeneratedReport
     public int getFreeResourceAmount(String label) {
         int free = 0;
         label = Util.fixEmpty(label);
@@ -252,6 +256,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // ---------------------------------------------------------------------------
     /**
      * @deprecated Use getResourcesWithLabel(String label)
+     * Note: The param *params* is not used (has no effect)
      */
     @Deprecated
     @Restricted(NoExternalUse.class)
@@ -263,7 +268,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // ---------------------------------------------------------------------------
     /**
      * Returns resources matching by given *label*.
-     * Note: The param *params* is not used (has no effect)
      */
     @NonNull
     @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -97,6 +97,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
      * Get all resources - read only The same as getResources() but unmodifiable list. The
      * getResources() is unsafe to use because of possible concurrent modification exception.
      */
+    @Restricted(NoExternalUse.class)
     public List<LockableResource> getReadOnlyResources() {
         synchronized (this.syncResources) {
             return new ArrayList<>(Collections.unmodifiableCollection(this.resources));

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -76,6 +76,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
     private static final int enabledCausesCount =
             SystemProperties.getInteger(Constants.SYSTEM_PROPERTY_PRINT_QUEUE_INFO, 2);
 
+    // ---------------------------------------------------------------------------
+    /** C-tor */
     @SuppressFBWarnings(
             value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
             justification = "Common Jenkins pattern to call method that can be overridden")
@@ -84,13 +86,28 @@ public class LockableResourcesManager extends GlobalConfiguration {
         load();
     }
 
+    // ---------------------------------------------------------------------------
+    /** Get all resources Includes declared, ephemeral and node resources */
     public List<LockableResource> getResources() {
-        return resources;
+        return this.resources;
     }
 
-    public synchronized List<LockableResource> getDeclaredResources() {
+    // ---------------------------------------------------------------------------
+    /**
+     * Get all resources - read only The same as getResources() but unmodifiable list. The
+     * getResources() is unsafe to use because of possible concurrent modification exception.
+     */
+    public List<LockableResource> getReadOnlyResources() {
+        synchronized (this.syncResources) {
+            return new ArrayList<>(Collections.unmodifiableCollection(this.resources));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    /** Get declared resources, means only defined in config file (xml or JCaC yaml). */
+    public List<LockableResource> getDeclaredResources() {
         ArrayList<LockableResource> declaredResources = new ArrayList<>();
-        for (LockableResource r : resources) {
+        for (LockableResource r : this.getReadOnlyResources()) {
             if (!r.isEphemeral() && !r.isNodeResource()) {
                 declaredResources.add(r);
             }
@@ -98,49 +115,56 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return declaredResources;
     }
 
+    // ---------------------------------------------------------------------------
+    /** Set all declared resources (do not includes ephemeral and node resources). */
     @DataBoundSetter
-    public synchronized void setDeclaredResources(List<LockableResource> declaredResources) {
-        Map<String, LockableResource> lockedResources = new HashMap<>();
-        for (LockableResource r : this.resources) {
-            if (!r.isLocked()) continue;
-            lockedResources.put(r.getName(), r);
-        }
-
-        // Removed from configuration locks became ephemeral.
-        ArrayList<LockableResource> mergedResources = new ArrayList<>();
-        Set<String> addedLocks = new HashSet<>();
-        for (LockableResource r : declaredResources) {
-            if (!addedLocks.add(r.getName())) {
-                continue;
+    public void setDeclaredResources(List<LockableResource> declaredResources) {
+        synchronized (this.syncResources) {
+            Map<String, LockableResource> lockedResources = new HashMap<>();
+            for (LockableResource r : this.resources) {
+                if (!r.isLocked()) continue;
+                lockedResources.put(r.getName(), r);
             }
-            LockableResource locked = lockedResources.remove(r.getName());
-            if (locked != null) {
-                // Merge already locked lock.
-                locked.setDescription(r.getDescription());
-                locked.setLabels(r.getLabels());
-                locked.setEphemeral(false);
-                locked.setNote(r.getNote());
-                mergedResources.add(locked);
-                continue;
+
+            // Removed from configuration locks became ephemeral.
+            ArrayList<LockableResource> mergedResources = new ArrayList<>();
+            Set<String> addedLocks = new HashSet<>();
+            for (LockableResource r : declaredResources) {
+                if (!addedLocks.add(r.getName())) {
+                    continue;
+                }
+                LockableResource locked = lockedResources.remove(r.getName());
+                if (locked != null) {
+                    // Merge already locked lock.
+                    locked.setDescription(r.getDescription());
+                    locked.setLabels(r.getLabels());
+                    locked.setEphemeral(false);
+                    locked.setNote(r.getNote());
+                    mergedResources.add(locked);
+                    continue;
+                }
+                mergedResources.add(r);
             }
-            mergedResources.add(r);
-        }
 
-        for (LockableResource r : lockedResources.values()) {
-            // Removed locks became ephemeral.
-            r.setDescription("");
-            r.setLabels("");
-            r.setNote("");
-            r.setEphemeral(true);
-            mergedResources.add(r);
-        }
+            for (LockableResource r : lockedResources.values()) {
+                // Removed locks became ephemeral.
+                r.setDescription("");
+                r.setLabels("");
+                r.setNote("");
+                r.setEphemeral(true);
+                mergedResources.add(r);
+            }
 
-        this.resources = mergedResources;
+            this.resources = mergedResources;
+        }
     }
 
+    // ---------------------------------------------------------------------------
+    /** Get all resources used by project. */
+    @Restricted(NoExternalUse.class)
     public List<LockableResource> getResourcesFromProject(String fullName) {
         List<LockableResource> matching = new ArrayList<>();
-        for (LockableResource r : resources) {
+        for (LockableResource r : this.getReadOnlyResources()) {
             String rName = r.getQueueItemProject();
             if (rName != null && rName.equals(fullName)) {
                 matching.add(r);
@@ -149,9 +173,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return matching;
     }
 
+    // ---------------------------------------------------------------------------
+    /** Get all resources used by build. */
+    @Restricted(NoExternalUse.class)
     public List<LockableResource> getResourcesFromBuild(Run<?, ?> build) {
         List<LockableResource> matching = new ArrayList<>();
-        for (LockableResource r : resources) {
+        for (LockableResource r : this.getReadOnlyResources()) {
             Run<?, ?> rBuild = r.getBuild();
             if (rBuild != null && rBuild == build) {
                 matching.add(r);
@@ -160,17 +187,18 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return matching;
     }
 
-    // ----------------------------------------------------------------------------
-    @SuppressFBWarnings(value = "NP_LOAD_OF_KNOWN_NULL_VALUE", justification = "null value is checked correctly")
+    // ---------------------------------------------------------------------------
+    /**
+     * Check if the label is valid. Valid in this context means, if is configured on someone resource.
+     */
+    @Restricted(NoExternalUse.class)
     public Boolean isValidLabel(@Nullable String label) {
         if (label == null || label.isEmpty()) {
             return false;
         }
-        if (this.getAllLabels().contains(label)) return true;
 
-        final Map<String, Object> params = null;
-        for (LockableResource r : this.resources) {
-            if (r.isValidLabel(label, params)) {
+        for (LockableResource r : this.getReadOnlyResources()) {
+            if (r != null && r.isValidLabel(label)) {
                 return true;
             }
         }
@@ -178,10 +206,16 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return false;
     }
 
-    // ----------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    /** Returns all configured labels. */
+    @NonNull
+    @Restricted(NoExternalUse.class)
     public Set<String> getAllLabels() {
         Set<String> labels = new HashSet<>();
-        for (LockableResource r : this.resources) {
+        for (LockableResource r : this.getReadOnlyResources()) {
+            if (r == null) {
+                continue;
+            }
             List<String> toAdd = r.getLabelsAsList();
             if (toAdd.isEmpty()) {
                 continue;
@@ -192,13 +226,22 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     // ---------------------------------------------------------------------------
+    /** Get amount of free resources contained given *label* */
+    @NonNull
+    @Restricted(NoExternalUse.class)
     public int getFreeResourceAmount(String label) {
         int free = 0;
-        for (LockableResource r : this.resources) {
-            if (r.isLocked() || r.isQueued() || r.isReserved()) {
+        label = Util.fixEmpty(label);
+
+        if (label == null) {
+            return free;
+        }
+
+        for (LockableResource r : this.getResourcesWithLabel(label)) {
+            if (r == null) {
                 continue;
             }
-            if (r.hasLabel(label)) {
+            if (r.isFree()) {
                 free++;
             }
         }
@@ -247,7 +290,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     // ---------------------------------------------------------------------------
     /**
-     * Get a list of resources matching the script.
+     * Returns a list of resources matching by given *script*.
      *
      * @param script Script
      * @param params Additional parameters
@@ -257,11 +300,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
      * @since 2.0
      */
     @NonNull
+    @Restricted(NoExternalUse.class)
     public List<LockableResource> getResourcesMatchingScript(
             @NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params) throws ExecutionException {
         List<LockableResource> found = new ArrayList<>();
-        for (LockableResource r : this.resources) {
-            if (r.scriptMatches(script, params)) found.add(r);
+        synchronized (this.syncResources) {
+            for (LockableResource r : this.resources) {
+                if (r.scriptMatches(script, params)) found.add(r);
+            }
         }
         return found;
     }
@@ -412,7 +458,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 candidates.retainAll(resources);
             } else {
                 candidates = (systemGroovyScript == null)
-                        ? getResourcesWithLabel(requiredResources.label, params)
+                        ? getResourcesWithLabel(requiredResources.label)
                         : getResourcesMatchingScript(systemGroovyScript, params);
                 cachedCandidates.put(queueItemId, candidates);
             }
@@ -458,7 +504,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     // Return false if another item queued for this project -> bail out
     private boolean checkCurrentResourcesStatus(
             List<LockableResource> selected, String project, long taskId, Logger log) {
-        for (LockableResource r : resources) {
+        for (LockableResource r : this.resources) {
             // This project might already have something in queue
             String rProject = r.getQueueItemProject();
             if (rProject != null && rProject.equals(project)) {
@@ -469,7 +515,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
                     // The project has another buildable item waiting -> bail out
                     log.log(
                             Level.FINEST,
-                            "{0} has another build " + "that already queued resource {1}. Continue queueing.",
+                            "{0} has another build that already queued resource {1}. Continue queueing.",
                             new Object[] {project, r});
                     return false;
                 }
@@ -673,6 +719,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return resourceNames;
     }
 
+    /** Returns names (IDs) off all existing resources (inc ephemeral) */
+    @Restricted(NoExternalUse.class)
+    public List<String> getAllResourcesNames() {
+        synchronized (this.syncResources) {
+            return getResourcesNames(this.resources);
+        }
+    }
+
     /**
      * @see #getNextQueuedContext(List, List, boolean, QueuedContextStruct)
      */
@@ -737,10 +791,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return newestEntry;
     }
 
+    // ---------------------------------------------------------------------------
     /** Returns current queue */
     @Restricted(NoExternalUse.class) // used by jelly
     public List<QueuedContextStruct> getCurrentQueuedContext() {
-        return Collections.unmodifiableList(this.queuedContexts);
+        synchronized (this.syncResources) {
+            return Collections.unmodifiableList(this.queuedContexts);
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -796,7 +853,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
     public boolean addResource(@Nullable final LockableResource resource, final boolean doSave) {
 
         if (resource == null || resource.getName() == null || resource.getName().isEmpty()) {
-            LOGGER.warning("Internal failure: We will add wrong resource: " + resource + getStack());
+            LOGGER.warning("Internal failure: We will add wrong resource: '" + resource + "' " + getStack());
             return false;
         }
         synchronized (this.syncResources) {
@@ -819,7 +876,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
      */
     public synchronized boolean reserve(List<LockableResource> resources, String userName) {
         for (LockableResource r : resources) {
-            if (r.isReserved() || r.isLocked() || r.isQueued()) {
+            if (!r.isFree()) {
                 return false;
             }
         }
@@ -852,7 +909,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
      */
     public synchronized void reassign(List<LockableResource> resources, String userName) {
         for (LockableResource r : resources) {
-            if (r.isReserved() || r.isLocked() || r.isQueued()) {
+            if (!r.isFree()) {
                 r.unReserve();
             }
             r.setReservedBy(userName);
@@ -1234,6 +1291,8 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 if (selected.size() >= requiredAmount) {
                     break;
                 }
+                // TODO: it shall be used isFree() here, but in that case we need to change the
+                // logic in parametrized builds and that is much more effort as I want to spend here now
                 if (!rs.isReserved() && !rs.isLocked()) {
                     selected.add(rs);
                 }
@@ -1372,8 +1431,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
         return (LockableResourcesManager) Jenkins.get().getDescriptorOrDie(LockableResourcesManager.class);
     }
 
+    // ---------------------------------------------------------------------------
     @Override
-    public synchronized void save() {
+    public void save() {
         if (enableSave == -1) {
             // read system property and cache it.
             enableSave = SystemProperties.getBoolean(Constants.SYSTEM_PROPERTY_DISABLE_SAVE) ? 0 : 1;
@@ -1381,12 +1441,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
         if (enableSave == 0) return; // saving is disabled
 
-        if (BulkChange.contains(this)) return; // no change detected
+        synchronized (this.syncResources) {
+            if (BulkChange.contains(this)) return;
 
-        try {
-            getConfigFile().write(this);
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to save " + getConfigFile(), e);
+            try {
+                getConfigFile().write(this);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to save " + getConfigFile(), e);
+            }
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -185,13 +185,7 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
             } else {
                 List<String> wrongNames = new ArrayList<>();
                 for (String name : names.split("\\s+")) {
-                    boolean found = false;
-                    for (LockableResource r : LockableResourcesManager.get().getResources()) {
-                        if (r.getName().equals(name)) {
-                            found = true;
-                            break;
-                        }
-                    }
+                    boolean found = LockableResourcesManager.get().resourceExist(name);
                     if (!found) wrongNames.add(name);
                 }
                 if (wrongNames.isEmpty()) {
@@ -293,8 +287,9 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
             value = Util.fixEmptyAndTrim(value);
 
             if (value != null) {
-                for (LockableResource r : LockableResourcesManager.get().getResources()) {
-                    if (r.getName().startsWith(value)) c.add(r.getName());
+                List<String> allNames = LockableResourcesManager.get().getAllResourcesNames();
+                for (String name : allNames) {
+                    if (name.startsWith(value)) c.add(name);
                 }
             }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -110,7 +110,7 @@ public class LockableResourcesRootAction implements RootAction {
     @Exported
     @Restricted(NoExternalUse.class) // used by jelly
     public List<LockableResource> getResources() {
-        return LockableResourcesManager.get().getResources();
+        return LockableResourcesManager.get().getReadOnlyResources();
     }
 
     // ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ public class LockableResourcesRootAction implements RootAction {
     public LinkedHashMap<String, LockableResourcesLabel> getLabelsList() {
         LinkedHashMap<String, LockableResourcesLabel> map = new LinkedHashMap<>();
 
-        for (LockableResource r : LockableResourcesManager.get().getResources()) {
+        for (LockableResource r : LockableResourcesManager.get().getReadOnlyResources()) {
             if (r == null || r.getName().isEmpty()) {
                 continue; // defensive, shall never happens, but ...
             }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
@@ -4,11 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import hudson.model.AutoCompletionCandidates;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.AccessDeniedException3;
 import hudson.util.FormValidation;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.TreeSet;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,5 +84,81 @@ public class LockableResourceManagerTest {
         SecurityContextHolder.getContext().setAuthentication(manager.impersonate2());
         assertEquals(FormValidation.ok(), d.doCheckResourceNames("resource1", null, false, item));
         assertEquals(FormValidation.ok(), d.doCheckLabelName("some-label", null, false, item));
+    }
+
+    @Test
+    public void doAutoCompleteLabelName() throws Exception {
+        RequiredResourcesProperty.DescriptorImpl d = new RequiredResourcesProperty.DescriptorImpl();
+        LockableResourcesManager.get().createResourceWithLabel("resource1", "label-1-A label-2-B");
+        LockableResourcesManager.get().createResource("resource2");
+        LockableResourcesManager.get().createResourceWithLabel("resource3", "label-1-A");
+        LockableResourcesManager.get().createResourceWithLabel("resource4", "Label-1");
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ)
+                .everywhere()
+                .to("user")
+                .grant(Jenkins.ADMINISTER)
+                .everywhere()
+                .to("manager"));
+
+        j.buildAndAssertSuccess(j.createFreeStyleProject("aProject"));
+        Item item = j.jenkins.getItem("aProject");
+        assertNotNull(item);
+
+        User user = User.get("user", true, Collections.emptyMap());
+        SecurityContextHolder.getContext().setAuthentication(user.impersonate2());
+        // the 'user' has no permission
+        assertThrows(AccessDeniedException3.class, () -> d.doAutoCompleteLabelName("resource1", item));
+
+        User manager = User.get("manager", true, Collections.emptyMap());
+        SecurityContextHolder.getContext().setAuthentication(manager.impersonate2());
+
+        assertContains(d.doAutoCompleteLabelName("lab", item), "label-1-A", "label-2-B");
+        assertContains(d.doAutoCompleteLabelName("label-1", item), "label-1-A");
+        assertContains(d.doAutoCompleteLabelName("label-2", item), "label-2-B");
+        assertContains(d.doAutoCompleteLabelName("Lab", item), "Label-1");
+        d.doAutoCompleteLabelName(null, item);
+        d.doAutoCompleteLabelName("", item);
+        d.doAutoCompleteLabelName("resource1", item);
+    }
+
+    @Test
+    public void doAutoCompleteResourceNames() throws Exception {
+        RequiredResourcesProperty.DescriptorImpl d = new RequiredResourcesProperty.DescriptorImpl();
+        LockableResourcesManager.get().createResource("resource1");
+        LockableResourcesManager.get().createResource("Resource1");
+        LockableResourcesManager.get().createResource("resource2");
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ)
+                .everywhere()
+                .to("user")
+                .grant(Jenkins.ADMINISTER)
+                .everywhere()
+                .to("manager"));
+
+        j.buildAndAssertSuccess(j.createFreeStyleProject("aProject"));
+        Item item = j.jenkins.getItem("aProject");
+        assertNotNull(item);
+
+        User user = User.get("user", true, Collections.emptyMap());
+        SecurityContextHolder.getContext().setAuthentication(user.impersonate2());
+        // the 'user' has no permission
+        assertThrows(AccessDeniedException3.class, () -> d.doAutoCompleteResourceNames("resource1", item));
+
+        User manager = User.get("manager", true, Collections.emptyMap());
+        SecurityContextHolder.getContext().setAuthentication(manager.impersonate2());
+
+        assertContains(d.doAutoCompleteResourceNames("Res", item), "Resource1");
+        assertContains(d.doAutoCompleteResourceNames("res", item), "resource1", "resource2");
+        d.doAutoCompleteResourceNames(null, item);
+        d.doAutoCompleteResourceNames("", item);
+    }
+
+    private void assertContains(AutoCompletionCandidates c, String... values) {
+        assertEquals(new TreeSet<>(Arrays.asList(values)), new TreeSet<>(c.getValues()));
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -385,6 +385,7 @@ public class LockableResourcesRootActionTest extends LockStepTestBase {
         this.LRM.createResourceWithLabel("resource-A", "resource-label-1 ");
         this.LRM.createResourceWithLabel("resource-B", "resource-label-1 resource-label-2");
         this.LRM.createResourceWithLabel(" resource-C", "resource-label-1 \n \t \r resource-label-2 resource-label-3");
+        this.LRM.createResourceWithLabel("resource-D", null);
 
         Set<String> expectedLabels = new HashSet<>();
         expectedLabels.add("resource-label-1");


### PR DESCRIPTION
inspired by #558 and partly eliminates
see #503 
see #597 

The sense of this PR is to split the changes in mentiond PR #558 to make the review (and in worst case revert) much more simple.

The code documentation has been also extended, in case somebody else want read and extend the code.

The 'property' free has been added to API. This is summary state of the resource. That means, check if the resource is currently free or not, is much more easy.

Also performance shall be little better, but I didn´t measurments before and after.

note: dissallow white space check to eliminate many many changes produced by code formatting

### Testing done

I Provide few manual test cases, and waiting for automatic tests. There are currently no stres tests. Therefore I hope, when current automated test are OK, that we do not change any interfaces.

### Proposed upgrade guidelines

N/A

### Localizations

N/N

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- [] For new APIs and extension points, there is a link to at least one consumer.
- ~~[ ] Any localizations are transferred to *.properties files.~~
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

