### PR TITLE
Set the "reserved" timestamp when stealing a lock as well

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -939,6 +940,11 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 r.setStolen();
             }
             unlock(resources, null, false);
+            // unlock() nulls resource.reservedTimestamp via resource.setBuild(null), so set it afterwards
+            Date date = new Date();
+            for (LockableResource r : resources) {
+                r.setReservedTimestamp(date);
+            }
             save();
         }
         return true;

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -2,6 +2,8 @@ package org.jenkins.plugins.lockableresources.actions;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -330,8 +332,10 @@ public class LockableResourcesRootActionTest extends LockStepTestBase {
         // system must be permitted to create resource
         resource = this.createResource("resource1");
         // when the resource is not reserved, the doSteal action reserve it for you
+        assertNull(resource.getReservedTimestamp());
         action.doSteal(req, rsp);
         assertTrue("is reserved by system", resource.isReserved());
+        assertNotNull(resource.getReservedTimestamp());
 
         // somebody
         SecurityContextHolder.getContext().setAuthentication(this.reserve_user1.impersonate2());
@@ -344,15 +348,18 @@ public class LockableResourcesRootActionTest extends LockStepTestBase {
         SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());
         action.doReset(req, rsp);
         assertFalse("unreserved", resource.isReserved());
+        assertNull(resource.getReservedTimestamp());
 
         // switch to user1 and reserve it
         action.doReserve(req, rsp);
         assertTrue("is reserved by user1", resource.isReserved());
+        assertNotNull(resource.getReservedTimestamp());
 
         // switch to user with STEAL permission
         SecurityContextHolder.getContext().setAuthentication(this.steal_user.impersonate2());
         action.doSteal(req, rsp);
         assertEquals("reserved by user", this.steal_user.getId(), resource.getReservedBy());
+        assertNotNull(resource.getReservedTimestamp());
 
         // invalid params. Just check if it crash here
         SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on github issue -->
Closes #636
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
