### PR TITLE
Remove useless annotation

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -11,7 +11,6 @@ package org.jenkins.plugins.lockableresources;
 import static java.text.DateFormat.MEDIUM;
 import static java.text.DateFormat.SHORT;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -19,7 +18,6 @@ import groovy.lang.Binding;
 import hudson.Extension;
 import hudson.Util;
 import hudson.console.ModelHyperlinkNote;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Label;
@@ -486,7 +484,6 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
         return null;
     }
 
-    @WithBridgeMethods(value = AbstractBuild.class, adapterMethod = "getAbstractBuild")
     public Run<?, ?> getBuild() {
         if (build == null && buildExternalizableId != null) {
             build = Run.fromExternalizableId(buildExternalizableId);


### PR DESCRIPTION
https://github.com/jenkinsci/lockable-resources-plugin/pull/432 effectively removed the bridge method from the generated bytecode by removing `bridge-method-injector` from the build, but it did not remove the `@WithBridgeMethods` annotation, turning it into dead code. Since the intervening 3 years have clearly demonstrated that the bridge method is not actually needed, remove the useless annotation rather than adding `bridge-method-injector` back to the build.

### Testing done

Dumped the bytecode of the class with `javap` before and after this change and verified it was the same (i.e., no bridge method both before and after, as expected).

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
