### PR TITLE
`SerializableSecureGroovyScriptTest` must use `JenkinsRule`

### DIFF
--- a/src/test/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScriptTest.java
@@ -4,9 +4,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class SerializableSecureGroovyScriptTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
     @Test
     public void testRehydrate() {
         SerializableSecureGroovyScript nullCheck = new SerializableSecureGroovyScript(null);


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/3869#issuecomment-2447963528 adapting to https://github.com/jenkinsci/script-security-plugin/pull/585 by @jgarciacloudbees. Minimal for PCT.