### PR TITLE
Add timeout for resource allocation in lock step and freestyle jobs

### DIFF
--- a/src/doc/examples/lock-with-timeout.md
+++ b/src/doc/examples/lock-with-timeout.md
@@ -1,0 +1,77 @@
+## Lock with allocation timeout
+
+By default, the `lock` step waits indefinitely until the requested resource becomes available.
+With `timeoutForAllocateResource` you can set a maximum wait time — if the resource is not
+acquired within that period, the build fails immediately instead of blocking the queue forever.
+
+This is useful when:
+- You prefer a fast failure over an indefinitely blocked pipeline
+- You want to detect resource starvation early
+- Your CI/CD has SLAs that cap how long a job may wait
+
+### Pipeline (scripted)
+
+```groovy
+node {
+    // Wait up to 5 minutes for the resource, then fail
+    lock(resource: 'my-printer', timeoutForAllocateResource: 5, timeoutUnit: 'MINUTES') {
+        echo "Printer locked, printing ..."
+    }
+}
+```
+
+### Pipeline (declarative)
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Deploy') {
+            options {
+                lock(resource: 'staging-env', timeoutForAllocateResource: 10, timeoutUnit: 'MINUTES')
+            }
+            steps {
+                echo "Deploying to staging ..."
+            }
+        }
+    }
+}
+```
+
+### Label-based locking with timeout
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Test') {
+            steps {
+                lock(label: 'phone', quantity: 1, variable: 'PHONE',
+                     timeoutForAllocateResource: 2, timeoutUnit: 'MINUTES') {
+                    echo "Running tests on ${env.PHONE}"
+                }
+            }
+        }
+    }
+}
+```
+
+### Freestyle jobs
+
+In a freestyle job configuration, go to **This build requires lockable resources** and set:
+- **Lock wait timeout**: the maximum time to wait (e.g. `5`)
+- **Timeout unit**: `SECONDS`, `MINUTES`, or `HOURS`
+
+If the resource is not available within the configured timeout, the build is automatically
+removed from the Jenkins queue.
+
+### Timeout values
+
+| `timeoutUnit` | Description |
+|---------------|-------------|
+| `SECONDS`     | Timeout in seconds |
+| `MINUTES`     | Timeout in minutes (default) |
+| `HOURS`       | Timeout in hours |
+
+Setting `timeoutForAllocateResource: 0` (the default) disables the timeout — the build
+waits indefinitely, which preserves the original behaviour.

