### PR TITLE
[JENKINS-73949] Extract inline event handlers from `LockableResourcesRootAction/tableResources/table.jelly`

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -91,7 +91,8 @@ THE SOFTWARE.
                 </div>
                 <div class="col-auto jenkins-!-margin-right-2">
                   <l:hasPermission permission="${it.RESERVE}">
-                    <a class="jenkins-table__link" id="note-link" href="editNote" onclick="return replaceNote(this, '${resource.name}');">
+                    <a class="jenkins-table__link lockable-resources-replace-note" data-resource-name="${resource.name}"
+                       id="note-link" href="editNote">
                       <l:icon class="symbol-edit-note icon-sm" />
                       ${%btn.editNote}
                     </a>
@@ -251,8 +252,8 @@ THE SOFTWARE.
                 <j:when test="${resource.locked}">
                   <l:hasPermission permission="${it.UNLOCK}">
                     <button
-                      onClick="resource_action(this, 'unlock');"
-                      class="jenkins-button j.jenkins-!-warning-color"
+                      data-action="unlock"
+                      class="jenkins-button j.jenkins-!-warning-color lockable-resources-action-button"
                       tooltip="${%btn.unlock.detail}"
                     >
                       ${%btn.unlock}
@@ -260,8 +261,8 @@ THE SOFTWARE.
                   </l:hasPermission>
                   <l:hasPermission permission="${it.STEAL}">
                     <button
-                      onClick="resource_action(this, 'steal');"
-                      class="jenkins-button jenkins-!-destructive-color"
+                      data-action="steal"
+                      class="jenkins-button jenkins-!-destructive-color lockable-resources-action-button"
                       tooltip="${%btn.steal.detail}"
                     >
                       ${%btn.steal}
@@ -272,8 +273,8 @@ THE SOFTWARE.
                   <l:hasPermission permission="${it.RESERVE}">
                     <j:if test="${resource.isReservedByCurrentUser() or h.hasPermission(app.ADMINISTER)}">
                       <button
-                        onClick="resource_action(this, 'unreserve');"
-                        class="jenkins-button jenkins-!-success-color"
+                        data-action="unreserve"
+                        class="jenkins-button jenkins-!-success-color lockable-resources-action-button"
                         tooltip="${%btn.unReserve.detail}"
                       >
                         ${%btn.unReserve}
@@ -283,8 +284,8 @@ THE SOFTWARE.
                   <l:hasPermission permission="${it.STEAL}">
                     <j:if test="${!resource.isReservedByCurrentUser()}">
                       <button
-                        onClick="resource_action(this, 'reassign');"
-                        class="jenkins-button jenkins-button--primary"
+                        data-action="reassign"
+                        class="jenkins-button jenkins-button--primary lockable-resources-action-button"
                         tooltip="${%btn.reassign.detail}"
                       >
                         ${%btn.reassign}
@@ -295,8 +296,8 @@ THE SOFTWARE.
                 <j:when test="${resource.queued}">
                   <l:hasPermission permission="${it.UNLOCK}">
                     <button
-                      onClick="resource_action(this, 'reset');"
-                      class="jenkins-button jenkins-!-destructive-color"
+                      data-action="reset"
+                      class="jenkins-button jenkins-!-destructive-color lockable-resources-action-button"
                       tooltip="${%btn.reset.detail}"
                     >
                       ${%btn.reset}
@@ -306,8 +307,8 @@ THE SOFTWARE.
                 <j:otherwise>
                   <l:hasPermission permission="${it.RESERVE}">
                     <button
-                      onClick="resource_action(this, 'reserve');"
-                      class="jenkins-button jenkins-button--primary"
+                      data-action="reserve"
+                      class="jenkins-button jenkins-button--primary lockable-resources-action-button"
                       tooltip="${%btn.reserve.detail}"
                     >
                       ${%btn.reserve}

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -146,16 +146,16 @@ jQuery(document).ready(function () {
     }
   });
 
-  document.querySelectorAll(".lockable-resources-action-button").forEach(function(button) {
-    button.addEventListener("click", function(event) {
+  document.querySelectorAll(".lockable-resources-action-button").forEach(function (button) {
+    button.addEventListener("click", function (event) {
       const target = event.target;
       const action = target.dataset.action;
       resource_action(target, action);
     });
   });
 
-  document.querySelectorAll(".lockable-resources-replace-note").forEach(function(anchor) {
-    anchor.addEventListener("click", function(event) {
+  document.querySelectorAll(".lockable-resources-replace-note").forEach(function (anchor) {
+    anchor.addEventListener("click", function (event) {
       event.preventDefault();
       replaceNote(event.target.dataset.resourceName);
     });

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -59,7 +59,7 @@ function resource_action(button, action) {
   });
 }
 
-function replaceNote(element, resourceName) {
+function replaceNote(resourceName) {
   var d = document.getElementById("note-" + resourceName);
   d.innerHTML = "<div class='spinner-right' style='flex-grow: 1;'>loading...</div>";
   fetch("noteForm", {
@@ -80,7 +80,6 @@ function replaceNote(element, resourceName) {
       layoutUpdateCallback.call();
     });
   });
-  return false;
 }
 
 function format(d) {
@@ -145,6 +144,21 @@ jQuery(document).ready(function () {
       row.child(format(row.data())).show();
       tr.addClass('shown');
     }
+  });
+
+  document.querySelectorAll(".lockable-resources-action-button").forEach(function(button) {
+    button.addEventListener("click", function(event) {
+      const target = event.target;
+      const action = target.dataset.action;
+      resource_action(target, action);
+    });
+  });
+
+  document.querySelectorAll(".lockable-resources-replace-note").forEach(function(anchor) {
+    anchor.addEventListener("click", function(event) {
+      event.preventDefault();
+      replaceNote(event.target.dataset.resourceName);
+    });
   });
 });
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
@@ -80,8 +80,8 @@ public class LockableResourceRootActionSEC1361Test {
 
         HtmlElement reserveButton = null;
         for (HtmlElement b : allButtons) {
-            String onClick = b.getAttribute("onClick");
-            if (onClick != null && onClick.contains("reserve")) {
+            String action = b.getAttribute("data-action");
+            if (action != null && action.contains("reserve")) {
                 reserveButton = b;
             }
         }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->
See [JENKINS-73949](https://issues.jenkins.io/browse/JENKINS-73949).
<!-- in case you work on github issue -->
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

Create resources via the Global Configuration page. Then go to the lockable resources page. Click all the action buttons. Rendering of those is conditional, so  to see some of them there's a need to lock resources by running a job that acquires a lock on a resource.

For Note button it's straightforward. Click it and see textarea appear that lets add a note for a resource.

https://www.loom.com/share/8dcbe0b992164412af5def9829d2b44b

https://www.loom.com/share/828b59fbcf424475b7f45a0732fce2f6

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
