### PR TITLE
fix: Use PAT for rebase workflow to trigger subsequent checks

### DIFF
--- a/.github/workflows/rebase-open-prs.yml
+++ b/.github/workflows/rebase-open-prs.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: mPokornyETM/rebase-open-prs-action@v1
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use PAT to trigger subsequent workflows (security scan, etc.)
+          # Falls back to github.token if GH_TOKEN secret is not set
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GH_TOKEN || github.token }}


### PR DESCRIPTION
﻿## Summary
Use PAT instead of github.token for the rebase workflow to trigger subsequent CI checks.

## Problem
When the rebase workflow force-pushes PR branches, it uses github.token. GitHub does not trigger other workflows (like Jenkins Security Scan) for pushes made with this token - this is a security feature to prevent recursive triggers.

This caused PRs to get stuck because the required Jenkins Security Scan check never ran after rebasing.

## Solution
- Use secrets.GH_TOKEN (PAT) if configured
- Fall back to github.token if no PAT is available

## To complete this fix
A repository admin needs to:
1. Create a Personal Access Token with repo and workflow scopes
2. Add it as repository secret named GH_TOKEN
