### PR TITLE
Fix ConcurrentModificationException in getDeclaredResources and getResourcesFromProject

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -161,13 +161,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
     /** Get declared resources, means only defined in config file (xml or JCaC yaml). */
     @Restricted(NoExternalUse.class)
     public List<LockableResource> getDeclaredResources() {
-        ArrayList<LockableResource> declaredResources = new ArrayList<>();
-        for (LockableResource r : this.getResources()) {
-            if (!r.isEphemeral() && !r.isNodeResource()) {
-                declaredResources.add(r);
+        synchronized (syncResources) {
+            ArrayList<LockableResource> declaredResources = new ArrayList<>();
+            for (LockableResource r : this.resources) {
+                if (!r.isEphemeral() && !r.isNodeResource()) {
+                    declaredResources.add(r);
+                }
             }
+            return declaredResources;
         }
-        return declaredResources;
     }
 
     // ---------------------------------------------------------------------------
@@ -231,14 +233,16 @@ public class LockableResourcesManager extends GlobalConfiguration {
     /** Get all resources used by project. */
     @Restricted(NoExternalUse.class)
     public List<LockableResource> getResourcesFromProject(String fullName) {
-        List<LockableResource> matching = new ArrayList<>();
-        for (LockableResource r : this.getResources()) {
-            String rName = r.getQueueItemProject();
-            if (rName != null && rName.equals(fullName)) {
-                matching.add(r);
+        synchronized (syncResources) {
+            List<LockableResource> matching = new ArrayList<>();
+            for (LockableResource r : this.resources) {
+                String rName = r.getQueueItemProject();
+                if (rName != null && rName.equals(fullName)) {
+                    matching.add(r);
+                }
             }
+            return matching;
         }
-        return matching;
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes ConcurrentModificationException reported in [JENKINS-64127](https://issues.jenkins.io/browse/JENKINS-64127) / #933.

Two methods in LockableResourcesManager iterated over the esources list without synchronization, while other threads could modify it concurrently:

- \getDeclaredResources()\ — called from CasC/config
- \getResourcesFromProject()\ — called from \LockRunListener\

### Fix

Wrap both methods in \synchronized(syncResources)\ and iterate over \	his.resources\ directly (instead of \	his.getResources()\ which returns an unprotected reference).

### Analysis

The original issue listed 10 methods. Of those:
- 6 were already fixed in previous releases (using \synchronized(syncResources)\ or \getReadOnlyResources()\)
- \getResourcesFromBuild()\ was removed entirely
- \checkCurrentResourcesStatus()\ is private and only called from within an existing \synchronized(syncResources)\ block in \	ryQueue()\
- **2 remained vulnerable**: \getDeclaredResources()\ and \getResourcesFromProject()\ — fixed in this PR

### Testing

Existing tests cover both methods (\ConfigurationAsCodeTest\, \LockRunListener\ integration tests). All pass.

Fixes #933