### PR TITLE
Make matrix-project dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>javax.annotation</groupId>

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -20,6 +20,7 @@ import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
+import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -94,8 +95,14 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
             }
 
             if (item.task instanceof MatrixConfiguration) {
-                MatrixConfiguration matrix = (MatrixConfiguration) item.task;
-                params.putAll(matrix.getCombination());
+                try {
+                    MatrixConfiguration matrix = (MatrixConfiguration) item.task;
+                    matrix.onLoad(matrix.getParent(), matrix.getName());
+                    params.putAll(matrix.getCombination());
+                } catch (IOException ex) {
+                    // Could not load configuration
+
+                }
             }
 
             final List<LockableResource> selected;

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
@@ -12,9 +12,11 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixProject;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
+import java.io.IOException;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 
 public final class Utils {
@@ -36,8 +38,13 @@ public final class Utils {
         EnvVars env = new EnvVars();
 
         if (project instanceof MatrixConfiguration) {
-            env.putAll(((MatrixConfiguration) project).getCombination());
-            project = (Job<?, ?>) project.getParent();
+            try {
+                project.onLoad((MatrixProject) project.getParent(), project.getName());
+                env.putAll(((MatrixConfiguration) project).getCombination());
+                project = (Job<?, ?>) project.getParent();
+            } catch (IOException ex) {
+                // coudn't load
+            }
         }
 
         RequiredResourcesProperty property = project.getProperty(RequiredResourcesProperty.class);


### PR DESCRIPTION

resolves #683 
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->
## What I've done
1. Update pom.xml to have optional = true for dependency
2. Load MatrixConfiguration before usage, in case not downloaded because of optional = true option
     - I don't know if that is the correct way to do it, I need some help on this part

## Note
I'm not sure if PR is complete, I may be solved the issue by 70 % and raising PR to ask for feedback to complete the remaining 30%  



### Localizations

- [x] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).
