### PR TITLE
fix:replace master with main

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,7 @@ Please note, that changes in non-default localizations files without Crowdin tra
 ### Submitter checklist
 
 - [ ] The Jira / Github issue, if it exists, is well-described.
-- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
+- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
   - The changelog generator for plugins uses the **pull request title as the changelog entry**.
   - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
 - [ ] There is automated testing or an explanation that explains why this change has no tests.


### PR DESCRIPTION
Extension of [#7841](https://github.com/jenkins-infra/jenkins.io/pull/7841)
This PR is basically an extension of our primary PR in the jenkins.io repo.
We are on a larger mission to replace all master references to main .
This findings are of Kevin Sir ([his comment regarding this](https://github.com/jenkins-infra/jenkins.io/pull/7841#issuecomment-2755502715)) . Much thankful to him for his support