### PR TITLE
Document effect of setting quantity to 0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ pipeline {
 }
 ```
 
+Setting `quantity` to `null`, `0` or a smaller number, all available resources of that label are locked at once.
+
 #### Take first position in queue
 
 ```groovy

--- a/src/doc/examples/scripted-vs-declarative-pipeline.md
+++ b/src/doc/examples/scripted-vs-declarative-pipeline.md
@@ -32,3 +32,8 @@ node() {
     }
 }
 ```
+
+## Pitfalls
+
+Setting `quantity` to `null`, `0` or a smaller number, all available resources of that label are locked at once.
+See [#198 - Lock All resources by setting quantity to 0 is not documented](https://github.com/jenkinsci/lockable-resources-plugin/issues/198).


### PR DESCRIPTION
This relates to already solved #198

### Testing done

N/A only documentation

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
