### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -1,26 +1,24 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import hudson.Functions;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
 import org.jenkins.plugins.lockableresources.util.Constants;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ConcurrentModificationExceptionTest {
+@WithJenkins
+class ConcurrentModificationExceptionTest {
 
     private static final Logger LOGGER = Logger.getLogger(ConcurrentModificationExceptionTest.class.getName());
 
-    @Rule
-    public final JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void parallelTasksTest() throws Exception {
+    void parallelTasksTest(JenkinsRule j) throws Exception {
 
         final int agentsCount = Functions.isWindows() ? 5 : 10;
         final int extraAgentsCount = Functions.isWindows() ? 5 : 20;
@@ -61,7 +59,7 @@ public class ConcurrentModificationExceptionTest {
             public void run() {
                 System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
                 LOGGER.info("run NodesMirror");
-                NodesMirror.createNodeResources();
+                org.jenkins.plugins.lockableresources.NodesMirror.createNodeResources();
                 LOGGER.info("NodesMirror done");
             }
         };
@@ -135,11 +133,11 @@ public class ConcurrentModificationExceptionTest {
                     + LRM.getResourcesWithLabel("extra-agent").size() + " == 0 "
                     + " agent: " + LRM.getResourcesWithLabel("agent").size());
             if (LRM.resourceExist("ExtraResource_" + extraResourcesCount)
-                    && LRM.getResourcesWithLabel("extra-agent").size() == 0
+                    && LRM.getResourcesWithLabel("extra-agent").isEmpty()
                     && LRM.getResourcesWithLabel("agent").size() == agentsCount) break;
         }
 
-        // normally is is bad idea to make so much assertions, but we need verify if all works fine
+        // normally it is bad idea to make so much assertions, but we need verify if all works fine
         for (int i = 1; i <= resourcesCount; i++) {
             assertNotNull(LockableResourcesManager.get().fromName("resource_" + i));
         }

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -2,41 +2,39 @@ package org.jenkins.plugins.lockableresources;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.Util;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.List;
 import org.jenkins.plugins.lockableresources.util.Constants;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ConfigurationAsCodeTest {
+@WithJenkinsConfiguredWithCode
+class ConfigurationAsCodeTest {
 
     // ---------------------------------------------------------------------------
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     }
 
-    @ClassRule
-    @ConfiguredWithCode("configuration-as-code.yml")
-    public static JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
-
     @Test
-    public void should_support_configuration_as_code() {
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_support_configuration_as_code(JenkinsConfiguredWithCodeRule r) {
         LockableResourcesManager LRM = LockableResourcesManager.get();
         List<LockableResource> declaredResources = LRM.getDeclaredResources();
         assertEquals(
-                "The number of declared resources is wrong. Check your configuration-as-code.yml",
                 1,
-                declaredResources.size());
+                declaredResources.size(),
+                "The number of declared resources is wrong. Check your configuration-as-code.yml");
 
         LockableResource declaredResource = declaredResources.get(0);
         assertEquals("Resource_A", declaredResource.getName());
@@ -46,9 +44,7 @@ public class ConfigurationAsCodeTest {
         assertEquals("Note A", declaredResource.getNote());
 
         assertEquals(
-                "The number of resources is wrong. Check your configuration-as-code.yml",
-                1,
-                LRM.getResources().size());
+                1, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
 
         LockableResource resource = LRM.getFirst();
         assertEquals("Resource_A", resource.getName());
@@ -59,7 +55,8 @@ public class ConfigurationAsCodeTest {
     }
 
     @Test
-    public void should_support_configuration_export() throws Exception {
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_support_configuration_export(JenkinsConfiguredWithCodeRule r) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = Util.getUnclassifiedRoot(context).get("lockableResourcesManager");

--- a/src/test/java/org/jenkins/plugins/lockableresources/DeclarativePipelineTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/DeclarativePipelineTest.java
@@ -1,6 +1,6 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.common.base.Joiner;
 import hudson.model.Result;
@@ -8,25 +8,23 @@ import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class DeclarativePipelineTest {
+@WithJenkins
+class DeclarativePipelineTest {
 
     // ---------------------------------------------------------------------------
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     }
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void lockByIdInOptionsSection() throws Exception {
+    void lockByIdInOptionsSection(JenkinsRule j) throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 m(
@@ -52,7 +50,7 @@ public class DeclarativePipelineTest {
     }
 
     @Test
-    public void lockByLabelInOptionsSection() throws Exception {
+    void lockByLabelInOptionsSection(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
@@ -78,7 +76,7 @@ public class DeclarativePipelineTest {
     }
 
     @Test
-    public void stepScriptLockByLabel() throws Exception {
+    void stepScriptLockByLabel(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
@@ -105,7 +103,7 @@ public class DeclarativePipelineTest {
     }
 
     @Test
-    public void stepLockByLabel() throws Exception {
+    void stepLockByLabel(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
@@ -130,7 +128,7 @@ public class DeclarativePipelineTest {
     }
 
     @Test
-    public void missingLabel() throws Exception {
+    void missingLabel(JenkinsRule j) throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 m(
@@ -153,7 +151,7 @@ public class DeclarativePipelineTest {
         j.assertLogContains("Missing required parameter: \"resource\"", b1);
     }
 
-    private String m(String... lines) {
+    private static String m(String... lines) {
         return Joiner.on('\n').join(lines);
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -3,11 +3,11 @@ package org.jenkins.plugins.lockableresources;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -33,29 +33,27 @@ import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class FreeStyleProjectTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class FreeStyleProjectTest {
 
     // ---------------------------------------------------------------------------
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     }
 
     @Test
     @Issue("JENKINS-34853")
-    public void security170fix() throws Exception {
+    void security170fix(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("resource1");
         FreeStyleProject p = j.createFreeStyleProject("p");
         p.addProperty(new RequiredResourcesProperty("resource1", "resourceNameVar", null, null, null));
@@ -67,7 +65,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void migrateToScript() throws Exception {
+    void migrateToScript(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("resource1");
 
         FreeStyleProject p = j.createFreeStyleProject("p");
@@ -103,16 +101,16 @@ public class FreeStyleProjectTest {
 
         long buildAEndTime = buildA.getStartTimeInMillis() + buildA.getDuration();
         assertTrue(
+                buildB.getStartTimeInMillis() >= buildAEndTime,
                 "Project A build should be finished before the build of project B starts. "
                         + "A finished at "
                         + buildAEndTime
                         + ", B started at "
-                        + buildB.getStartTimeInMillis(),
-                buildB.getStartTimeInMillis() >= buildAEndTime);
+                        + buildB.getStartTimeInMillis());
     }
 
     @Test
-    public void configRoundTripPlain() throws Exception {
+    void configRoundTripPlain(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("resource1");
 
         FreeStyleProject withResource = j.createFreeStyleProject("withResource");
@@ -129,7 +127,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void configRoundTripWithLabel() throws Exception {
+    void configRoundTripWithLabel(JenkinsRule j) throws Exception {
         FreeStyleProject withLabel = j.createFreeStyleProject("withLabel");
         withLabel.addProperty(new RequiredResourcesProperty(null, null, null, "some-label", null));
         FreeStyleProject withLabelRoundTrip = j.configRoundtrip(withLabel);
@@ -144,7 +142,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void configRoundTripWithScript() throws Exception {
+    void configRoundTripWithScript(JenkinsRule j) throws Exception {
         FreeStyleProject withScript = j.createFreeStyleProject("withScript");
         SecureGroovyScript origScript = new SecureGroovyScript("return true", false, null);
         withScript.addProperty(new RequiredResourcesProperty(null, null, null, null, origScript));
@@ -162,7 +160,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void approvalRequired() throws Exception {
+    void approvalRequired(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource(LockableResourcesRootAction.ICON);
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -215,7 +213,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void autoCreateResource() throws Exception {
+    void autoCreateResource(JenkinsRule j) throws Exception {
         FreeStyleProject f = j.createFreeStyleProject("f");
         assertNull(LockableResourcesManager.get().fromName("resource1"));
         f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
@@ -229,7 +227,7 @@ public class FreeStyleProjectTest {
     }
 
     @Test
-    public void competingLabelLocks() throws Exception {
+    void competingLabelLocks(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResourceWithLabel("resource1", "group1");
         LockableResourcesManager.get().createResourceWithLabel("resource2", "group2");
         LockableResourcesManager.get().createResource("shared");

--- a/src/test/java/org/jenkins/plugins/lockableresources/InteroperabilityTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/InteroperabilityTest.java
@@ -11,32 +11,36 @@ import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class InteroperabilityTest extends LockStepTestBase {
+@WithJenkins
+class InteroperabilityTest extends LockStepTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(InteroperabilityTest.class.getName());
+
     // ---------------------------------------------------------------------------
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     }
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void interoperability() throws Exception {
+    void interoperability(JenkinsRule j) throws Exception {
         final Semaphore semaphore = new Semaphore(1);
         LockableResourcesManager.get().createResource("resource1");
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(
-                new CpsFlowDefinition("lock('resource1') {\n" + "	echo 'Locked'\n" + "}\n" + "echo 'Finish'", true));
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                    lock('resource1') {
+                        echo 'Locked'
+                    }
+                    echo 'Finish'""",
+                true));
 
         FreeStyleProject f = j.createFreeStyleProject("f");
         f.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTestBase.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTestBase.java
@@ -1,20 +1,15 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
-import org.junit.ClassRule;
-import org.jvnet.hudson.test.BuildWatcher;
 
 public class LockStepTestBase {
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-
-    protected void isPaused(WorkflowRun run, int count, int effectivePauses) {
+    protected static void isPaused(WorkflowRun run, int count, int effectivePauses) {
         int pauseActions = 0, pausedActions = 0;
         for (FlowNode node : new FlowGraphWalker(run.getExecution())) {
             for (PauseAction pauseAction : PauseAction.getPauseActions(node)) {

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_manualUnreserveUnblocksJob.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_manualUnreserveUnblocksJob.java
@@ -2,28 +2,26 @@ package org.jenkins.plugins.lockableresources;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class LockStepTest_manualUnreserveUnblocksJob extends LockStepTestBase {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class LockStepTest_manualUnreserveUnblocksJob extends LockStepTestBase {
 
     @Issue("JENKINS-34433")
     @Test
-    public void manualUnreserveUnblocksJob() throws Exception {
+    void manualUnreserveUnblocksJob(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("resource1");
 
         TestHelpers testHelpers = new TestHelpers();
@@ -40,7 +38,13 @@ public class LockStepTest_manualUnreserveUnblocksJob extends LockStepTestBase {
         assertThat(apiRes, hasEntry("reservedBy", "someone"));
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("lock('resource1') {\n" + "    echo('I am inside')\n" + "}\n", true));
+        p.setDefinition(new CpsFlowDefinition(
+                """
+            lock('resource1') {
+                echo('I am inside')
+            }
+            """,
+                true));
 
         WorkflowRun r = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage("[resource1] is not free, waiting for execution ...", r);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_reserveInsideLockHonoured.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_reserveInsideLockHonoured.java
@@ -4,20 +4,18 @@ import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class LockStepTest_reserveInsideLockHonoured extends LockStepTestBase {
+@WithJenkins
+class LockStepTest_reserveInsideLockHonoured extends LockStepTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(LockStepTest_reserveInsideLockHonoured.class.getName());
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Test
     // @Issue("JENKINS-XXXXX")
-    public void reserveInsideLockHonoured() throws Exception {
+    @Test
+    void reserveInsideLockHonoured(JenkinsRule j) throws Exception {
         // Use-case is a job keeping the resource reserved so it can use
         // it in other stages and free it later, not all in one closure
         // Variant: using the LockableResourcesManager to manipulate

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_setReservedByInsideLockHonoured.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTest_setReservedByInsideLockHonoured.java
@@ -4,20 +4,18 @@ import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class LockStepTest_setReservedByInsideLockHonoured extends LockStepTestBase {
+@WithJenkins
+class LockStepTest_setReservedByInsideLockHonoured extends LockStepTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(LockStepTest_setReservedByInsideLockHonoured.class.getName());
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Test
     // @Issue("JENKINS-XXXXX")
-    public void setReservedByInsideLockHonoured() throws Exception {
+    @Test
+    void setReservedByInsideLockHonoured(JenkinsRule j) throws Exception {
         // Use-case is a job keeping the resource reserved so it can use
         // it in other stages and free it later, not all in one closure
         // Variant: directly using the LockableResource object

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithRestartTest.java
@@ -29,7 +29,11 @@ public class LockStepWithRestartTest extends LockStepTestBase {
             LockableResourcesManager.get().createResource("resource1");
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
-                    "lock('resource1') {\n" + "  semaphore 'wait-inside-lockOrderRestart'\n" + "}\n" + "echo 'Finish'",
+                    """
+                    lock('resource1') {
+                      semaphore 'wait-inside-lockOrderRestart'
+                    }
+                    echo 'Finish'""",
                     true));
             WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait-inside-lockOrderRestart/1", b1);
@@ -74,8 +78,11 @@ public class LockStepWithRestartTest extends LockStepTestBase {
             LockableResourcesManager.get().createResource("resource1");
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
-                    "lock('resource1') {\n" + "  semaphore 'wait-inside-interoperabilityOnRestart'\n" + "}\n"
-                            + "echo 'Finish'",
+                    """
+                    lock('resource1') {
+                      semaphore 'wait-inside-interoperabilityOnRestart'
+                    }
+                    echo 'Finish'""",
                     true));
             WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait-inside-interoperabilityOnRestart/1", b1);
@@ -121,7 +128,12 @@ public class LockStepWithRestartTest extends LockStepTestBase {
 
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
-                    "lock('resource1') {\n" + "  echo 'inside'\n" + "}\n" + "echo 'Finish'", true));
+                    """
+                    lock('resource1') {
+                      echo 'inside'
+                    }
+                    echo 'Finish'""",
+                    true));
             WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
             j.waitForMessage("The resource [resource1] is reserved by user", b1);
             isPaused(b1, 1, 1);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceApiTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceApiTest.java
@@ -5,31 +5,29 @@ package org.jenkins.plugins.lockableresources;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.jenkins.plugins.lockableresources.util.Constants;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class LockableResourceApiTest {
+@WithJenkins
+class LockableResourceApiTest {
 
     // ---------------------------------------------------------------------------
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
     }
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void reserveUnreserveApi() throws Exception {
+    void reserveUnreserveApi(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("a1");
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -46,7 +44,7 @@ public class LockableResourceApiTest {
 
     @Test
     @Issue("SECURITY-1958")
-    public void apiUsageHttpGet() {
+    void apiUsageHttpGet(JenkinsRule j) {
         JenkinsRule.WebClient wc = j.createWebClient();
         FailingHttpStatusCodeException e = assertThrows(
                 FailingHttpStatusCodeException.class, () -> wc.goTo("lockable-resources/reserve?resource=resource1"));

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceManagerTest.java
@@ -1,8 +1,8 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Item;
@@ -13,19 +13,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.TreeSet;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-public class LockableResourceManagerTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class LockableResourceManagerTest {
 
     @Test
-    public void validationFailure() throws Exception {
+    void validationFailure(JenkinsRule j) throws Exception {
         RequiredResourcesProperty.DescriptorImpl d = new RequiredResourcesProperty.DescriptorImpl();
         LockableResourcesManager.get().createResource("resource1");
         LockableResource r = LockableResourcesManager.get().getFirst();
@@ -87,7 +85,7 @@ public class LockableResourceManagerTest {
     }
 
     @Test
-    public void doAutoCompleteLabelName() throws Exception {
+    void doAutoCompleteLabelName(JenkinsRule j) throws Exception {
         RequiredResourcesProperty.DescriptorImpl d = new RequiredResourcesProperty.DescriptorImpl();
         LockableResourcesManager.get().createResourceWithLabel("resource1", "label-1-A label-2-B");
         LockableResourcesManager.get().createResource("resource2");
@@ -125,7 +123,7 @@ public class LockableResourceManagerTest {
     }
 
     @Test
-    public void doAutoCompleteResourceNames() throws Exception {
+    void doAutoCompleteResourceNames(JenkinsRule j) throws Exception {
         RequiredResourcesProperty.DescriptorImpl d = new RequiredResourcesProperty.DescriptorImpl();
         LockableResourcesManager.get().createResource("resource1");
         LockableResourcesManager.get().createResource("Resource1");
@@ -147,18 +145,23 @@ public class LockableResourceManagerTest {
         User user = User.get("user", true, Collections.emptyMap());
         SecurityContextHolder.getContext().setAuthentication(user.impersonate2());
         // the 'user' has no permission
-        assertThrows(AccessDeniedException3.class, () -> d.doAutoCompleteResourceNames("resource1", item));
+        assertThrows(
+                AccessDeniedException3.class,
+                () -> RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames("resource1", item));
 
         User manager = User.get("manager", true, Collections.emptyMap());
         SecurityContextHolder.getContext().setAuthentication(manager.impersonate2());
 
-        assertContains(d.doAutoCompleteResourceNames("Res", item), "Resource1");
-        assertContains(d.doAutoCompleteResourceNames("res", item), "resource1", "resource2");
-        d.doAutoCompleteResourceNames(null, item);
-        d.doAutoCompleteResourceNames("", item);
+        assertContains(RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames("Res", item), "Resource1");
+        assertContains(
+                RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames("res", item),
+                "resource1",
+                "resource2");
+        RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(null, item);
+        RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames("", item);
     }
 
-    private void assertContains(AutoCompletionCandidates c, String... values) {
+    private static void assertContains(AutoCompletionCandidates c, String... values) {
         assertEquals(new TreeSet<>(Arrays.asList(values)), new TreeSet<>(c.getValues()));
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
@@ -35,28 +35,26 @@ import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlElementUtil;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class LockableResourceRootActionSEC1361Test {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class LockableResourceRootActionSEC1361Test {
 
     @Test
-    public void regularCase() throws Exception {
-        checkXssWithResourceName("resource1");
+    void regularCase(JenkinsRule j) throws Exception {
+        checkXssWithResourceName(j, "resource1");
     }
 
     @Test
     @Issue("SECURITY-1361")
-    public void noXssOnClick() throws Exception {
-        checkXssWithResourceName("\"); alert(123);//");
+    void noXssOnClick(JenkinsRule j) throws Exception {
+        checkXssWithResourceName(j, "\"); alert(123);//");
     }
 
-    private void checkXssWithResourceName(String resourceName) throws Exception {
+    private static void checkXssWithResourceName(JenkinsRule j, String resourceName) throws Exception {
         LockableResourcesManager.get().createResource(resourceName);
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceTest.java
@@ -1,21 +1,21 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Date;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LockableResourceTest {
+class LockableResourceTest {
 
-    LockableResource instance = new LockableResource("r1");
+    private final LockableResource instance = new LockableResource("r1");
 
     // Not sure how useful this is...
     @Test
-    public void testGetters() {
+    void testGetters() {
         assertEquals("r1", instance.getName());
         assertEquals("", instance.getDescription());
         assertEquals("", instance.getLabels());
@@ -33,7 +33,7 @@ public class LockableResourceTest {
     }
 
     @Test
-    public void testNote() {
+    void testNote() {
         final LockableResource resource = new LockableResource("Name 1");
 
         assertEquals("", resource.getNote());
@@ -49,22 +49,22 @@ public class LockableResourceTest {
     }
 
     @Test
-    public void testUnqueue() {
+    void testUnqueue() {
         instance.unqueue();
     }
 
     @Test
-    public void testSetBuild() {
+    void testSetBuild() {
         instance.setBuild(null);
     }
 
     @Test
-    public void testSetReservedBy() {
+    void testSetReservedBy() {
         instance.setReservedBy("");
     }
 
     @Test
-    public void testReservedTimestamp() {
+    void testReservedTimestamp() {
         instance.setReservedTimestamp(null);
         assertNull(instance.getReservedTimestamp());
 
@@ -74,31 +74,31 @@ public class LockableResourceTest {
     }
 
     @Test
-    public void testReserve() {
+    void testReserve() {
         instance.reserve("testUser1");
         assertEquals("testUser1", instance.getReservedBy());
         assertNotNull(instance.getReservedTimestamp());
     }
 
     @Test
-    public void testUnReserve() {
+    void testUnReserve() {
         instance.unReserve();
         assertNull(instance.getReservedBy());
         assertNull(instance.getReservedTimestamp());
     }
 
     @Test
-    public void testReset() {
+    void testReset() {
         instance.reset();
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals("r1", instance.toString());
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         assertNotEquals(null, instance);
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -1,8 +1,8 @@
 package org.jenkins.plugins.lockableresources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.logging.Logger;
 import org.jenkins.plugins.lockableresources.util.Constants;
@@ -10,19 +10,18 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class NodesMirrorTest {
+@WithJenkins
+class NodesMirrorTest {
 
-    private static final Logger LOGGER = Logger.getLogger(NodesMirror.class.getName());
-
-    @Rule
-    public final JenkinsRule j = new JenkinsRule();
+    private static final Logger LOGGER =
+            Logger.getLogger(org.jenkins.plugins.lockableresources.NodesMirror.class.getName());
 
     @Test
-    public void mirror_few_nodes() throws Exception {
+    void mirror_few_nodes(JenkinsRule j) throws Exception {
         System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
 
         LOGGER.info("add agent: FirstAgent");
@@ -62,7 +61,7 @@ public class NodesMirrorTest {
     }
 
     @Test
-    public void mirror_locked_nodes() throws Exception {
+    void mirror_locked_nodes(JenkinsRule j) throws Exception {
         System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
 
         j.createSlave("FirstAgent", "label label2", null);
@@ -74,11 +73,12 @@ public class NodesMirrorTest {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "lock(label: 'label && label2', variable : 'lockedNode') {\n"
-                        + " echo 'wait for node: ' + env.lockedNode\n"
-                        + "	semaphore 'wait-inside'\n"
-                        + "}\n"
-                        + "echo 'Finish'",
+                """
+                lock(label: 'label && label2', variable : 'lockedNode') {
+                 echo 'wait for node: ' + env.lockedNode
+                    semaphore 'wait-inside'
+                }
+                echo 'Finish'""",
                 true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage("wait for node: FirstAgent", b1);

--- a/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/PressureTest.java
@@ -9,17 +9,15 @@ import org.jenkins.plugins.lockableresources.util.Constants;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.WithTimeout;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PressureTest extends LockStepTestBase {
+@WithJenkins
+class PressureTest extends LockStepTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(PressureTest.class.getName());
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
 
     /**
      * Pressure test to lock resources via labels, resource name, ephemeral ... It simulates big
@@ -28,21 +26,21 @@ public class PressureTest extends LockStepTestBase {
      */
     @Test
     // it depends on which node you are running
-    @WithTimeout(900)
-    public void pressureEnableSave() throws Exception {
+    @Timeout(900)
+    void pressureEnableSave(JenkinsRule j) throws Exception {
         // keep in mind, that the windows nodes at jenkins-infra are not very fast
-        pressure(Functions.isWindows() ? 10 : 10);
+        pressure(j, Functions.isWindows() ? 10 : 10);
     }
 
     @Test
-    @WithTimeout(900)
-    public void pressureDisableSave() throws Exception {
+    @Timeout(900)
+    void pressureDisableSave(JenkinsRule j) throws Exception {
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
         // keep in mind, that the windows nodes at jenkins-infra are not very fast
-        pressure(Functions.isWindows() ? 10 : 10);
+        pressure(j, Functions.isWindows() ? 10 : 10);
     }
 
-    public void pressure(final int resourcesCount) throws Exception {
+    private static void pressure(JenkinsRule j, final int resourcesCount) throws Exception {
         // count of parallel jobs
         final int jobsCount = (resourcesCount * 2) + 1;
         final int nodesCount = (resourcesCount / 10) + 1;

--- a/src/test/java/org/jenkins/plugins/lockableresources/TestHelpers.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/TestHelpers.java
@@ -37,7 +37,7 @@ public final class TestHelpers {
     @Mock
     private StaplerResponse2 rsp;
 
-    private AutoCloseable mocks;
+    private final AutoCloseable mocks;
 
     // Utility class
     public TestHelpers() {
@@ -83,7 +83,7 @@ public final class TestHelpers {
         return rule.getJSON("plugin/lockable-resources/api/json").getJSONObject();
     }
 
-    /** SImulate the click on the button in the LRM page
+    /** Simulate the click on the button in the LRM page
      *  note: Currently does not click on the button. Just simulate the doAction (stapler request)
      *  on the given resource.
      *  We shall provide some better solution like selenium tests. But for now it is fine.

--- a/src/test/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/util/SerializableSecureGroovyScriptTest.java
@@ -1,22 +1,20 @@
 package org.jenkins.plugins.lockableresources.util;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SerializableSecureGroovyScriptTest {
-
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+@WithJenkins
+class SerializableSecureGroovyScriptTest {
 
     @Test
-    public void testRehydrate() throws Exception {
+    void testRehydrate(JenkinsRule r) throws Exception {
         SerializableSecureGroovyScript nullCheck = new SerializableSecureGroovyScript(null);
-        assertNull("SerializableSecureGroovyScript null check", nullCheck.rehydrate());
+        assertNull(nullCheck.rehydrate(), "SerializableSecureGroovyScript null check");
 
         // SecureGroovyScript(@NonNull String script, boolean sandbox, @CheckForNull
         // List<ClasspathEntry> classpath)


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There is one exception where a migration was not possible as the tests rely on `Rule` implementations that have not (yet) been migrated to JUnit5:

* `LockStepWithRestartTest` using `JenkinsSessionRule` (in combination with `SemaphoreStep` -> see https://github.com/jenkinsci/jenkins-test-harness/pull/936)

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
