### PR TITLE
Reduce verbose log levels

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -66,7 +66,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
                     if (lrm.createResource(resource.resource)) {
                         LockableResourcesManager.printLogs(
                                 "Resource [" + resource.resource + "] did not exist. Created.",
-                                Level.INFO,
+                                Level.FINE,
                                 LOGGER,
                                 logger);
                     }
@@ -113,12 +113,12 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
         if (step.skipIfLocked) {
             this.printBlockCause(logger, resourceHolderList);
             LockableResourcesManager.printLogs(
-                    "[" + step + "] is not free, skipping execution ...", Level.INFO, LOGGER, logger);
+                    "[" + step + "] is not free, skipping execution ...", Level.FINE, LOGGER, logger);
             getContext().onSuccess(null);
         } else {
             this.printBlockCause(logger, resourceHolderList);
             LockableResourcesManager.printLogs(
-                    "[" + step + "] is not free, waiting for execution ...", Level.INFO, LOGGER, logger);
+                    "[" + step + "] is not free, waiting for execution ...", Level.FINE, LOGGER, logger);
             LockableResourcesManager lrm = LockableResourcesManager.get();
             lrm.queueContext(getContext(), resourceHolderList, step.toString(), step.variable);
         }
@@ -154,7 +154,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
             node = context.get(FlowNode.class);
             logger = context.get(TaskListener.class).getLogger();
             LockableResourcesManager.printLogs(
-                    "Lock acquired on [" + resourceDescription + "]", Level.INFO, LOGGER, logger);
+                    "Lock acquired on [" + resourceDescription + "]", Level.FINE, LOGGER, logger);
         } catch (Exception e) {
             context.onFailure(e);
             return;
@@ -225,7 +225,7 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
                     .unlockNames(this.resourceNames, context.get(Run.class), this.inversePrecedence);
             LockableResourcesManager.printLogs(
                     "Lock released on resource [" + resourceDescription + "]",
-                    Level.INFO,
+                    Level.FINE,
                     LOGGER,
                     context.get(TaskListener.class).getLogger());
         }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -626,7 +626,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
             uncacheIfFreeing(resource, true, false);
 
             if (resource.isEphemeral()) {
-                LOGGER.info("Remove ephemeral resource: " + resource);
+                LOGGER.fine("Remove ephemeral resource: " + resource);
                 this.resources.remove(resource);
             }
         }


### PR DESCRIPTION
Reduces some verbose lock related logging messages from `INFO` to `FINE` (as in #558) so they don't appear in the default Jenkins log UI.

See #558


<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

Test suite and manual testing.

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transferred to *.properties files.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
