### PR TITLE
feat: add dropdown for resource select strategies and fix empty resource strategy in pipeline syntax

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -80,7 +82,9 @@ public class LockStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setResourceSelectStrategy(String resourceSelectStrategy) {
-        this.resourceSelectStrategy = resourceSelectStrategy;
+      if (resourceSelectStrategy != null && !resourceSelectStrategy.isEmpty()) {
+            this.resourceSelectStrategy = resourceSelectStrategy;
+      }
     }
 
     @DataBoundSetter
@@ -140,6 +144,14 @@ public class LockStep extends Step implements Serializable {
         public AutoCompletionCandidates doAutoCompleteResource(
                 @QueryParameter String value, @AncestorInPath Item item) {
             return RequiredResourcesProperty.DescriptorImpl.doAutoCompleteResourceNames(value, item);
+        }
+
+        public ListBoxModel doFillResourceSelectStrategyItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (ResourceSelectStrategy resSelStrategy : ResourceSelectStrategy.values()) {
+                items.add(resSelStrategy.name());
+            }
+            return items;
         }
 
         @RequirePOST

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -20,7 +20,7 @@
     <f:checkbox title="${%entry.skipIfLocked.title}"/>
   </f:entry>
   <f:entry title="${%entry.resourceSelectStrategy.title}" field="resourceSelectStrategy">
-    <f:textbox/>
+    <f:select/>
   </f:entry>
   <f:entry title="${%entry.priority.title}" field="priority">
     <f:number/>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->
This PR fixes a bug in the Pipeline Syntax and improves its UX.

fix: in /pipeline-syntax, when not specifying anything under "Strategy for resource selection", it would return an empty string in the generated snippet, which is an invalid input:
![image](https://github.com/user-attachments/assets/680c5837-d57c-4d58-85cd-9c31e98fdcd8)
To resolve this, a null/empty check was added.

feat: add dropdown for resource select strategies
While the comments state which values are valid, it can also be parsed from the enum and can be made available via dropdown.

With these changes, it looks like this:
![image](https://github.com/user-attachments/assets/8a4b6e27-3330-45d6-a2a9-c6303e8968e4)

### Testing done
I consider this to be a minor change without tests requiring adaption. If you think different, let me know. 

- Tested /pipeline-syntax
- Tested /directive-generator

### Proposed upgrade guidelines

N/A

### Localizations

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated. [No function in this file does this, so I left it out as well)
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Any localizations are transferred to *.properties files.
- [x] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
