### PR TITLE
[JENKINS-73835] Delete `LockStepTest.deleteRunningBuildNewBuildClearsLock` now that running builds may not be deleted

### DIFF
--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -696,7 +696,7 @@ public class LockStepTest extends LockStepTestBase {
      */
     @Issue("JENKINS-36479")
     @Test
-    public void deleteRunningBuildNewBuildClearsLock() throws Exception {
+    public void killThenDeleteRunningBuildNewBuildClearsLock() throws Exception {
         assumeFalse(Functions.isWindows());
 
         LockableResourcesManager.get().createResource("resource1");
@@ -722,6 +722,7 @@ public class LockStepTest extends LockStepTestBase {
         j.waitForMessage("[resource1] is locked by build " + b1.getFullDisplayName(), b3);
         isPaused(b3, 1, 1);
 
+        b1.doKill(); // Kills the build immediately and does not interrupt running steps.
         b1.delete();
 
         // Verify that b2 gets the lock.

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -4,10 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assume.assumeFalse;
 
 import com.google.common.collect.ImmutableMap;
-import hudson.Functions;
 import hudson.model.Result;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest.java
@@ -684,62 +684,6 @@ public class LockStepTest extends LockStepTestBase {
         assertNull(LockableResourcesManager.get().fromName("resource1"));
     }
 
-    /* TODO: This test does not run on Windows. Before wasting another afternoon trying to fix this, I'd suggest watching
-     * a good movie instead. If you really want to try your luck, here are some pointers:
-     * - Windows doesn't like to delete files that are currently in use
-     * - When deleting a running pipeline job, the listener keeps its logfile open
-     * This has the potential to fail at two points:
-     * - Right when deleting the run: Jenkins tries to remove the run directory, which contains the open log file
-     * - After the test, on cleanup, the jenkins test harness tries to remove the complete Jenkins data directory
-     * Things already tried: Getting a handle on the listener and closing its logfile.
-     * Stupid idea: Implement a JEP-210 extension, which keeps log files in memory...
-     */
-    @Issue("JENKINS-36479")
-    @Test
-    public void killThenDeleteRunningBuildNewBuildClearsLock() throws Exception {
-        assumeFalse(Functions.isWindows());
-
-        LockableResourcesManager.get().createResource("resource1");
-
-        WorkflowJob p1 = j.jenkins.createProject(WorkflowJob.class, "p");
-        p1.setDefinition(new CpsFlowDefinition("lock('resource1') { echo 'locked!'; semaphore 'wait-inside' }", true));
-        WorkflowRun b1 = p1.scheduleBuild2(0).waitForStart();
-        j.waitForMessage("locked!", b1);
-        SemaphoreStep.waitForStart("wait-inside/1", b1);
-
-        WorkflowJob p2 = j.jenkins.createProject(WorkflowJob.class, "p2");
-        p2.setDefinition(new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
-        WorkflowRun b2 = p2.scheduleBuild2(0).waitForStart();
-        // Make sure that b2 is blocked on b1's lock.
-        j.waitForMessage("[resource1] is locked by build " + b1.getFullDisplayName(), b2);
-        isPaused(b2, 1, 1);
-
-        // Now b2 is still sitting waiting for a lock. Create b3 and launch it to verify order of
-        // unlock.
-        WorkflowJob p3 = j.jenkins.createProject(WorkflowJob.class, "p3");
-        p3.setDefinition(new CpsFlowDefinition("lock('resource1') {\n" + "  semaphore 'wait-inside'\n" + "}", true));
-        WorkflowRun b3 = p3.scheduleBuild2(0).waitForStart();
-        j.waitForMessage("[resource1] is locked by build " + b1.getFullDisplayName(), b3);
-        isPaused(b3, 1, 1);
-
-        b1.doKill(); // Kills the build immediately and does not interrupt running steps.
-        b1.delete();
-
-        // Verify that b2 gets the lock.
-        j.waitForMessage("Trying to acquire lock on [Resource: resource1]", b2);
-        SemaphoreStep.success("wait-inside/2", b2);
-        // Verify that b2 releases the lock and finishes successfully.
-        j.waitForMessage("Lock released on resource [Resource: resource1]", b2);
-        j.assertBuildStatusSuccess(j.waitForCompletion(b2));
-        isPaused(b2, 1, 0);
-
-        // Now b3 should get the lock and do its thing.
-        j.waitForMessage("Trying to acquire lock on [Resource: resource1]", b3);
-        SemaphoreStep.success("wait-inside/3", b3);
-        j.assertBuildStatusSuccess(j.waitForCompletion(b3));
-        isPaused(b3, 1, 0);
-    }
-
     @Test
     public void unlockButtonWithWaitingRuns() throws Exception {
         LockableResourcesManager.get().createResource("resource1");


### PR DESCRIPTION
See [JENKINS-73835](https://issues.jenkins.io/browse/JENKINS-73835), https://github.com/jenkinsci/jenkins/pull/9810 (and specifically https://github.com/jenkinsci/jenkins/pull/9810#issuecomment-2414506452). It is no longer possible to delete builds that are still running, so `LockStepTest.deleteRunningBuildNewBuildClearsLock` fails against Jenkins 2.481+.

I considered making the test perform a hard kill via `WorkflowRun.doKill` before deleting the build, but hard kills are already covered by various tests in https://github.com/jenkinsci/lockable-resources-plugin/blob/f310d75b5595c93593b0b81767e549389c8fea06/src/test/java/org/jenkins/plugins/lockableresources/LockStepHardKillTest.java, so I am proposing to just delete the test instead.

### Testing done

I tried a few test changes against 2.481 before deciding to delete the test.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transferred to *.properties files.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] java code changes are tested by automated test.
