### PR TITLE
fix: Show proper empty message instead of 'Loading' for empty DataTables

### DIFF
--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -40,6 +40,7 @@ THE SOFTWARE.
         data-table-configuration='
         {
           "stateSave": true,
+          "language": { "emptyTable": "${%table.empty}" },
           "lengthMenu": [
             [10, 25, 50, 100, -1],
             [10, 25, 50, 100, "${%table.settings.page.length.all}"]

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
@@ -28,3 +28,4 @@ labels.free.tooltip={0} % free
 
 # Table settings
 table.settings.page.length.all=ALL
+table.empty=No labels configured

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
@@ -64,6 +64,7 @@ THE SOFTWARE.
       data-table-configuration='
       {
         "stateSave": true,
+        "language": { "emptyTable": "${%table.empty}" },
         "lengthMenu": [
           [10, 25, 50, 100, -1],
           [10, 25, 50, 100, "${%table.settings.page.length.all}"]

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
@@ -38,6 +38,7 @@ queue.table.column.reason=Reason
 queue.table.column.priority=Queue priority
 queue.table.column.action=Action
 queue.table.column.id=Queue ID
+table.empty=No entries in the queue
 
 #status
 resource.status.locked=<strong class="jenkins-!-warning-color">Locked</strong> by <a class="jenkins-table__link model-link jenkins-table__badge" href="{0}">{1}</a>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -53,6 +53,7 @@ THE SOFTWARE.
         ],
         "order": [ 0, "asc" ],
         "stateSave": true,
+        "language": { "emptyTable": "${%table.empty}" },
         "lengthMenu": [
           [10, 25, 50, 100, -1],
           [10, 25, 50, 100, "${%table.settings.page.length.all}"]

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -68,3 +68,4 @@ btn.editNote.detail=Edit resource note.
 
 # Table settings
 table.settings.page.length.all=ALL
+table.empty=No resources configured

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
@@ -60,6 +60,7 @@ THE SOFTWARE.
             data-table-configuration='
             {
               "stateSave": true,
+              "language": { "emptyTable": "${%table.empty}" },
               "lengthMenu": [
                 [10, 25, 50, 100, -1],
                 [10, 25, 50, 100, "${%table.settings.page.length.all}"]

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.properties
@@ -29,3 +29,4 @@ table.column.step=Step
 table.column.timeStamp=Timestamp
 table.column.action=Action
 table.settings.page.length.all=ALL
+table.empty=No resources were used by this build


### PR DESCRIPTION
﻿When a DataTable has 0 entries (e.g. empty queue tab, or a build that used no lockable resources), the data-tables-api plugin displays its default emptyTable language string: **Loading - please wait ...** which never changes because inline-data tables skip the AJAX load path.

## Fix

Override the language.emptyTable string in data-table-configuration for the two affected tables:

- **Queue table**: "No entries in the queue"
- **Build action table**: "No resources were used by this build"

Tables that already guard against empty state with j:if (resources, labels) are not affected.

Fixes #706
