### PR TITLE
Ignore unconfigurable properties in casc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ unclassified:
       - name: "S7_1200_1"
         description: "S7 PLC model 1200"
         labels: "plc:S7 model:1200"
-        reservedBy: "Reserved due maintenance window"
       - name: "S7_1200_2"
         labels: "plc:S7 model:1200"
       - name: "Resource-with-properties"
@@ -316,7 +315,9 @@ unclassified:
             value: "Value"
 ```
 
-Properties *description*, *labels* and *reservedBy* are optional.
+Properties *description*, *labels* and *properties* are optional.
+
+Fields like *reservedBy*, *reservedTimestamp* or *note* are not supported, they will be ignored.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ which is already locked, it will wait for the resource to be free.
 “Open source” does not mean “includes free support”
 
 You can support the contributor and buy him a coffee.
-[![coffee](https://www.buymeacoffee.com/assets/img/custom_images/black_img.png)](https://www.buymeacoffee.com/mpokornyetm) 
+[![coffee](https://www.buymeacoffee.com/assets/img/custom_images/black_img.png)](https://www.buymeacoffee.com/mpokornyetm)
 Every second invested in an open-source project is a second you can't invest in your own family / friends / hobby.
 That`s the reason, why supporting the contributors is so important.
 
@@ -149,7 +149,7 @@ lock(resource: 'staging-server', priority: 10) {
 
   Resulting lock order: j1 -> j6 -> j4 -> j2 -> j3 -> j5
 
-#### Resolve a variable configured with the resource name and properties 
+#### Resolve a variable configured with the resource name and properties
 
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -592,6 +592,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
         if (sourceResource != null) {
             setReservedTimestamp(sourceResource.getReservedTimestamp());
             setNote(sourceResource.getNote());
+            setReservedBy(sourceResource.getReservedBy());
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -597,6 +597,16 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     }
 
     /**
+     * Reset unconfigurable properties. Normally, called after "lockable resource" configuration
+     * change, to make sure that these fields are ignored if defined in CasC configuration file.
+     */
+    public void resetUnconfigurableProperties() {
+        setReservedBy(null);
+        setReservedTimestamp(null);
+        setNote("");
+    }
+
+    /**
      * Tell LRM to recycle this resource, including notifications for whoever may be waiting in the
      * queue so they can proceed immediately. WARNING: Do not use this from inside the lock step
      * closure which originally locked this resource, to avoid nasty surprises! Just stick with

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -163,19 +163,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
             for (LockableResource newResource : mergedResources) {
                 final LockableResource oldDeclaredResource = fromName(newResource.getName());
                 if (oldDeclaredResource != null) {
-                    // When configuring through UI, the configuration shown in UI is based on current configuration. So
-                    // it does not matter if unchanged fields are coming from old or new resource.
-                    // But for CasC configuration, these fields are generally not specified, so when empty, use the
-                    // value from the old resource.
-                    if (newResource.getReservedBy() == null) {
-                        newResource.setReservedBy(oldDeclaredResource.getReservedBy());
-                    }
-                    if (newResource.getNote() == null || newResource.getNote().isEmpty()) {
-                        newResource.setNote(oldDeclaredResource.getNote());
-                    }
-                    if (newResource.getReservedTimestamp() == null) {
-                        newResource.setReservedTimestamp(oldDeclaredResource.getReservedTimestamp());
-                    }
+                    newResource.copyUnconfigurableProperties(oldDeclaredResource);
                 }
             }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -159,11 +159,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 mergedResources.add(r);
             }
 
-            // Copy reservations and unconfigurable properties from old instances
+            // Copy reservations and unconfigurable properties from old instances. Clear unconfigurable
+            // properties for new resources: they should be empty anyway for new resources from UI
+            // configuration. For CasC configuration, we ignore those fields, so set them to empty.
             for (LockableResource newResource : mergedResources) {
                 final LockableResource oldDeclaredResource = fromName(newResource.getName());
                 if (oldDeclaredResource != null) {
                     newResource.copyUnconfigurableProperties(oldDeclaredResource);
+                } else {
+                    newResource.resetUnconfigurableProperties();
                 }
             }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1056,8 +1056,6 @@ public class LockableResourcesManager extends GlobalConfiguration {
     public boolean configure(StaplerRequest2 req, JSONObject json) {
         synchronized (this.syncResources) {
             try (BulkChange bc = new BulkChange(this)) {
-                // reset resources to default which are not currently locked
-                this.resources.removeIf(resource -> !resource.isLocked());
                 req.bindJSON(this, json);
                 bc.commit();
             } catch (IOException exception) {

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.jelly
@@ -20,9 +20,6 @@
   <f:entry title="${%entry.labels.title}" field="labels">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%entry.reservedBy.title}" field="reservedBy">
-    <f:textbox/>
-  </f:entry>
   <f:entry title="${%entry.properties.title}">
     <f:repeatableProperty field="properties" header="" minimum="0" add="${%entry.properties.add}">
       <f:block>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config.properties
@@ -23,7 +23,6 @@
 entry.name.title=Name
 entry.description.title=Description
 entry.labels.title=Labels
-entry.reservedBy.title=Reserved by
 entry.properties.title=Properties
 entry.properties.add=Add Property
 entry.properties.delete=Delete Property

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_cs.properties
@@ -23,4 +23,3 @@
 entry.name.title=Jm\u00e9no
 entry.description.title=Popis
 entry.labels.title=Popisky
-entry.reservedBy.title=Rezervace u\u017eivatelem

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_de.properties
@@ -23,4 +23,3 @@
 entry.name.title=Name
 entry.description.title=Beschreibung
 entry.labels.title=Labels
-entry.reservedBy.title=Reserviert durch

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_fr.properties
@@ -23,7 +23,6 @@
 entry.name.title=Nom
 entry.description.title=Description
 entry.labels.title=Libell\u00e9s
-entry.reservedBy.title=R\u00e9serv\u00e9e par
 entry.properties.title=Propri\u00e9t\u00e9s
 entry.properties.add=Ajouter une propri\u00e9t\u00e9
 entry.properties.delete=Supprimer une propri\u00e9t\u00e9

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResource/config_sk.properties
@@ -23,4 +23,3 @@
 entry.name.title=Meno
 entry.description.title=Popis
 entry.labels.title=\u0160t\u00edtky
-entry.reservedBy.title=Rezervovan\u00e9 u\u017e\u00edvate\u013eom

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -43,8 +43,9 @@ class ConfigurationAsCodeTest {
         assertEquals("Resource_A", declaredResource.getName());
         assertEquals("Description_A", declaredResource.getDescription());
         assertEquals("Label_A", declaredResource.getLabels());
-        assertEquals("Reserved_A", declaredResource.getReservedBy());
-        assertEquals("Note A", declaredResource.getNote());
+        // not supported in JCaC
+        // assertEquals("Reserved_A", declaredResource.getReservedBy());
+        // assertEquals("Note A", declaredResource.getNote());
 
         assertEquals(
                 2, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
@@ -53,8 +54,9 @@ class ConfigurationAsCodeTest {
         assertEquals("Resource_A", resource.getName());
         assertEquals("Description_A", resource.getDescription());
         assertEquals("Label_A", resource.getLabels());
-        assertEquals("Reserved_A", resource.getReservedBy());
-        assertEquals("Note A", resource.getNote());
+        // not supported in JCaC
+        // assertEquals("Reserved_A", resource.getReservedBy());
+        // assertEquals("Note A", resource.getNote());
     }
 
     @Test
@@ -75,7 +77,6 @@ class ConfigurationAsCodeTest {
         LockableResourcesManager LRM = LockableResourcesManager.get();
 
         LRM.reserve(Collections.singletonList(LRM.fromName("Resource_B")), "testUser");
-        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
         assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
         Date timestampBeforeReload = LRM.fromName("Resource_B").getReservedTimestamp();
         String noteBeforeReload = LRM.fromName("Resource_B").getNote();
@@ -84,7 +85,6 @@ class ConfigurationAsCodeTest {
         List<String> srcs = ConfigurationAsCode.get().getSources();
         ConfigurationAsCode.get().configure(srcs);
 
-        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
         assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
         assertEquals(timestampBeforeReload, LRM.fromName("Resource_B").getReservedTimestamp());
         assertEquals(noteBeforeReload, LRM.fromName("Resource_B").getNote());

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -35,7 +35,7 @@ class ConfigurationAsCodeTest {
         LockableResourcesManager LRM = LockableResourcesManager.get();
         List<LockableResource> declaredResources = LRM.getDeclaredResources();
         assertEquals(
-                2,
+                3,
                 declaredResources.size(),
                 "The number of declared resources is wrong. Check your configuration-as-code.yml");
 
@@ -44,19 +44,19 @@ class ConfigurationAsCodeTest {
         assertEquals("Description_A", declaredResource.getDescription());
         assertEquals("Label_A", declaredResource.getLabels());
         // not supported in JCaC
-        // assertEquals("Reserved_A", declaredResource.getReservedBy());
-        // assertEquals("Note A", declaredResource.getNote());
+        assertEquals(null, declaredResource.getReservedBy());
+        assertEquals("", declaredResource.getNote());
 
         assertEquals(
-                2, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
+                3, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
 
         LockableResource resource = LRM.getFirst();
         assertEquals("Resource_A", resource.getName());
         assertEquals("Description_A", resource.getDescription());
         assertEquals("Label_A", resource.getLabels());
         // not supported in JCaC
-        // assertEquals("Reserved_A", resource.getReservedBy());
-        // assertEquals("Note A", resource.getNote());
+        assertEquals(null, declaredResource.getReservedBy());
+        assertEquals("", declaredResource.getNote());
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -11,6 +12,8 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import org.jenkins.plugins.lockableresources.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +35,7 @@ class ConfigurationAsCodeTest {
         LockableResourcesManager LRM = LockableResourcesManager.get();
         List<LockableResource> declaredResources = LRM.getDeclaredResources();
         assertEquals(
-                1,
+                2,
                 declaredResources.size(),
                 "The number of declared resources is wrong. Check your configuration-as-code.yml");
 
@@ -44,7 +47,7 @@ class ConfigurationAsCodeTest {
         assertEquals("Note A", declaredResource.getNote());
 
         assertEquals(
-                1, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
+                2, LRM.getResources().size(), "The number of resources is wrong. Check your configuration-as-code.yml");
 
         LockableResource resource = LRM.getFirst();
         assertEquals("Resource_A", resource.getName());
@@ -64,5 +67,26 @@ class ConfigurationAsCodeTest {
         String expected = Util.toStringFromYamlFile(this, "casc_expected_output.yml");
 
         assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_keep_reservations_after_reload(JenkinsConfiguredWithCodeRule r) {
+        LockableResourcesManager LRM = LockableResourcesManager.get();
+
+        LRM.reserve(Collections.singletonList(LRM.fromName("Resource_B")), "testUser");
+        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
+        assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
+        Date timestampBeforeReload = LRM.fromName("Resource_B").getReservedTimestamp();
+        String noteBeforeReload = LRM.fromName("Resource_B").getNote();
+
+        // Get current sources and reconfigure with those sources
+        List<String> srcs = ConfigurationAsCode.get().getSources();
+        ConfigurationAsCode.get().configure(srcs);
+
+        assertEquals("Reserved_A", LRM.fromName("Resource_A").getReservedBy());
+        assertEquals("testUser", LRM.fromName("Resource_B").getReservedBy());
+        assertEquals(timestampBeforeReload, LRM.fromName("Resource_B").getReservedTimestamp());
+        assertEquals(noteBeforeReload, LRM.fromName("Resource_B").getNote());
     }
 }

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -5,3 +5,8 @@ declaredResources:
 - description: "Description_B"
   labels: "Label_B"
   name: "Resource_B"
+- description: "Description_C"
+  labels: "Label_C"
+  name: "Resource_C"
+  note: "Note_C"
+  reservedBy: "User_C"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -8,5 +8,3 @@ declaredResources:
 - description: "Description_C"
   labels: "Label_C"
   name: "Resource_C"
-  note: "Note_C"
-  reservedBy: "User_C"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -2,8 +2,6 @@ declaredResources:
 - description: "Description_A"
   labels: "Label_A"
   name: "Resource_A"
-  note: "Note A"
-  reservedBy: "Reserved_A"
 - description: "Description_B"
   labels: "Label_B"
   name: "Resource_B"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -4,3 +4,6 @@ declaredResources:
   name: "Resource_A"
   note: "Note A"
   reservedBy: "Reserved_A"
+- description: "Description_B"
+  labels: "Label_B"
+  name: "Resource_B"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
@@ -13,3 +13,8 @@ unclassified:
       - description: "Description_B"
         labels: "Label_B"
         name: "Resource_B"
+      - description: "Description_C"
+        labels: "Label_C"
+        name: "Resource_C"
+        reservedBy: "User_C"
+        note: "Note_C"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
@@ -10,8 +10,6 @@ unclassified:
       - description: "Description_A"
         labels: "Label_A"
         name: "Resource_A"
-        reservedBy: "Reserved_A"
-        note: "Note A"
       - description: "Description_B"
         labels: "Label_B"
         name: "Resource_B"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code.yml
@@ -12,3 +12,6 @@ unclassified:
         name: "Resource_A"
         reservedBy: "Reserved_A"
         note: "Note A"
+      - description: "Description_B"
+        labels: "Label_B"
+        name: "Resource_B"


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- in case you work on a Jira issue, replace XXXXX with the numeric part of the issue ID you created in Jira -->
<!-- in case you work on github issue -->
Close #527 
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Explanation
This is a combination of #770 and #650, to remove reservedBy from UI configuration and to ignore reservedBy/reservedTimestamp/note from CasC configuration.

Users can reserve lockable resources and add notes. These reservations and notes currently disappear when reloading CasC configuration, or when Jenkins simply restarts. This pull request attempts to fix that.

The reservedTimestamp and note were already copied when reconfiguring lockable resources in the UI. This happened in LockableResourceManager.configure(). Move this part to the setDeclaredResources(), so it also runs when configuring from CasC config. 

_reservedBy_, _reservedTimestamp_ and _note_ are now ignored if they are defined in CasC. _reservedBy_ is removed from UI configuration.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Added test ConfigurationAsCodeTest#should_keep_reservations_after_reload. This test also fails when leaving out my changes.

Did some manual tests. CasC configuration with 
1. resource with filled in reservedBy/note fields
2. resource with empty reservedBy/note fields
3. resource without reservedBy/note fields

Reserved/reassigned/unreserved the resources, updated the notes. When reloading configuration, resources 1, 2 and 3 kept their reservation/note from before the reload. Also when making changes in the UI configuration, the reservations were kept.


### Proposed upgrade guidelines
_reservedBy_, _reservedTimestamp_ and _note_ are now ignored if they are defined in CasC.

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.



