### PR TITLE
Make `matrix-project` dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -100,6 +101,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>variant</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -10,7 +10,6 @@ package org.jenkins.plugins.lockableresources.queue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -36,7 +35,9 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
     public void onStarted(Run<?, ?> build, TaskListener listener) {
         // Skip locking for multiple configuration projects,
         // only the child jobs will actually lock resources.
-        if (build instanceof MatrixBuild) return;
+        if (build.getClass().getName().equals("hudson.matrix.MatrixBuild")) {
+            return;
+        }
 
         if (build instanceof AbstractBuild) {
             LockableResourcesManager lrm = LockableResourcesManager.get();
@@ -96,7 +97,9 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
     public void onCompleted(Run<?, ?> build, @NonNull TaskListener listener) {
         // Skip unlocking for multiple configuration projects,
         // only the child jobs will actually unlock resources.
-        if (build instanceof MatrixBuild) return;
+        if (build.getClass().getName().equals("hudson.matrix.MatrixBuild")) {
+            return;
+        }
         LOGGER.info(build.getFullDisplayName());
         LockableResourcesManager.get().unlockBuild(build);
     }
@@ -105,7 +108,9 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
     public void onDeleted(Run<?, ?> build) {
         // Skip unlocking for multiple configuration projects,
         // only the child jobs will actually unlock resources.
-        if (build instanceof MatrixBuild) return;
+        if (build.getClass().getName().equals("hudson.matrix.MatrixBuild")) {
+            return;
+        }
         LOGGER.info(build.getFullDisplayName());
         LockableResourcesManager.get().unlockBuild(build);
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/Utils.java
@@ -11,11 +11,14 @@ package org.jenkins.plugins.lockableresources.queue;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
+import hudson.ExtensionList;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
+import java.util.Map;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 
 public final class Utils {
     private Utils() {}
@@ -35,14 +38,35 @@ public final class Utils {
     public static LockableResourcesStruct requiredResources(@NonNull Job<?, ?> project) {
         EnvVars env = new EnvVars();
 
-        if (project instanceof MatrixConfiguration) {
-            env.putAll(((MatrixConfiguration) project).getCombination());
-            project = (Job<?, ?>) project.getParent();
+        for (var ma : ExtensionList.lookup(MatrixAssist.class)) {
+            env.putAll(ma.getCombination(project));
+            project = ma.getMainProject(project);
         }
 
         RequiredResourcesProperty property = project.getProperty(RequiredResourcesProperty.class);
         if (property != null) return new LockableResourcesStruct(property, env);
 
         return null;
+    }
+
+    public interface MatrixAssist {
+        @NonNull
+        Map<String, String> getCombination(@NonNull Job<?, ?> project);
+
+        @NonNull
+        Job<?, ?> getMainProject(@NonNull Job<?, ?> project);
+    }
+
+    @OptionalExtension(requirePlugins = "matrix-project")
+    public static final class MatrixImpl implements MatrixAssist {
+        @Override
+        public Map<String, String> getCombination(Job<?, ?> project) {
+            return project instanceof MatrixConfiguration mc ? mc.getCombination() : Map.of();
+        }
+
+        @Override
+        public Job<?, ?> getMainProject(Job<?, ?> project) {
+            return project instanceof MatrixConfiguration mc ? mc.getParent() : project;
+        }
     }
 }


### PR DESCRIPTION
Closes #757. Modelled after https://github.com/jenkinsci/email-ext-plugin/pull/642.

If approved & merged, needs a release; suggested label: `enhancement`

Testing: was able to use the Pipeline `lock` step in its simplest form with or without `matrix-project` enabled.

There is no apparent test coverage for the `matrix-project` integration, but interactively it seemed to work: after enabling this checkbox on a matrix project and triggering a build, while a Pipeline build held the lock, both combination builds waited in queue; when the Pipeline build completed, they both ran. Or if I added a shell step `sleep 30` to the matrix project, it would run one combination at a time. Note that `/job/m/lastSuccessfulBuild/X=2/locked-resources/` just says

> Loading - please wait ...

which I suppose was a preëxisting bug (symptom like https://github.com/jenkinsci/lockable-resources-plugin/issues/706 but different circumstances).