### PR TITLE
More concurrent modification exception avoidance

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -30,7 +30,7 @@ public final class FreeDeadJobs {
         LockableResourcesManager lrm = LockableResourcesManager.get();
         synchronized (lrm.syncResources) {
             LOG.log(Level.FINE, "lockable-resources-plugin free post mortem task run");
-            for (LockableResource resource : lrm.getResources()) {
+            for (LockableResource resource : lrm.getReadOnlyResources()) {
                 if (resource.getBuild() != null && !resource.getBuild().isInProgress()) {
                     LOG.log(
                             Level.INFO,

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1042,11 +1042,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
     }
 
     /**
-     * Make the lockable resource re-usable and notify the queue(s), if any WARNING: Do not use this
-     * from inside the lock step closure which originally locked this resource, to avoid nasty
-     * surprises! Namely, this *might* let a second consumer use the resource quickly, but when the
-     * original closure ends and unlocks again that resource, a third consumer might then effectively
-     * hijack it from the second one.
+     * Make the lockable resource re-usable and notify the queue(s), if any.
+     * <p>
+     * WARNING: Do not use this from inside the lock step closure which originally locked this resource,
+     * to avoid nasty surprises! Namely, this *might* let a second consumer use the resource quickly,
+     * but when the original closure ends and unlocks again that resource, a third consumer might then
+     * effectively hijack it from the second one.
      */
     public synchronized void recycle(List<LockableResource> resources) {
         // Not calling reset() because that also un-queues the resource

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -61,20 +61,22 @@ public class NodesMirror extends ComputerListener {
 
     // ---------------------------------------------------------------------------
     private static void deleteNotExistingNodes() {
-        Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
-        while (resourceIterator.hasNext()) {
-            LockableResource resource = resourceIterator.next();
-            if (!resource.isNodeResource() || (Jenkins.get().getNode(resource.getName()) != null)) {
-                continue;
-            }
-            if (resource.isFree()) {
-                // we can remove this resource. Is newer used currently
-                LOGGER.config("lockable-resources-plugin: remove node resource '" + resource.getName() + "'.");
-                resourceIterator.remove();
-            } else {
-                LOGGER.warning("lockable-resources-plugin: can not remove node-resource '"
-                        + resource.getName()
-                        + "'. The resource is currently used (not free).");
+        synchronized (lrm.syncResources) {
+            Iterator<LockableResource> resourceIterator = lrm.getResources().iterator();
+            while (resourceIterator.hasNext()) {
+                LockableResource resource = resourceIterator.next();
+                if (!resource.isNodeResource() || (Jenkins.get().getNode(resource.getName()) != null)) {
+                    continue;
+                }
+                if (resource.isFree()) {
+                    // we can remove this resource. Is newer used currently
+                    LOGGER.config("lockable-resources-plugin: remove node resource '" + resource.getName() + "'.");
+                    resourceIterator.remove();
+                } else {
+                    LOGGER.warning("lockable-resources-plugin: can not remove node-resource '"
+                            + resource.getName()
+                            + "'. The resource is currently used (not free).");
+                }
             }
         }
     }


### PR DESCRIPTION
See #604, #601 and similar efforts.

This PR adds synchronization for operations done with LRM resources property, because during a Jenkins start with recent plugin version I've still occasionally got that ConcurrentModificationException. My best guess is that `freePostMortemResources()` (explicitly mentioned in the starting page stack trace) and perhaps `deleteNotExistingNodes()` locked horns. 

The XML mentioned a number of resources, all are `ephemeral=true` (probably saved with a graceful shutdown, then slated for deletion during start-up as no living jobs referenced them). On that system, there are no lockable resources defined persistently.

### Testing done

Deployed into the Jenkins instance that suffered the issue. It started and seems to work correctly (gotta run some builds that lock/unlock stuff, to be more sure), and cleaned away many of the ephemeral resources. 

On one restart I saw two remaining (one claimed locked by a job that was aborted by the restart), on another one remained and did not disappear after I claimed and released it via UI.

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