--- a/src/doc/examples/readme.md
+++ b/src/doc/examples/readme.md
@@ -13,3 +13,4 @@ If you have a question, please open a [GitHub issue](https://github.com/jenkinsc
 - [Scripted vs declarative pipeline](scripted-vs-declarative-pipeline.md)
 - [Timeout inside lock](timeout-inside-lock.md)
 - [Dynamic resource pool expansion](dynamic-resource-pool-expansion.md)
+- [Lock with allocation timeout](lock-with-timeout.md)

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStep.java
@@ -71,6 +71,20 @@ public class LockStep extends Step implements Serializable {
     @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public int priority = 0;
 
+    /**
+     * Timeout in the specified {@link #timeoutUnit} for waiting to acquire the resource.
+     * 0 means no timeout (wait indefinitely). When the timeout expires, the step fails
+     * with an exception instead of waiting forever.
+     */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
+    public long timeoutForAllocateResource = 0;
+
+    /**
+     * Time unit for {@link #timeoutForAllocateResource}. Defaults to MINUTES.
+     */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
+    public String timeoutUnit = "MINUTES";
+
     // it should be LockStep() - without params. But keeping this for backward compatibility
     // so `lock('resource1')` still works and `lock(label: 'label1', quantity: 3)` works too (resource
     // is not required)
@@ -154,6 +168,24 @@ public class LockStep extends Step implements Serializable {
         this.extra = extra;
     }
 
+    @DataBoundSetter
+    public void setTimeoutForAllocateResource(long timeoutForAllocateResource) {
+        this.timeoutForAllocateResource = Math.max(0, timeoutForAllocateResource);
+    }
+
+    @DataBoundSetter
+    public void setTimeoutUnit(String timeoutUnit) {
+        if (timeoutUnit != null && !timeoutUnit.trim().isEmpty()) {
+            // Validate it is a valid TimeUnit name
+            try {
+                java.util.concurrent.TimeUnit.valueOf(timeoutUnit.toUpperCase(Locale.ENGLISH));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid timeoutUnit: " + timeoutUnit);
+            }
+            this.timeoutUnit = timeoutUnit.toUpperCase(Locale.ENGLISH);
+        }
+    }
+
     @Extension
     public static final class DescriptorImpl extends StepDescriptor {
 
@@ -227,6 +259,20 @@ public class LockStep extends Step implements Serializable {
                 }
             }
             return FormValidation.ok();
+        }
+
+        @RequirePOST
+        public ListBoxModel doFillTimeoutUnitItems(@AncestorInPath Item item) {
+            if (item != null) {
+                item.checkPermission(Item.CONFIGURE);
+            } else {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            }
+            ListBoxModel items = new ListBoxModel();
+            items.add("Seconds", "SECONDS");
+            items.add("Minutes", "MINUTES");
+            items.add("Hours", "HOURS");
+            return items;
         }
 
         @Override

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -147,8 +147,12 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
             getContext().onSuccess(null);
         } else {
             this.printBlockCause(logger, resourceHolderList);
-            LockableResourcesManager.printLogs(
-                    "[" + step + "] is not free, waiting for execution ...", Level.FINE, LOGGER, logger);
+            String waitMsg = "[" + step + "] is not free, waiting for execution ...";
+            if (step.timeoutForAllocateResource > 0) {
+                waitMsg += " (timeout: " + step.timeoutForAllocateResource + " "
+                        + step.timeoutUnit.toLowerCase(java.util.Locale.ENGLISH) + ")";
+            }
+            LockableResourcesManager.printLogs(waitMsg, Level.FINE, LOGGER, logger);
             LockableResourcesManager lrm = LockableResourcesManager.get();
             lrm.queueContext(
                     getContext(),
@@ -157,7 +161,9 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Seri
                     step.variable,
                     step.inversePrecedence,
                     step.priority,
-                    step.reason);
+                    step.reason,
+                    step.timeoutForAllocateResource,
+                    step.timeoutUnit);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -95,6 +95,12 @@ public class LockableResourcesManager extends GlobalConfiguration {
     private transient volatile AtomicBoolean savePending;
     private transient volatile ScheduledExecutorService saveExecutor;
 
+    /** Single scheduled timeout task. Guarded by {@link #syncResources}. */
+    private transient java.util.concurrent.ScheduledFuture<?> nextTimeoutTask;
+
+    /** Deadline (epoch ms) the current {@link #nextTimeoutTask} targets. 0 = none. */
+    private transient long nextTimeoutDeadline;
+
     @DataBoundSetter
     public void setAllowEmptyOrNullValues(boolean allowEmptyOrNullValues) {
         this.allowEmptyOrNullValues = allowEmptyOrNullValues;
@@ -870,8 +876,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
         LOGGER.fine("current queue size: " + this.queuedContexts.size());
         LOGGER.finest("current queue: " + this.queuedContexts);
-        List<QueuedContextStruct> orphan = new ArrayList<>();
+        List<QueuedContextStruct> toRemove = new ArrayList<>();
         QueuedContextStruct nextEntry = null;
+        long earliestDeadline = Long.MAX_VALUE;
 
         // the first one added lock is the oldest one, and this wins
 
@@ -880,17 +887,42 @@ public class LockableResourcesManager extends GlobalConfiguration {
             // check queue list first
             if (!entry.isValid()) {
                 LOGGER.fine("well be removed: " + idx + " " + entry);
-                orphan.add(entry);
+                toRemove.add(entry);
                 continue;
             }
+
+            // check if the entry has timed out waiting for resources
+            if (entry.isTimedOut()) {
+                LOGGER.info("Queue entry timed out waiting for resources: " + entry);
+                toRemove.add(entry);
+                PrintStream logger = entry.getLogger();
+                String msg = "[" + entry.getResourceDescription()
+                        + "] timed out waiting for resource allocation after "
+                        + entry.getTimeoutForAllocateResource() + " "
+                        + entry.getTimeoutUnit().toLowerCase(java.util.Locale.ENGLISH);
+                printLogs(msg, logger, Level.WARNING);
+                entry.getContext()
+                        .onFailure(new org.jenkins.plugins.lockableresources.queue.LockWaitTimeoutException(msg));
+                continue;
+            }
+
+            // track the earliest deadline among remaining entries for rescheduling
+            long deadline = entry.getTimeoutDeadlineMillis();
+            if (deadline > 0 && deadline < earliestDeadline) {
+                earliestDeadline = deadline;
+            }
+
             LOGGER.finest("oldest win - index: " + idx + " " + entry);
 
             nextEntry = getNextQueuedContextEntry(entry);
         }
 
-        if (!orphan.isEmpty()) {
-            this.queuedContexts.removeAll(orphan);
+        if (!toRemove.isEmpty()) {
+            this.queuedContexts.removeAll(toRemove);
         }
+
+        // reschedule for the next earliest deadline
+        scheduleTimeoutAt(earliestDeadline);
 
         return nextEntry;
     }
@@ -1458,12 +1490,22 @@ public class LockableResourcesManager extends GlobalConfiguration {
             String variableName,
             boolean inversePrecedence,
             int priority) {
-        queueContext(context, requiredResources, resourceDescription, variableName, inversePrecedence, priority, null);
+        queueContext(
+                context,
+                requiredResources,
+                resourceDescription,
+                variableName,
+                inversePrecedence,
+                priority,
+                null,
+                0,
+                "MINUTES");
     }
 
+    // ---------------------------------------------------------------------------
     /*
      * Adds the given context and the required resources to the queue if
-     * this context is not yet queued.
+     * this context is not yet queued, with reason and timeout for resource allocation.
      */
     @Restricted(NoExternalUse.class)
     public void queueContext(
@@ -1473,7 +1515,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
             String variableName,
             boolean inversePrecedence,
             int priority,
-            String reason) {
+            String reason,
+            long timeoutForAllocateResource,
+            String timeoutUnit) {
         synchronized (syncResources) {
             for (QueuedContextStruct entry : this.queuedContexts) {
                 if (entry.getContext() == context) {
@@ -1484,7 +1528,14 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
             int queueIndex = 0;
             QueuedContextStruct newQueueItem = new QueuedContextStruct(
-                    context, requiredResources, resourceDescription, variableName, priority, reason);
+                    context,
+                    requiredResources,
+                    resourceDescription,
+                    variableName,
+                    priority,
+                    reason,
+                    timeoutForAllocateResource,
+                    timeoutUnit);
 
             if (!inversePrecedence || priority != 0) {
                 queueIndex = this.queuedContexts.size() - 1;
@@ -1506,6 +1557,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
                     Level.FINE);
 
             save();
+
+            // If this entry has a timeout and its deadline is earlier than the
+            // currently scheduled one, (re)schedule so it fires on time.
+            long deadline = newQueueItem.getTimeoutDeadlineMillis();
+            if (deadline > 0 && (nextTimeoutDeadline == 0 || deadline < nextTimeoutDeadline)) {
+                scheduleTimeoutAt(deadline);
+            }
         }
     }
 
@@ -1562,7 +1620,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         // Invalidate cached candidates so waiting jobs re-evaluate with current labels
         cachedCandidates.invalidateAll();
 
-        // Process waiting pipeline jobs
+        // Process waiting pipeline jobs (also handles timeouts)
         synchronized (syncResources) {
             while (proceedNextContext()) {
                 // process as many contexts as possible
@@ -1571,6 +1629,61 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
         // Notify Jenkins queue for freestyle jobs
         scheduleQueueMaintenance();
+    }
+
+    // ---------------------------------------------------------------------------
+    /**
+     * Checks for timed-out entries in the pipeline lock queue and fails them.
+     * Called by {@link org.jenkins.plugins.lockableresources.queue.LockWaitTimeoutPeriodicWork}
+     * as a safety net.
+     */
+    @Restricted(NoExternalUse.class)
+    public void checkTimeouts() {
+        synchronized (syncResources) {
+            // proceedNextContext → getNextQueuedContext handles timeouts + rescheduling
+            while (proceedNextContext()) {
+                // process as many contexts as possible
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    /**
+     * Schedules (or reschedules) the single timeout task to fire at the given
+     * deadline. If {@code deadline} is {@link Long#MAX_VALUE} the current task
+     * is cancelled and nothing new is scheduled.
+     * Must be called while holding {@link #syncResources}.
+     */
+    private void scheduleTimeoutAt(long deadline) {
+        // Cancel the current task — we will either replace it or clear it
+        if (nextTimeoutTask != null) {
+            nextTimeoutTask.cancel(false);
+            nextTimeoutTask = null;
+            nextTimeoutDeadline = 0;
+        }
+
+        if (deadline == Long.MAX_VALUE || deadline <= 0) {
+            return;
+        }
+
+        nextTimeoutDeadline = deadline;
+        // Small buffer so the deadline has definitely passed when we check
+        long delayMs = Math.max(0, deadline - System.currentTimeMillis()) + 500L;
+        LOGGER.fine("Scheduling timeout check in " + delayMs + "ms");
+        nextTimeoutTask = jenkins.util.Timer.get()
+                .schedule(
+                        () -> {
+                            LOGGER.fine("Scheduled timeout check fired");
+                            synchronized (syncResources) {
+                                nextTimeoutDeadline = 0;
+                                nextTimeoutTask = null;
+                                while (proceedNextContext()) {
+                                    // process as many contexts as possible
+                                }
+                            }
+                        },
+                        delayMs,
+                        java.util.concurrent.TimeUnit.MILLISECONDS);
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RequiredResourcesProperty.java
@@ -17,6 +17,7 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -26,6 +27,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -37,6 +39,17 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
     private final String resourceNumber;
     private final String labelName;
     private final @CheckForNull SecureGroovyScript resourceMatchScript;
+
+    /**
+     * Timeout for waiting to acquire the resource, in the specified {@link #lockTimeoutUnit}.
+     * 0 means no timeout (wait indefinitely).
+     */
+    private long lockTimeout = 0;
+
+    /**
+     * Time unit for {@link #lockTimeout}. Defaults to MINUTES.
+     */
+    private String lockTimeoutUnit = "MINUTES";
 
     @DataBoundConstructor
     public RequiredResourcesProperty(
@@ -142,6 +155,24 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
     @CheckForNull
     public SecureGroovyScript getResourceMatchScript() {
         return resourceMatchScript;
+    }
+
+    public long getLockTimeout() {
+        return lockTimeout;
+    }
+
+    @DataBoundSetter
+    public void setLockTimeout(long lockTimeout) {
+        this.lockTimeout = lockTimeout;
+    }
+
+    public String getLockTimeoutUnit() {
+        return lockTimeoutUnit;
+    }
+
+    @DataBoundSetter
+    public void setLockTimeoutUnit(String lockTimeoutUnit) {
+        this.lockTimeoutUnit = lockTimeoutUnit;
     }
 
     @Extension
@@ -331,6 +362,16 @@ public class RequiredResourcesProperty extends JobProperty<Job<?, ?>> {
             } else {
                 Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             }
+        }
+
+        @RequirePOST
+        public ListBoxModel doFillLockTimeoutUnitItems(@AncestorInPath Item item) {
+            checkPermission(item);
+            ListBoxModel items = new ListBoxModel();
+            items.add("Seconds", "SECONDS");
+            items.add("Minutes", "MINUTES");
+            items.add("Hours", "HOURS");
+            return items;
         }
     }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockWaitTimeoutException.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockWaitTimeoutException.java
@@ -1,0 +1,18 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.queue;
+
+/**
+ * Exception thrown when a lock step times out waiting for resource allocation.
+ */
+public class LockWaitTimeoutException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public LockWaitTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockWaitTimeoutPeriodicWork.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockWaitTimeoutPeriodicWork.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.queue;
+
+import hudson.Extension;
+import hudson.model.PeriodicWork;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+
+/**
+ * Periodic work that checks for timed-out lock queue entries.
+ *
+ * <p>This runs every 15 seconds to check if any queued pipeline contexts have exceeded
+ * their {@code timeoutForAllocateResource}. Without this, timed-out entries would only
+ * be detected when resources are freed (which might never happen if all resources are
+ * permanently busy).
+ */
+@Extension
+public class LockWaitTimeoutPeriodicWork extends PeriodicWork {
+
+    private static final Logger LOGGER = Logger.getLogger(LockWaitTimeoutPeriodicWork.class.getName());
+
+    @Override
+    public long getRecurrencePeriod() {
+        return 15_000L; // 15 seconds
+    }
+
+    @Override
+    protected void doRun() {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        if (lrm.getCurrentQueuedContext().isEmpty()) {
+            return;
+        }
+        LOGGER.log(Level.FINEST, "Checking for timed-out lock queue entries");
+        lrm.checkTimeouts();
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -21,12 +21,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -35,6 +37,9 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     private transient Cache<Long, Date> lastLogged =
             Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).build();
+
+    /** Tracks the deadline (epoch millis) for each queue item waiting for resources. */
+    private final transient ConcurrentHashMap<Long, Long> deadlines = new ConcurrentHashMap<>();
 
     static final Logger LOGGER = Logger.getLogger(LockableResourcesQueueTaskDispatcher.class.getName());
 
@@ -122,21 +127,64 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 
             if (selected != null) {
                 LOGGER.finest(project.getName() + " reserved resources " + selected);
+                deadlines.remove(item.getId());
                 return null;
             } else {
                 LOGGER.finest(project.getName() + " waiting for resources");
+                CauseOfBlockage timeout = checkFreestyleTimeout(item, project);
+                if (timeout != null) return timeout;
                 return new BecauseResourcesLocked(resources);
             }
 
         } else {
             if (LockableResourcesManager.get().queue(resources.required, item.getId(), project.getFullDisplayName())) {
                 LOGGER.finest(project.getName() + " reserved resources " + resources.required);
+                deadlines.remove(item.getId());
                 return null;
             } else {
                 LOGGER.finest(project.getName() + " waiting for resources " + resources.required);
+                CauseOfBlockage timeout = checkFreestyleTimeout(item, project);
+                if (timeout != null) return timeout;
                 return new BecauseResourcesLocked(resources);
             }
         }
+    }
+
+    /**
+     * Checks whether a freestyle queue item has exceeded the configured lock timeout.
+     * If timed out, the item is cancelled from the Jenkins queue.
+     *
+     * @return a {@link BecauseResourcesTimeout} if timed out, {@code null} otherwise
+     */
+    private CauseOfBlockage checkFreestyleTimeout(Queue.Item item, Job<?, ?> project) {
+        RequiredResourcesProperty prop = project.getProperty(RequiredResourcesProperty.class);
+        if (prop == null || prop.getLockTimeout() <= 0) {
+            return null;
+        }
+
+        long now = System.currentTimeMillis();
+        long deadline = deadlines.computeIfAbsent(item.getId(), k -> {
+            long timeoutMillis;
+            try {
+                timeoutMillis = TimeUnit.valueOf(prop.getLockTimeoutUnit()).toMillis(prop.getLockTimeout());
+            } catch (IllegalArgumentException e) {
+                timeoutMillis = TimeUnit.MINUTES.toMillis(prop.getLockTimeout());
+            }
+            return now + timeoutMillis;
+        });
+
+        if (now >= deadline) {
+            LOGGER.log(Level.INFO, "{0} timed out waiting for lockable resources (timeout: {1} {2})", new Object[] {
+                project.getFullName(),
+                prop.getLockTimeout(),
+                prop.getLockTimeoutUnit().toLowerCase(java.util.Locale.ENGLISH)
+            });
+            deadlines.remove(item.getId());
+            // Cancel the queue item
+            jenkins.model.Jenkins.get().getQueue().cancel(item);
+            return new BecauseResourcesTimeout(project.getFullName(), prop.getLockTimeout(), prop.getLockTimeoutUnit());
+        }
+        return null;
     }
 
     public static class BecauseResourcesLocked extends CauseOfBlockage {
@@ -194,6 +242,28 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
             String resourceInfo =
                     resources.label.isEmpty() ? resources.required.toString() : "with label " + resources.label;
             return "Execution failed while acquiring the resource " + resourceInfo + ". " + cause.getMessage();
+        }
+    }
+
+    // Only for UI
+    @Restricted(NoExternalUse.class)
+    public static class BecauseResourcesTimeout extends CauseOfBlockage {
+
+        private final String projectName;
+        private final long timeout;
+        private final String timeoutUnit;
+
+        public BecauseResourcesTimeout(String projectName, long timeout, String timeoutUnit) {
+            this.projectName = projectName;
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+        }
+
+        @Override
+        public String getShortDescription() {
+            return projectName + " cancelled: timed out after " + timeout + " "
+                    + timeoutUnit.toLowerCase(java.util.Locale.ENGLISH)
+                    + " waiting for lockable resources";
         }
     }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/QueuedContextStruct.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -53,6 +54,24 @@ public class QueuedContextStruct implements Serializable {
 
     private int priority = 0;
 
+    /*
+     * Timeout for waiting to acquire the resource, in the specified timeoutUnit.
+     * 0 means no timeout (wait indefinitely).
+     */
+    private long timeoutForAllocateResource = 0;
+
+    /*
+     * Time unit for the timeout. Defaults to MINUTES.
+     */
+    private String timeoutUnit = "MINUTES";
+
+    /*
+     * Pre-computed absolute deadline (epoch millis) when this entry times out.
+     * 0 means no timeout. Calculated once at construction time to avoid
+     * repeated TimeUnit.valueOf() + toMillis() on every queue check.
+     */
+    private long timeoutDeadlineMillis = 0;
+
     // cached candidates
     public transient List<String> candidates = null;
 
@@ -70,11 +89,11 @@ public class QueuedContextStruct implements Serializable {
             String resourceDescription,
             String variableName,
             int priority) {
-        this(context, lockableResourcesStruct, resourceDescription, variableName, priority, null);
+        this(context, lockableResourcesStruct, resourceDescription, variableName, priority, null, 0, "MINUTES");
     }
 
     /*
-     * Constructor for the QueuedContextStruct class with reason.
+     * Constructor for the QueuedContextStruct class with reason and timeout.
      */
     @Restricted(NoExternalUse.class)
     public QueuedContextStruct(
@@ -83,14 +102,29 @@ public class QueuedContextStruct implements Serializable {
             String resourceDescription,
             String variableName,
             int priority,
-            String reason) {
+            String reason,
+            long timeoutForAllocateResource,
+            String timeoutUnit) {
         this.context = context;
         this.lockableResourcesStruct = lockableResourcesStruct;
         this.resourceDescription = resourceDescription;
         this.variableName = variableName;
         this.priority = priority;
         this.reason = reason;
+        this.timeoutForAllocateResource = timeoutForAllocateResource;
+        this.timeoutUnit = timeoutUnit != null ? timeoutUnit : "MINUTES";
         this.id = UUID.randomUUID().toString();
+
+        // Pre-compute deadline once to avoid repeated calculation on every queue check
+        if (timeoutForAllocateResource > 0) {
+            try {
+                TimeUnit unit = TimeUnit.valueOf(this.timeoutUnit);
+                this.timeoutDeadlineMillis = System.currentTimeMillis() + unit.toMillis(timeoutForAllocateResource);
+            } catch (IllegalArgumentException e) {
+                LOGGER.warning("Invalid timeoutUnit '" + this.timeoutUnit + "', timeout disabled");
+                this.timeoutDeadlineMillis = 0;
+            }
+        }
     }
 
     @Restricted(NoExternalUse.class)
@@ -173,6 +207,42 @@ public class QueuedContextStruct implements Serializable {
      */
     public String getVariableName() {
         return this.variableName;
+    }
+
+    /**
+     * Checks whether this queued context has exceeded its allocation timeout.
+     * Uses a pre-computed deadline for performance since this is called on every queue check.
+     *
+     * @return true if a timeout was set and has expired, false otherwise
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isTimedOut() {
+        return timeoutDeadlineMillis > 0 && System.currentTimeMillis() > timeoutDeadlineMillis;
+    }
+
+    /**
+     * Returns the pre-computed deadline (epoch millis) when this entry times out.
+     * 0 means no timeout is configured.
+     */
+    @Restricted(NoExternalUse.class)
+    public long getTimeoutDeadlineMillis() {
+        return this.timeoutDeadlineMillis;
+    }
+
+    /**
+     * Returns the configured timeout for resource allocation.
+     */
+    @Restricted(NoExternalUse.class)
+    public long getTimeoutForAllocateResource() {
+        return this.timeoutForAllocateResource;
+    }
+
+    /**
+     * Returns the time unit for the allocation timeout.
+     */
+    @Restricted(NoExternalUse.class)
+    public String getTimeoutUnit() {
+        return this.timeoutUnit;
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.jelly
@@ -28,6 +28,12 @@
   <f:entry title="${%entry.priority.title}" field="priority">
     <f:number/>
   </f:entry>
+  <f:entry title="${%entry.timeoutForAllocateResource.title}" field="timeoutForAllocateResource">
+    <f:number default="0"/>
+  </f:entry>
+  <f:entry title="${%entry.timeoutUnit.title}" field="timeoutUnit">
+    <f:select/>
+  </f:entry>
   <f:entry title="${%entry.extra.title}">
     <f:repeatable field="extra" header="" minimum="0" add="${%entry.extra.add}">
       <table width="100%">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/config.properties
@@ -29,5 +29,7 @@ entry.inversePrecedence.checkbox.title=Inverse precedence
 entry.skipIfLocked.title=Skip if locked
 entry.priority.title=Queue priority
 entry.resourceSelectStrategy.title=Strategy for resource selection
+entry.timeoutForAllocateResource.title=Timeout for resource allocation
+entry.timeoutUnit.title=Timeout unit
 entry.extra.title=Extra resources
 entry.extra.add=Add Resource

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-timeoutForAllocateResource.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-timeoutForAllocateResource.html
@@ -1,0 +1,9 @@
+<div>
+  <p>
+    Maximum time (in the specified time unit) to wait for a resource to become available.
+  </p>
+  <p>
+    If the resource is not acquired within this time, the pipeline step will fail with a timeout error.
+    Set to 0 (the default) to wait indefinitely.
+  </p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-timeoutUnit.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockStep/help-timeoutUnit.html
@@ -1,0 +1,8 @@
+<div>
+  <p>
+    The time unit for the resource allocation timeout.
+  </p>
+  <p>
+    Allowed values: SECONDS, MINUTES, HOURS. Default is MINUTES.
+  </p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.jelly
@@ -28,6 +28,12 @@
       <f:entry title="${%entry.resourceNumber.title}" field="resourceNumber">
         <f:textbox/>
       </f:entry>
+      <f:entry title="${%entry.lockTimeout.title}" field="lockTimeout">
+        <f:number default="0"/>
+      </f:entry>
+      <f:entry title="${%entry.lockTimeoutUnit.title}" field="lockTimeoutUnit">
+        <f:select/>
+      </f:entry>
     </f:nested>
   </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/config.properties
@@ -26,3 +26,5 @@ entry.labelName.title=Label
 optionalProperty.resourceMatchScript.title=Groovy Expression
 entry.resourceNamesVar.title=Reserved resources variable name
 entry.resourceNumber.title=Number of resources to request
+entry.lockTimeout.title=Lock wait timeout
+entry.lockTimeoutUnit.title=Timeout unit

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-lockTimeout.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-lockTimeout.html
@@ -1,0 +1,9 @@
+<div>
+  <p>
+    Maximum time (in the specified time unit) to wait for a resource to become available.
+  </p>
+  <p>
+    If the resource is not acquired within this time, the build will be cancelled from the queue.
+    Set to 0 (the default) to wait indefinitely.
+  </p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-lockTimeoutUnit.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RequiredResourcesProperty/help-lockTimeoutUnit.html
@@ -1,0 +1,8 @@
+<div>
+  <p>
+    The time unit for the lock wait timeout.
+  </p>
+  <p>
+    Allowed values: SECONDS, MINUTES, HOURS. Default is MINUTES.
+  </p>
+</div>

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleTimeoutTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleTimeoutTest.java
@@ -1,0 +1,163 @@
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.triggers.TimerTrigger;
+import hudson.util.OneShotEvent;
+import java.util.concurrent.TimeUnit;
+import org.jenkins.plugins.lockableresources.util.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FreeStyleTimeoutTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
+    }
+
+    /**
+     * A freestyle job with a short lockTimeout should be cancelled from the queue
+     * when the resource is not freed in time.
+     */
+    @Test
+    void freestyleLockTimeoutCancelsQueueItem(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A grabs the resource and holds it
+        FreeStyleProject jobA = j.createFreeStyleProject("jobA");
+        jobA.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
+        SemaphoreBuilder builderA = new SemaphoreBuilder();
+        jobA.getBuildersList().add(builderA);
+
+        QueueTaskFuture<FreeStyleBuild> futureA = jobA.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+        // Wait until jobA is actually running (has left the queue and locked the resource)
+        TestHelpers.waitForQueue(j.jenkins, jobA);
+        builderA.started.block(5000);
+        assertTrue(builderA.started.isSignaled(), "jobA should have started");
+
+        // Job B: 3-second timeout
+        FreeStyleProject jobB = j.createFreeStyleProject("jobB");
+        RequiredResourcesProperty prop = new RequiredResourcesProperty("resource1", null, null, null, null);
+        prop.setLockTimeout(3);
+        prop.setLockTimeoutUnit("SECONDS");
+        jobB.addProperty(prop);
+        jobB.getBuildersList().add(new NoopBuilder());
+
+        jobB.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+        TestHelpers.waitForQueue(j.jenkins, jobB);
+
+        // Poll until the queue item for jobB is cancelled (timeout: 30s to handle slow CI)
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (j.jenkins.getQueue().getItem(jobB) != null) {
+            assertTrue(
+                    System.currentTimeMillis() < deadline,
+                    "jobB should have been removed from the queue after timeout");
+            Thread.sleep(500);
+        }
+
+        // Release jobA
+        builderA.release();
+        FreeStyleBuild buildA = futureA.get(30, TimeUnit.SECONDS);
+        j.assertBuildStatusSuccess(buildA);
+    }
+
+    /**
+     * A freestyle job with lockTimeout=0 (default) waits indefinitely.
+     */
+    @Test
+    void freestyleNoTimeoutWaitsIndefinitely(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A grabs the resource
+        FreeStyleProject jobA = j.createFreeStyleProject("jobA");
+        jobA.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
+        SemaphoreBuilder builderA = new SemaphoreBuilder();
+        jobA.getBuildersList().add(builderA);
+
+        QueueTaskFuture<FreeStyleBuild> futureA = jobA.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+        TestHelpers.waitForQueue(j.jenkins, jobA);
+        builderA.started.block(5000);
+
+        // Job B: no timeout → should stay in queue
+        FreeStyleProject jobB = j.createFreeStyleProject("jobB");
+        jobB.addProperty(new RequiredResourcesProperty("resource1", null, null, null, null));
+        jobB.getBuildersList().add(new NoopBuilder());
+
+        jobB.scheduleBuild2(0, new TimerTrigger.TimerTriggerCause());
+        TestHelpers.waitForQueue(j.jenkins, jobB);
+
+        // Wait a bit and verify jobB is still in the queue
+        Thread.sleep(2000);
+        assertNotNull(j.jenkins.getQueue().getItem(jobB), "jobB should still be in the queue (no timeout)");
+
+        // Release jobA → jobB should proceed
+        builderA.release();
+        FreeStyleBuild buildA = futureA.get(30, TimeUnit.SECONDS);
+        j.assertBuildStatusSuccess(buildA);
+
+        // Wait for B to complete
+        j.waitUntilNoActivity();
+        FreeStyleBuild buildB = jobB.getLastBuild();
+        assertNotNull(buildB, "jobB should have run after jobA released the resource");
+        assertEquals(Result.SUCCESS, buildB.getResult());
+    }
+
+    /**
+     * Config round-trip: lockTimeout and lockTimeoutUnit survive save/reload.
+     */
+    @Test
+    void configRoundTripWithTimeout(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        FreeStyleProject p = j.createFreeStyleProject("withTimeout");
+        RequiredResourcesProperty prop = new RequiredResourcesProperty("resource1", null, null, null, null);
+        prop.setLockTimeout(5);
+        prop.setLockTimeoutUnit("MINUTES");
+        p.addProperty(prop);
+
+        FreeStyleProject roundTripped = j.configRoundtrip(p);
+        RequiredResourcesProperty rtProp = roundTripped.getProperty(RequiredResourcesProperty.class);
+        assertNotNull(rtProp);
+        assertEquals("resource1", rtProp.getResourceNames());
+        assertEquals(5, rtProp.getLockTimeout());
+        assertEquals("MINUTES", rtProp.getLockTimeoutUnit());
+    }
+
+    private static class SemaphoreBuilder extends TestBuilder {
+        final OneShotEvent started = new OneShotEvent();
+        private final OneShotEvent event = new OneShotEvent();
+
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException {
+            started.signal();
+            event.block();
+            return true;
+        }
+
+        void release() {
+            event.signal();
+        }
+    }
+
+    private static class NoopBuilder extends TestBuilder {
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepTimeoutTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepTimeoutTest.java
@@ -1,0 +1,217 @@
+package org.jenkins.plugins.lockableresources;
+
+import hudson.model.Result;
+import org.jenkins.plugins.lockableresources.util.Constants;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class LockStepTimeoutTest extends LockStepTestBase {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
+    }
+
+    /**
+     * A pipeline that waits for a resource with a short timeout should fail
+     * when the resource is never released.
+     */
+    @Test
+    void lockTimeoutExpires(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A grabs the resource and holds it via semaphore
+        WorkflowJob jobA = j.jenkins.createProject(WorkflowJob.class, "jobA");
+        jobA.setDefinition(new CpsFlowDefinition("""
+                lock('resource1') {
+                    semaphore 'hold-lock'
+                }
+                """, true));
+        WorkflowRun runA = jobA.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("hold-lock/1", runA);
+
+        // Job B tries to lock with a 3-second timeout
+        WorkflowJob jobB = j.jenkins.createProject(WorkflowJob.class, "jobB");
+        jobB.setDefinition(new CpsFlowDefinition("""
+                lock(resource: 'resource1', timeoutForAllocateResource: 3, timeoutUnit: 'SECONDS') {
+                    echo 'Should never reach here'
+                }
+                """, true));
+        WorkflowRun runB = jobB.scheduleBuild2(0).waitForStart();
+
+        // Wait for B to enter the queue
+        j.waitForMessage("[Resource: resource1] is not free, waiting for execution ... (timeout: 3 seconds)", runB);
+
+        // B should fail after the timeout
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(runB));
+        j.assertLogContains("timed out waiting for resource allocation after 3 seconds", runB);
+        j.assertLogNotContains("Should never reach here", runB);
+
+        // Release A so it finishes cleanly
+        SemaphoreStep.success("hold-lock/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(runA));
+    }
+
+    /**
+     * A pipeline with timeoutForAllocateResource=0 (default) waits indefinitely
+     * until the resource is freed.
+     */
+    @Test
+    void lockNoTimeoutWaitsIndefinitely(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A grabs the resource
+        WorkflowJob jobA = j.jenkins.createProject(WorkflowJob.class, "jobA");
+        jobA.setDefinition(new CpsFlowDefinition("""
+                lock('resource1') {
+                    semaphore 'hold-lock'
+                }
+                """, true));
+        WorkflowRun runA = jobA.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("hold-lock/1", runA);
+
+        // Job B: no timeout → waits until resource is free
+        WorkflowJob jobB = j.jenkins.createProject(WorkflowJob.class, "jobB");
+        jobB.setDefinition(new CpsFlowDefinition("""
+                lock(resource: 'resource1', timeoutForAllocateResource: 0) {
+                    echo 'Got the lock'
+                }
+                echo 'Finish'
+                """, true));
+        WorkflowRun runB = jobB.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("is not free, waiting for execution ...", runB);
+
+        // Release A → B should proceed
+        SemaphoreStep.success("hold-lock/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(runA));
+        j.assertBuildStatusSuccess(j.waitForCompletion(runB));
+        j.assertLogContains("Got the lock", runB);
+    }
+
+    /**
+     * A pipeline with a timeout that gets the resource in time should succeed.
+     */
+    @Test
+    void lockTimeoutSucceedsWhenResourceFreedInTime(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A grabs the resource
+        WorkflowJob jobA = j.jenkins.createProject(WorkflowJob.class, "jobA");
+        jobA.setDefinition(new CpsFlowDefinition("""
+                lock('resource1') {
+                    semaphore 'hold-lock'
+                }
+                """, true));
+        WorkflowRun runA = jobA.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("hold-lock/1", runA);
+
+        // Job B: generous timeout
+        WorkflowJob jobB = j.jenkins.createProject(WorkflowJob.class, "jobB");
+        jobB.setDefinition(new CpsFlowDefinition("""
+                lock(resource: 'resource1', timeoutForAllocateResource: 5, timeoutUnit: 'MINUTES') {
+                    echo 'Got the lock in time'
+                }
+                echo 'Finish'
+                """, true));
+        WorkflowRun runB = jobB.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("[Resource: resource1] is not free, waiting for execution ... (timeout: 5 minutes)", runB);
+
+        // Release A quickly → B succeeds within its timeout
+        SemaphoreStep.success("hold-lock/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(runA));
+        j.assertBuildStatusSuccess(j.waitForCompletion(runB));
+        j.assertLogContains("Got the lock in time", runB);
+        j.assertLogNotContains("timed out", runB);
+    }
+
+    /**
+     * Timeout with label-based resource locking.
+     */
+    @Test
+    void lockTimeoutWithLabel(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResourceWithLabel("resource1", "label1");
+
+        // Job A grabs all resources with label1
+        WorkflowJob jobA = j.jenkins.createProject(WorkflowJob.class, "jobA");
+        jobA.setDefinition(new CpsFlowDefinition("""
+                lock(label: 'label1', quantity: 1) {
+                    semaphore 'hold-lock'
+                }
+                """, true));
+        WorkflowRun runA = jobA.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("hold-lock/1", runA);
+
+        // Job B tries label lock with short timeout
+        WorkflowJob jobB = j.jenkins.createProject(WorkflowJob.class, "jobB");
+        jobB.setDefinition(new CpsFlowDefinition("""
+                lock(label: 'label1', quantity: 1, timeoutForAllocateResource: 3, timeoutUnit: 'SECONDS') {
+                    echo 'Should not reach here'
+                }
+                """, true));
+        WorkflowRun runB = jobB.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("is not free, waiting for execution ... (timeout: 3 seconds)", runB);
+
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(runB));
+        j.assertLogContains("timed out waiting for resource allocation after 3 seconds", runB);
+
+        SemaphoreStep.success("hold-lock/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(runA));
+    }
+
+    /**
+     * Multiple queued jobs with different timeouts: the one with shorter timeout
+     * fails first, the one with no timeout eventually gets the resource.
+     */
+    @Test
+    void multipleJobsDifferentTimeouts(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("resource1");
+
+        // Job A holds the lock
+        WorkflowJob jobA = j.jenkins.createProject(WorkflowJob.class, "jobA");
+        jobA.setDefinition(new CpsFlowDefinition("""
+                lock('resource1') {
+                    semaphore 'hold-lock'
+                }
+                """, true));
+        WorkflowRun runA = jobA.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("hold-lock/1", runA);
+
+        // Job B: short timeout → will fail
+        WorkflowJob jobB = j.jenkins.createProject(WorkflowJob.class, "jobB");
+        jobB.setDefinition(new CpsFlowDefinition("""
+                lock(resource: 'resource1', timeoutForAllocateResource: 3, timeoutUnit: 'SECONDS') {
+                    echo 'B got the lock'
+                }
+                """, true));
+        WorkflowRun runB = jobB.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("[Resource: resource1] is not free, waiting for execution ... (timeout: 3 seconds)", runB);
+
+        // Job C: no timeout → will wait and eventually succeed
+        WorkflowJob jobC = j.jenkins.createProject(WorkflowJob.class, "jobC");
+        jobC.setDefinition(new CpsFlowDefinition("""
+                lock('resource1') {
+                    echo 'C got the lock'
+                }
+                echo 'C Finish'
+                """, true));
+        WorkflowRun runC = jobC.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("[Resource: resource1] is not free, waiting for execution ...", runC); // no timeout info
+
+        // B fails after timeout
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(runB));
+        j.assertLogContains("timed out waiting for resource allocation", runB);
+
+        // Release A → C should get the resource
+        SemaphoreStep.success("hold-lock/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(runA));
+        j.assertBuildStatusSuccess(j.waitForCompletion(runC));
+        j.assertLogContains("C got the lock", runC);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 	imeoutForAllocateResource and 	imeoutUnit parameters to the lock() pipeline step, and lockTimeout/lockTimeoutUnit to freestyle job resource configuration (RequiredResourcesProperty).

When a timeout is set and the resource is not acquired within the specified duration:
- **Pipeline jobs**: the build fails with a LockWaitTimeoutException
- **Freestyle jobs**: the queue item is cancelled

## Implementation

- LockStep: new 	imeoutForAllocateResource (long, default 0) and 	imeoutUnit (String, default MINUTES) fields with @DataBoundSetter
- LockStepExecution: passes timeout to queueContext(); extended log message shows timeout info
- QueuedContextStruct: pre-computes 	imeoutDeadlineMillis at construction; isTimedOut() is a single comparison
- LockableResourcesManager: single ScheduledFuture targeting the earliest deadline; getNextQueuedContext() removes timed-out entries (same as orphans) and reschedules for the next deadline; LockWaitTimeoutPeriodicWork (15s) as safety-net fallback
- RequiredResourcesProperty: new lockTimeout/lockTimeoutUnit fields
- LockableResourcesQueueTaskDispatcher: checkFreestyleTimeout() with pre-computed deadlines per queue item

## Testing

- LockStepTimeoutTest: 5 tests (timeout expires, no timeout waits, timeout succeeds when freed in time, label-based timeout, multiple jobs with different timeouts)
- FreeStyleTimeoutTest: 3 tests (timeout cancels queue item, no timeout waits, config round-trip)
- Manual testing confirmed

## Documentation

- [lock-with-timeout.md](src/doc/examples/lock-with-timeout.md): pipeline scripted/declarative examples, label-based, freestyle usage, timeout values table

Fixes #866
Fixes #849
Fixes #30