### PR TITLE
fix: Make BecauseResourcesTimeout fatal to fix freestyle lock timeout on Jenkins 2.532+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.528</jenkins.baseline>
+    <jenkins.baseline>2.541</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.effort>Max</spotbugs.effort>
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>6329.v403d8c87a_5ce</version>
+        <version>6364.v16b_76a_4023c7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -265,5 +265,15 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
                     + timeoutUnit.toLowerCase(java.util.Locale.ENGLISH)
                     + " waiting for lockable resources";
         }
+
+        /**
+         * Signals that this blockage is fatal and the queue item should be removed.
+         * Since Jenkins 2.532 (core PR #11173), the queue checks this flag and
+         * cancels the item itself instead of re-adding it as a {@code BlockedItem}.
+         */
+        @Override
+        public boolean isFatal() {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Jenkins 2.532 (core PR jenkinsci/jenkins#11173) changed `Queue.maintain()` to create a **new** `BlockedItem` instead of updating the existing one when `canRun()` returns a `CauseOfBlockage`. This caused the manual `Queue.cancel()` in `checkFreestyleTimeout()` to be immediately undone, so the freestyle lock timeout never actually removed the queue item.

## Fix
- Override `isFatal()` returning `true` on `BecauseResourcesTimeout`, so the queue itself handles the cancellation via the new mechanism.
- Bump Jenkins baseline from 2.528 to 2.541 (the next LTS line that includes the `isFatal()` API from core PR #11173).
- Update BOM to `6364.v16b_76a_4023c7` (latest for bom-2.541.x).

The existing manual `Queue.cancel()` call in `checkFreestyleTimeout` is kept as belt-and-suspenders.

Fixes #1026