### PR TITLE
fix: Use PAT for Dependabot auto-merge to trigger downstream workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,4 +17,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
When Dependabot PRs are merged using \secrets.GITHUB_TOKEN\, the resulting push does not trigger \on: push\ workflows (by design). This means \ebase-open-prs.yml\ is never triggered for Dependabot merges, leaving other open PRs out of date.

Switch to \secrets.GH_TOKEN\ (the existing PAT) so that the merge push triggers downstream workflows like rebase-open-prs.