### PR TITLE
Remove redundant queue maintenance on build completion/deletion

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -111,7 +111,6 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
         }
         LOGGER.info(build.getFullDisplayName());
         LockableResourcesManager.get().unlockBuild(build);
-        LockableResourcesManager.scheduleQueueMaintenance();
     }
 
     @Override
@@ -123,6 +122,5 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
         }
         LOGGER.info(build.getFullDisplayName());
         LockableResourcesManager.get().unlockBuild(build);
-        LockableResourcesManager.scheduleQueueMaintenance();
     }
 }


### PR DESCRIPTION
<!-- Link related issue(s): Fixes #XXXXX or See JENKINS-XXXXX -->

### What does this PR do?

<!-- Brief description of the change. The PR title is used as the changelog entry. -->
Do not schedule queue maintenance after build completion/deletion if no lockable resources had to be unlocked. As queue maintenance is automatically scheduled when unlockResources actually unlocks something, there is no need to explicitly trigger it in the LockRunListener.

### Testing done

<!-- How was this tested? Automated tests, manual steps, screenshots, etc. -->

### Checklist

- [ ] Automated tests added or existing tests cover the change
- [x] PR title is a clear, imperative-mood changelog entry
- [ ] Breaking changes or upgrade steps are documented below
