### PR TITLE
Set the reserved timestamp on reassign

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -971,11 +971,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
      */
     public void reassign(List<LockableResource> resources, String userName) {
         synchronized (syncResources) {
+            Date date = new Date();
             for (LockableResource r : resources) {
                 if (!r.isFree()) {
                     r.unReserve();
                 }
                 r.setReservedBy(userName);
+                r.setReservedTimestamp(date);
             }
             save();
         }

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -145,20 +145,24 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
         SecurityContextHolder.getContext().setAuthentication(this.reserve_user1.impersonate2());
         assertThrows(AccessDeniedException.class, () -> action.doReassign(req, rsp));
         assertEquals(this.reserve_user1.getId(), resource.getReservedBy(), "reserved by user");
+        assertNotNull(resource.getReservedTimestamp());
 
         // switch to admin and try to reassign
         SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());
         action.doReassign(req, rsp);
         assertEquals(this.admin.getId(), resource.getReservedBy(), "reserved by admin");
+        assertNotNull(resource.getReservedTimestamp());
 
         // try to steal reservation
         SecurityContextHolder.getContext().setAuthentication(this.steal_user.impersonate2());
         action.doReassign(req, rsp);
         assertEquals(this.steal_user.getId(), resource.getReservedBy(), "reserved by steal user");
+        assertNotNull(resource.getReservedTimestamp());
 
         // do reassign your self, makes no sense, but the application shall not crashed
         action.doReassign(req, rsp);
         assertEquals(this.steal_user.getId(), resource.getReservedBy(), "reserved by steal user");
+        assertNotNull(resource.getReservedTimestamp());
 
         // defensive tests
         when(req.getParameter("resource")).thenReturn("this-one-does-not-exists");


### PR DESCRIPTION
Closes #806 

### Submitter checklist

- [ ] The Jira / Github issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
