### PR TITLE
Only run GitHub actions in jenkinsci GitHub org

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jenkinsci'
 
     steps:
 


### PR DESCRIPTION
## Only run GitHub actions in jenkinsci GitHub org

Avoid 'Run failed' mail messages and don't waste GitHub resources by running the Crowdin action on forks.  Inspired by https://github.com/jenkins-infra/jenkins.io/pull/6974 with special thanks to @NotMyFault.

### Testing done

Tested in https://github.com/jenkins-infra/jenkins.io/pull/6974 to confirm that it works.  Test automation is not feasible for this change.

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] java code changes are tested by automated test.
