### PR TITLE
Fix permission names change with locale 

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -53,31 +53,31 @@ public class LockableResourcesRootAction implements RootAction {
             LockableResourcesManager.class, Messages._LockableResourcesRootAction_PermissionGroup());
     public static final Permission UNLOCK = new Permission(
             PERMISSIONS_GROUP,
-            Messages.LockableResourcesRootAction_UnlockPermission(),
+            "Unlock",
             Messages._LockableResourcesRootAction_UnlockPermission_Description(),
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);
     public static final Permission RESERVE = new Permission(
             PERMISSIONS_GROUP,
-            Messages.LockableResourcesRootAction_ReservePermission(),
+            "Reserve",
             Messages._LockableResourcesRootAction_ReservePermission_Description(),
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);
     public static final Permission STEAL = new Permission(
             PERMISSIONS_GROUP,
-            Messages.LockableResourcesRootAction_StealPermission(),
+            "Steal",
             Messages._LockableResourcesRootAction_StealPermission_Description(),
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);
     public static final Permission VIEW = new Permission(
             PERMISSIONS_GROUP,
-            Messages.LockableResourcesRootAction_ViewPermission(),
+            "View",
             Messages._LockableResourcesRootAction_ViewPermission_Description(),
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);
     public static final Permission QUEUE = new Permission(
             PERMISSIONS_GROUP,
-            Messages.LockableResourcesRootAction_QueueChangeOrderPermission(),
+            "Queue",
             Messages._LockableResourcesRootAction_QueueChangeOrderPermission_Description(),
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
@@ -8,19 +8,14 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 
 LockableResourcesRootAction.PermissionGroup=Lockable Resources
-LockableResourcesRootAction.UnlockPermission=Unlock
 LockableResourcesRootAction.UnlockPermission.Description=This permission grants the ability to manually \
   unlock resources that have been locked by builds.
-LockableResourcesRootAction.ReservePermission=Reserve
 LockableResourcesRootAction.ReservePermission.Description=This permission grants the ability to manually \
   reserve lockable resources outside of a build.
-LockableResourcesRootAction.StealPermission=Steal
 LockableResourcesRootAction.StealPermission.Description=This permission grants the ability to manually \
   "steal" resources that have been locked by builds or "reassign" those reserved by users.
-LockableResourcesRootAction.ViewPermission=View
 LockableResourcesRootAction.ViewPermission.Description=This permission grants the ability to view \
   lockable resources.
-LockableResourcesRootAction.QueueChangeOrderPermission=Queue
 LockableResourcesRootAction.QueueChangeOrderPermission.Description=This permission grants the ability to \
   manually manipulate the lockable resources queue..
 LockedResourcesBuildAction.displayName=Lockable resources

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages_cs.properties
@@ -8,12 +8,8 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 
 LockableResourcesRootAction.PermissionGroup=Uzamykateln\u00e9 zdroje
-LockableResourcesRootAction.UnlockPermission=Odemknout
 LockableResourcesRootAction.UnlockPermission.Description=Toto opr\u00e1vn\u011bn\u00ed ud\u011bluje mo\u017enost ru\u010dn\u011b odemknout zdroje, kter\u00e9 byly uzam\u010deny sestaven\u00edmi.
-LockableResourcesRootAction.ReservePermission=Rezervovat
 LockableResourcesRootAction.ReservePermission.Description=Toto opr\u00e1vn\u011bn\u00ed poskytuje mo\u017enost ru\u010dn\u011b rezervovat uzamykateln\u00e9 zdroje mimo sestaven\u00ed.
-LockableResourcesRootAction.StealPermission=Ukradnout
 LockableResourcesRootAction.StealPermission.Description=Toto opr\u00e1vn\u011bn\u00ed ud\u011bluje mo\u017enost manu\u00e1ln\u011b "ukradnout" zdroje, kter\u00e9 byly uzam\u010deny sestaven\u00edm nebo "p\u0159e\u0159adit" polo\u017eky rezervovan\u00e9 u\u017eivateli.
-LockableResourcesRootAction.ViewPermission=Zobrazit
 LockableResourcesRootAction.ViewPermission.Description=Toto opr\u00e1vn\u011bn\u00ed ud\u011bluje mo\u017enost zobrazit uzamykateln\u00e9 zdroje.
 

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages_de.properties
@@ -8,12 +8,8 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 
 LockableResourcesRootAction.PermissionGroup=Sperrbare Ressourcen
-LockableResourcesRootAction.UnlockPermission=Entsperren
 LockableResourcesRootAction.UnlockPermission.Description=Diese Berechtigung gew\u00e4hrt die M\u00f6glichkeit, Ressourcen manuell freizuschalten, die durch Builds gesperrt wurden.
-LockableResourcesRootAction.ReservePermission=Reservieren
 LockableResourcesRootAction.ReservePermission.Description=Diese Berechtigung gew\u00e4hrt die M\u00f6glichkeit, verschlie\u00dfbare Ressourcen au\u00dferhalb eines Build manuell zu reservieren.
-LockableResourcesRootAction.StealPermission=Stehlen
 LockableResourcesRootAction.StealPermission.Description=Diese Berechtigung gew\u00e4hrt die M\u00f6glichkeit, Ressourcen manuell zu stehlen, die durch Builds gesperrt oder von Benutzern reserviert wurden.
-LockableResourcesRootAction.ViewPermission=Ansicht
 LockableResourcesRootAction.ViewPermission.Description=Diese Berechtigung gew\u00e4hrt die M\u00f6glichkeit, gesperrte Ressourcen zu sehen.
 

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages_fr.properties
@@ -8,12 +8,8 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 
 LockableResourcesRootAction.PermissionGroup=Ressources verrouillables
-LockableResourcesRootAction.UnlockPermission=D\u00e9verrouiller
 LockableResourcesRootAction.UnlockPermission.Description=Cette permission accorde la possibilit\u00e9 de d\u00e9verrouiller manuellement les ressources qui ont \u00e9t\u00e9 verrouill\u00e9es par les builds.
-LockableResourcesRootAction.ReservePermission=R\u00e9server
 LockableResourcesRootAction.ReservePermission.Description=Cette permission accorde la possibilit\u00e9 de r\u00e9server manuellement les ressources verrouillables \u00e0 l'ext\u00e9rieur d'un build.
-LockableResourcesRootAction.StealPermission=Voler
 LockableResourcesRootAction.StealPermission.Description=Cette permission permet de "voler" manuellement les ressources qui ont \u00e9t\u00e9 verrouill\u00e9es par les builds ou de "r\u00e9assigner" celles r\u00e9serv\u00e9es par les utilisateurs.
-LockableResourcesRootAction.ViewPermission=Voir
 LockableResourcesRootAction.ViewPermission.Description=Cette permission accorde la possibilit\u00e9 de voir les ressources verrouillables.
 

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages_sk.properties
@@ -8,12 +8,8 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 
 LockableResourcesRootAction.PermissionGroup=Uzamykate\u013en\u00e9 zdroje
-LockableResourcesRootAction.UnlockPermission=Odomkn\u00fa\u0165
 LockableResourcesRootAction.UnlockPermission.Description=Toto opr\u00e1vnenie ude\u013euje mo\u017enos\u0165 ru\u010dne odomkn\u00fa\u0165 zdroje, ktor\u00e9 boli uzamknut\u00e9 zostaveniami.
-LockableResourcesRootAction.ReservePermission=Rezervova\u0165
 LockableResourcesRootAction.ReservePermission.Description=Toto opr\u00e1vnenie poskytuje mo\u017enos\u0165 ru\u010dne rezervova\u0165 uzamykate\u013en\u00e9 zdroje mimo zostavenia.
-LockableResourcesRootAction.StealPermission=Ukradn\u00fa\u0165
 LockableResourcesRootAction.StealPermission.Description=Toto opr\u00e1vnenie umo\u017e\u0148uje manu\u00e1lne "ukradn\u00fa\u0165" zdroj, ktor\u00fd bol uzamknut\u00fd zostaven\u00edm alebo "preradi\u0165" zdroje rezervovan\u00e9 u\u017e\u00edvate\u013eom.
-LockableResourcesRootAction.ViewPermission=Zobrazi\u0165
 LockableResourcesRootAction.ViewPermission.Description=Toto opr\u00e1vnenie ude\u013euje mo\u017enos\u0165 zobrazi\u0165 zamykate\u013en\u00e9 zdroje.
 


### PR DESCRIPTION
The permission names need to be constant and must not change with the locale. Otherwise switching from e.g. english to german will result in different names and on Jenkins start the permission assignments are lost or with CasC it will fail as the permission is not found.

fixes #466

<!-- Comment:
A great PR typically begins with the line below.
-->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done
manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, **you must describe** the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed upgrade guidelines

N/A

### Localizations

<!-- Comment:
To translate this plugin we used an awesome tool named [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin). At the moment there is a limited number of users allowed to validate the proposed translations, but anybody having a Crowdin account (created in a heartbeat) can participate in the translation effort.
+ Be sure any localization files are moved to *.properties files.
+ Please describe here which language has been translated by you.
+ English text's are mandatory for new entries.

Please note, that changes in non-default localizations files without Crowdin translations leads to misleading and merge conflicts. 
-->

- [ ] English
- [ ] German
- [ ] French
- [ ] Slovak
- [ ] Czech
- [ ] ...

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
<!-- Comment:
This steps need additional automation in release management. Therefore are commented out for now.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
-->
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
- [ ] Any localizations are transferred to *.properties files.
- [ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
