### PR TITLE
Use unix time of the timestamp for data-order.

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -194,7 +194,7 @@ THE SOFTWARE.
             -->
             <j:choose>
               <j:when test="${resource.reservedTimestamp != null}">
-                <td data-order="${logEntry.getDate().getTime()}">
+                <td data-order="${resource.reservedTimestamp.time}">
                   <i:formatDate
                     value="${resource.reservedTimestamp}"
                     type="both"


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->

<!-- in case you work on github issue -->
See #485. Use the unix time to sort the timestamp column.
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done
Set timestamp of all resources and sort on timestamp column. Check that they are sorted chronologically 
```
import org.jenkins.plugins.lockableresources.LockableResourcesManager

def d = 0;
LockableResourcesManager.get().getResources().each { resource ->
  resource.setReservedTimestamp(new Date().minus(d))
  d = d + 30    
}
```
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
