### PR TITLE
Resources are not removed from queue, when timeout is reached

### DIFF
--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithTimeout.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepWithTimeout.java
@@ -1,0 +1,147 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.model.Result;
+import java.util.Objects;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class LockStepWithTimeout extends LockStepTestBase {
+
+    private JenkinsRule jenkinsRule;
+
+    @BeforeEach
+    void setUp(JenkinsRule jenkinsRule) {
+        this.jenkinsRule = jenkinsRule;
+    }
+
+    @Test
+    void lockWithTimeoutInside() throws Exception {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        lrm.createResourceWithLabel("Resource1", "label1");
+        lrm.createResourceWithLabel("Resource2", "label2");
+
+        WorkflowJob p = jenkinsRule.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                def stages = [:];
+                        stages['stage1'] = {
+                            echo 'Start stage 1';
+                            lock('Resource1') {
+                                echo 'Resource1 locked in stage 1.'
+                                lock('Resource2') {
+                                    echo 'Resource2 locked in stage 1.'
+                                }
+                                echo 'Exiting timeout block in stage 1.'
+                            }
+                            echo 'Nothing locked in stage 1.'
+                        }
+                        stages['stage2'] = {
+                            echo 'Start stage 2';
+                            sleep 500; // Simulate some work
+                            lock('Resource1') {
+                                echo 'Resource1 locked in stage 2.'
+                                lock('Resource2') {
+                                    echo 'Resource2 locked in stage 2.'
+                                }
+                                echo 'Exiting timeout block in stage 2.'
+                            }
+                            echo 'Nothing locked in stage 2.'
+                        }
+                        stages['stage3'] = {
+                            echo 'Start stage 3';
+                            sleep 1000; // Simulate some work
+                            lock('Resource1') {
+                                echo 'Resource1 locked in stage 3.'
+                                lock('Resource2') {
+                                    echo 'Resource2 locked in stage 3.'
+                                }
+                                echo 'Exiting timeout block in stage 3.'
+                            }
+                            echo 'Nothing locked in stage 3.'
+                        }
+
+                    timeout(time: 5, unit: 'SECONDS') {
+                        echo 'Start timeout block.'
+                        parallel stages;
+                        echo 'Exiting timeout block.'
+                    }
+                    echo 'Finish'""",
+                true));
+
+        // at first I will just start the build and wait for it to complete. No resources are locked or reserved before.
+        // this shall be more or less a smoke test to see if the code runs without exceptions.
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b1));
+        j.assertLogContains("Start timeout block.", b1);
+        j.assertLogContains("Start stage 1", b1);
+        j.assertLogContains("Resource1 locked in stage 1.", b1);
+        j.assertLogContains("Resource2 locked in stage 1.", b1);
+        j.assertLogContains("Start stage 2", b1);
+        j.assertLogContains("Resource1 locked in stage 2.", b1);
+        j.assertLogContains("Resource2 locked in stage 2.", b1);
+        j.assertLogContains("Start stage 3", b1);
+        j.assertLogContains("Resource1 locked in stage 3.", b1);
+        j.assertLogContains("Resource2 locked in stage 3.", b1);
+        j.assertLogContains("Exiting timeout block.", b1);
+        j.assertLogContains("Finish", b1);
+        assertNotNull(lrm.fromName("Resource1"));
+        assertTrue(lrm.fromName("Resource1").isFree());
+        assertNotNull(lrm.fromName("Resource2"));
+        assertTrue(lrm.fromName("Resource2").isFree());
+
+        // now I will start the build again, but this time I will reserve the resources before.
+        lrm.fromName("Resource1").reserve();
+        // the build should now wait for the resource to be released, but the timeout should be triggered and the build should fail.
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b2));
+        j.assertLogContains("Start timeout block.", b2);
+        j.assertLogContains("Start stage 1", b2);
+        j.assertLogNotContains("Resource1 locked in stage 1.", b2);
+        j.assertLogNotContains("Resource2 locked in stage 1.", b2);
+        j.assertLogContains("Start stage 2", b2);
+        j.assertLogNotContains("Resource1 locked in stage 2.", b2);
+        j.assertLogNotContains("Resource2 locked in stage 2.", b2);
+        j.assertLogContains("Start stage 3", b2);
+        j.assertLogNotContains("Resource1 locked in stage 3.", b2);
+        j.assertLogNotContains("Resource2 locked in stage 3.", b2);
+        j.assertLogNotContains("Exiting timeout block.", b2);
+        j.assertLogContains("Finish", b2);
+        assertNotNull(lrm.fromName("Resource1"));
+        assertTrue(lrm.fromName("Resource1").isReserved());
+        assertNotNull(lrm.fromName("Resource2"));
+        assertTrue(lrm.fromName("Resource2").isFree());
+
+        // now I will release the Resource1 and reserve Resource2 and start the build again.
+        // the Resource2 will be 1 times reserved and 0 times locked and 3 times in the queue.
+        // the Resource1 will be 0 times reserved and 1 times locked and 2 times in the queue.
+        // the timeout should be triggered and the build should fail.
+        // the Resource1 must be free and the Resource2 must be reserved.
+        // The scope of queued stages can shall not be executed (because of abort signal by timeout).
+        lrm.unreserve(Collections.singletonList(lrm.fromName("Resource1")));
+        lrm.fromName("Resource2").reserve();
+        WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b3));
+        j.assertLogContains("Start timeout block.", b3);
+        j.assertLogContains("Start stage 1", b3);
+        j.assertLogContains("Resource1 locked in stage 1.", b3);
+        j.assertLogNotContains("Resource2 locked in stage 1.", b3);
+        j.assertLogContains("Start stage 2", b3);
+        j.assertLogNotContains("Resource1 locked in stage 2.", b3);
+        j.assertLogNotContains("Resource2 locked in stage 2.", b3);
+        j.assertLogContains("Start stage 3", b3);
+        j.assertLogNotContains("Resource1 locked in stage 3.", b3);
+        j.assertLogNotContains("Resource2 locked in stage 3.", b3);
+        j.assertLogNotContains("Exiting timeout block.", b3);
+        j.assertLogContains("Finish", b3);
+        assertNotNull(lrm.fromName("Resource1"));
+        assertTrue(lrm.fromName("Resource1").isFree());
+        assertNotNull(lrm.fromName("Resource2"));
+        assertTrue(lrm.fromName("Resource2").isReserved());
+    }
+}


### PR DESCRIPTION
fixed #773

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
