### PR TITLE
Keep existing reservations/notes when reloading casc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ which is already locked, it will wait for the resource to be free.
 “Open source” does not mean “includes free support”
 
 You can support the contributor and buy him a coffee.
-[![coffee](https://www.buymeacoffee.com/assets/img/custom_images/black_img.png)](https://www.buymeacoffee.com/mpokornyetm) 
+[![coffee](https://www.buymeacoffee.com/assets/img/custom_images/black_img.png)](https://www.buymeacoffee.com/mpokornyetm)
 Every second invested in an open-source project is a second you can't invest in your own family / friends / hobby.
 That`s the reason, why supporting the contributors is so important.
 
@@ -149,7 +149,7 @@ lock(resource: 'staging-server', priority: 10) {
 
   Resulting lock order: j1 -> j6 -> j4 -> j2 -> j3 -> j5
 
-#### Resolve a variable configured with the resource name and properties 
+#### Resolve a variable configured with the resource name and properties
 
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -11,6 +12,8 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import org.jenkins.plugins.lockableresources.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +35,7 @@ class ConfigurationAsCodeTest {
         LockableResourcesManager LRM = LockableResourcesManager.get();
         List<LockableResource> declaredResources = LRM.getDeclaredResources();
         assertEquals(
-                1,
+                2,
                 declaredResources.size(),
                 "The number of declared resources is wrong. Check your configuration-as-code.yml");
 
@@ -44,7 +47,7 @@ class ConfigurationAsCodeTest {
         assertEquals("Note A", declaredResource.getNote());
 
         assertEquals(
-                1, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
+                2, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
 
         LockableResource resource = LRM.getFirst();
         assertEquals("Resource_A", resource.getName());
@@ -64,5 +67,26 @@ class ConfigurationAsCodeTest {
         String expected = Util.toStringFromYamlFile(this, "casc_expected_output.yml");
 
         assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_keep_reservations_after_reload(JenkinsConfiguredWithCodeRule r) {
+        LockableResourcesManager LRM = LockableResourcesManager.get();
+
+        LRM.reserve(Collections.singletonList(LRM.fromName("Resource_B")), "testUser");
+        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
+        assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
+        Date timestampBeforeReload = LRM.fromName("Resource_B").getReservedTimestamp();
+        String noteBeforeReload = LRM.fromName("Resource_B").getNote();
+
+        // Get current sources and reconfigure with those sources
+        List<String> srcs = ConfigurationAsCode.get().getSources();
+        ConfigurationAsCode.get().configure(srcs);
+
+        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
+        assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
+        assertEquals(timestampBeforeReload, LRM.fromName("Resource_B").getReservedTimestamp());
+        assertEquals(noteBeforeReload, LRM.fromName("Resource_B").getNote());
     }
 }

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -4,3 +4,6 @@ declaredResources:
   name: "Resource_A"
   note: "Note A"
   reservedBy: "Reserved_A"
+- description: "Description_B"
+  labels: "Label_B"
+  name: "Resource_B"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
@@ -12,3 +12,6 @@ unclassified:
         name: "Resource_A"
         reservedBy: "Reserved_A"
         note: "Note A"
+      - description: "Description_B"
+        labels: "Label_B"
+        name: "Resource_B"


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->
<!-- in case you work on github issue -->
Close #527 
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Explanation
Users can reserve lockable resources and add notes. These reservations and notes currently disappear when reloading CasC configuration, or when Jenkins simply restarts. This pull request attempts to fix that.

The reservedTimestamp and note were already copied when reconfiguring lockable resources in the UI. This happened in LockableResourceManager.configure(). Move this part to the setDeclaredResources(), so it also runs when configuring from CasC config. If the note/reservedBy/reservedTimestamp is empty, copy it from the old resource. If it is not empty, then use the new value. 

You can't remove a reservation or note by defining the field in casc configuration and leaving it empty. When it is empty, the old value is kept. I didn't see a way around this.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Added test ConfigurationAsCodeTest#should_keep_reservations_after_reload. This test also fails when leaving out my changes.

Did some manual tests. CasC configuration with 
1. resource with filled in reservedBy/note fields
2. resource with empty reservedBy/note fields
3. resource without reservedBy/note fields

Reserved/reassigned/unreserved the resources, updated the notes. When reloading configuration, resource 1 always had the values from the CasC configuration. Resources 2 and 3 kept their reservation/note from before the reload.


### Proposed upgrade guidelines
N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.


