### PR TITLE
remove usages of commons lang 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,16 +91,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -36,12 +36,12 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.accmod.Restricted;
@@ -398,7 +398,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      */
     @Restricted(NoExternalUse.class) // called by jelly
     public boolean isReservedByCurrentUser() {
-        return (this.reservedBy != null && StringUtils.equals(getUserName(), this.reservedBy));
+        return (this.reservedBy != null && Objects.equals(getUserName(), this.reservedBy));
     }
 
     @Exported

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -41,7 +41,6 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
@@ -1115,7 +1114,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         for (LockableResourcesStruct requiredResources : requiredResourcesList) {
             List<LockableResource> available = new ArrayList<>();
             // filter by labels
-            if (!StringUtils.isBlank(requiredResources.label)) {
+            if (requiredResources.label != null && !requiredResources.label.isBlank()) {
                 // get required amount first
                 int requiredAmount = 0;
                 if (requiredResources.requiredNumber != null) {


### PR DESCRIPTION
replace with plain java.
The plan is to remove common lang 2 (EOL 2011 and https://nvd.nist.gov/vuln/detail/CVE-2025-48924) from core so all plugins that use it via core must be adjusted.

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

No testing, relying on the built-in tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
