### PR TITLE
Improve lockable resources UI tables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 # Contributing
 
 If you want to contribute to this plugin, you probably will need a Jenkins plugin development
-environment. This basically means a current version of Java (Java 11 should probably be okay for now)
+environment. This basically means a current version of Java (Java 17+)
 and [Apache Maven]. See the [Jenkins Plugin Tutorial] for details.
 You could also go the [GitPod](https://gitpod.io/#https://github.com/jenkinsci/lockable-resources-plugin) way.
 
@@ -28,17 +28,30 @@ local changes before committing.
 ## Code Style
 
 This plugin tries to migrate to [Google Java Code Style], please try to adhere to that style
-whenever adding new files or making big changes to existing files. If your IDE doesn't support
-this style, you can use the [fmt-maven-plugin], like this:
+whenever adding new files or making big changes to existing files.
+
+Formatting is enforced by the build via Spotless (configured by the Jenkins plugin parent POM).
+To verify formatting locally:
 
 ```sh
-    mvn fmt:format -DfilesNamePattern=ChangedFile\.java
+mvn -DskipTests spotless:check
+```
+
+To auto-format the code:
+
+```sh
+mvn -DskipTests spotless:apply
+```
+
+Tip: to format just a subset of files, Spotless supports `-DspotlessFiles=...` (path or glob), e.g.:
+
+```sh
+mvn -DskipTests -DspotlessFiles=src/main/java/**/ChangedFile.java spotless:apply
 ```
 
 to reformat Java code in the proper style.
 
 [Google Java Code Style]: https://google.github.io/styleguide/javaguide.html
-[fmt-maven-plugin]: https://github.com/coveo/fmt-maven-plugin
 
 ## Code coverage
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,23 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>org.jenkins-ci</groupId>
+              <artifactId>annotation-indexer</artifactId>
+              <version>1.18</version>
+            </path>
+            <path>
+              <groupId>net.java.sezpoz</groupId>
+              <artifactId>sezpoz</artifactId>
+              <version>1.13</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,42 @@
           <injectedTestPackage>org.jenkins.plugins.lockableresources</injectedTestPackage>
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>backup-sezpoz-extension-index</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.directory}/sezpoz-extension-index" />
+                <copy failonerror="false" overwrite="true" todir="${project.build.directory}/sezpoz-extension-index">
+                  <fileset dir="${project.build.outputDirectory}/META-INF/annotations" erroronmissingdir="false" />
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>restore-sezpoz-extension-index</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.outputDirectory}/META-INF/annotations" />
+                <copy failonerror="false" overwrite="true" todir="${project.build.outputDirectory}/META-INF/annotations">
+                  <fileset dir="${project.build.directory}/sezpoz-extension-index" erroronmissingdir="false" />
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/refactor-plan.md
+++ b/refactor-plan.md
@@ -1,0 +1,1130 @@
+# Lockable Resources Manager Refactoring Plan
+
+**Created:** 2026-04-14  
+**Status:** Brainstorming / Planning  
+**Related Issue:** To be created
+
+ATENTION: THIS DOCUMENT MUST BE REMOVED BEFORE WE MERGE THE CHAMGES INTO MASTER BRANCH
+
+
+---
+
+## Table of Contents
+
+1. [Current Architecture](#current-architecture)
+2. [Identified Problems](#identified-problems)
+3. [Proposed Solutions](#proposed-solutions)
+4. [Groups Concept](#groups-concept)
+5. [Resource Pages](#resource-pages)
+6. [Folder-Scoped Resources](#folder-scoped-resources)
+7. [Node Integration & lockNode() Step](#node-integration--locknode-step)
+8. [Multi-Instance Synchronization](#multi-instance-synchronization)
+9. [New APIs](#new-apis)
+10. [Migration Strategy](#migration-strategy)
+11. [Implementation Phases](#implementation-phases)
+12. [Open Questions](#open-questions)
+13. [AI Engineering](#ai-engineering)
+14. [Session Notes](#session-notes)
+
+---
+
+## Current Architecture
+
+### Core Data Structure
+
+```java
+// LockableResourcesManager.java (line 60)
+private List<LockableResource> resources;
+
+// Candidate cache per queue item (line 63)
+private final transient Cache<Long, List<LockableResource>> cachedCandidates =
+    CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
+```
+
+### How Resources Are Found
+
+1. **By Name** - `fromName(String resourceName)` - O(n) linear scan
+2. **By Label** - `getResourcesWithLabel(String label)` - O(n) linear scan  
+3. **By Script** - `getResourcesMatchingScript()` - O(n) with Groovy evaluation
+
+### Synchronization
+
+All operations use a single global lock:
+```java
+public static final Object syncResources = new Object();
+```
+
+### Typical Scale
+
+- Small installations: ~50 resources
+- Large installations: 100-1000 resources
+- Heavy users: 1000+ resources, 1000+ queue items
+
+---
+
+## Identified Problems
+
+### 1. O(n) Lookups
+Every `fromName()` call iterates through all resources. With 1000 resources and frequent lookups, this adds up.
+
+### 2. No Resource Grouping
+All resources are in a flat list. Users with different teams/projects cannot organize resources logically.
+
+### 3. Label Expression Complexity
+Label expressions like `(ABC && DD) || !HH` require full scan - cannot be indexed efficiently.
+
+### 4. No Resource Statistics
+No built-in way to track:
+- How often a resource is locked
+- Average lock duration
+- Queue wait times
+- Which jobs use which resources
+
+### 5. No Resource Detail Page
+Unlike Jenkins nodes (`/computer/<nodeName>`), resources have no dedicated page with history/config.
+
+### 6. Single Global Lock
+All operations go through `syncResources`, potential bottleneck at scale.
+
+### 7. Performance at Scale
+Performance must be a first-class concern throughout the refactoring:
+- `proceedNextContext()` iterates the full queue on every unlock — O(queue × resources)
+- `uncacheIfFreeing()` iterates all cache entries to find affected ones
+- Groovy-based resource matching (`resourceMatchScript`) is expensive per evaluation
+- Saving the full config on every lock/unlock generates I/O pressure at high throughput
+- No profiling or benchmarking harness exists today to measure regressions
+
+Every new feature (groups, node integration, multi-instance sync) must be evaluated
+for its impact on hot paths.
+
+### 8. No Multi-Instance Support ([#321](https://github.com/jenkinsci/lockable-resources-plugin/issues/321))
+Large environments run multiple Jenkins controllers. Resources locked on
+`jenkins1` are invisible to `jenkins2`, leading to conflicts when both
+controllers share the same physical equipment.
+
+### 9. No Native Node Integration
+In many use cases, lockable resources represent Jenkins **nodes** (agents).
+Today users must manually create a lockable resource for each node and keep
+the names / labels in sync. There is no built-in way to say
+"lock the node, not just a virtual resource."
+
+---
+
+## Proposed Solutions
+
+### Phase 1: Add Name Index (Low Risk)
+
+Add a `ConcurrentHashMap` index for O(1) name lookup:
+
+```java
+// Alongside existing list
+private List<LockableResource> resources;
+
+// New index - always in sync with list
+private final ConcurrentHashMap<String, LockableResource> resourcesByName = new ConcurrentHashMap<>();
+```
+
+**Benefits:**
+- `fromName()` becomes O(1)
+- Backward compatible - list still exists for iteration
+- No config file changes
+
+**Implementation:**
+```java
+public LockableResource fromName(String name) {
+    return resourcesByName.get(name);
+}
+
+// Keep index in sync
+public boolean addResource(LockableResource resource) {
+    synchronized (syncResources) {
+        if (resourcesByName.containsKey(resource.getName())) {
+            return false;
+        }
+        resources.add(resource);
+        resourcesByName.put(resource.getName(), resource);
+        // ...
+    }
+}
+```
+
+### Phase 2: Label Index (Medium Risk)
+
+Add index for single-label lookups:
+
+```java
+// Map: label -> Set of resources with that label
+private final ConcurrentHashMap<String, Set<LockableResource>> resourcesByLabel = new ConcurrentHashMap<>();
+```
+
+**Note:** This only helps simple label queries. Complex expressions like `(A && B) || !C` still need full scan.
+
+### Phase 3: Replace Guava Cache with Caffeine (Low Risk)
+
+```java
+// Current (Guava)
+private final Cache<Long, List<LockableResource>> cachedCandidates =
+    CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
+
+// Proposed (Caffeine) - better performance, same API
+private final Cache<Long, List<LockableResource>> cachedCandidates =
+    Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
+```
+
+---
+
+## Performance Strategy
+
+### Principles
+
+1. **Measure first** — add a JMH or Jenkins-benchmark harness before optimizing.
+2. **Profile hot paths** — `proceedNextContext()`, `tryLock()`, `queueContext()`,
+   `uncacheIfFreeing()`, `save()` are the most frequent callers under load.
+3. **Budget per feature** — every new feature (groups, node integration,
+   multi-instance sync) must document its expected cost on the hot path.
+4. **Regression gate** — CI should run a lightweight load scenario and fail if
+   median lock-cycle time regresses by more than 10%.
+
+### Concrete Targets
+
+| Area | Current | Target |
+|------|---------|--------|
+| `fromName()` | O(n) scan | O(1) via name index |
+| `getResourcesWithLabel()` | O(n) scan | O(1) for single labels via label index |
+| `uncacheIfFreeing()` | O(cache size) | O(1) via reverse index (resource → cache keys) |
+| `save()` under contention | Sync write per event | Coalesced async write (already exists, verify effective) |
+| Queue processing | O(queue × resources) | Evaluate read-write lock, partitioned queues |
+| Groovy script matching | Costly per call | Cache script compilation, limit evaluation frequency |
+
+---
+
+## Groups Concept
+
+### Motivation
+
+Teams/projects want isolated resource pools:
+- Team A has PLC resources
+- Team B has printers
+- Common pool for shared resources
+
+### Proposed API
+
+```groovy
+// Lock from specific group
+lock(group: 'plc', label: 'S7') {
+    // ...
+}
+
+// Default group is 'common'
+lock(label: 'printer') {
+    // Equivalent to: group: 'common', label: 'printer'
+}
+
+// Lock from any group (explicit)
+lock(group: '*', label: 'S7')
+```
+
+### Data Model
+
+```java
+public class ResourceGroup {
+    private String name;
+    private String description;
+    private List<LockableResource> resources;
+    // Optional: access control, quotas
+}
+
+public class LockableResourcesManager {
+    // Replace flat list with groups
+    private Map<String, ResourceGroup> groups = new ConcurrentHashMap<>();
+    
+    // Convenience: all resources (computed view)
+    public List<LockableResource> getResources() {
+        return groups.values().stream()
+            .flatMap(g -> g.getResources().stream())
+            .collect(Collectors.toList());
+    }
+}
+```
+
+### UI Changes
+
+- Group selector in resource configuration
+- Group filter on resources page
+- Group statistics
+
+### Config File Changes
+
+**Current format:**
+```xml
+<org.jenkins.plugins.lockableresources.LockableResourcesManager>
+  <resources>
+    <resource>
+      <name>resource1</name>
+      <labels>S7 plc</labels>
+    </resource>
+  </resources>
+</org.jenkins.plugins.lockableresources.LockableResourcesManager>
+```
+
+**New format:**
+```xml
+<org.jenkins.plugins.lockableresources.LockableResourcesManager>
+  <groups>
+    <group>
+      <name>plc</name>
+      <description>PLC test equipment</description>
+      <resources>
+        <resource>
+          <name>resource1</name>
+          <labels>S7</labels>
+        </resource>
+      </resources>
+    </group>
+    <group>
+      <name>common</name>
+      <resources>
+        <!-- migrated resources without explicit group -->
+      </resources>
+    </group>
+  </groups>
+</org.jenkins.plugins.lockableresources.LockableResourcesManager>
+```
+
+---
+
+## Resource Pages
+
+### Inspiration
+
+Jenkins nodes have dedicated pages at `/computer/<nodeName>` with:
+- Current status
+- History
+- Configuration
+- Statistics
+
+### Proposed URL Structure
+
+```
+/lockable-resources/                     # Main listing (existing)
+/lockable-resources/<resourceName>/      # Resource detail page (new)
+/lockable-resources/<resourceName>/configure  # Configuration (new)
+/lockable-resources/<resourceName>/history    # Lock history (new)
+```
+
+### Resource Detail Page Content
+
+1. **Status Panel**
+   - Current state (free/locked/reserved/queued)
+   - Current holder (build link or user)
+   - Lock duration
+   - Labels, description, properties
+
+2. **History Table** (persisted)
+   - Last N lock events
+   - Timestamp, duration, build/user, outcome
+   
+3. **Statistics**
+   - Total lock count
+   - Average lock duration
+   - Average queue wait time
+   - Top 10 jobs by usage
+
+4. **Actions**
+   - Reserve/Unreserve
+   - Steal
+   - Reset
+   - Configure (link)
+
+### Data Storage for History
+
+Option A: Append to resource XML (simple, grows unbounded)
+```xml
+<resource>
+  <name>resource1</name>
+  <history>
+    <event>
+      <timestamp>2026-04-14T10:30:00</timestamp>
+      <type>LOCK</type>
+      <build>job/test/42</build>
+      <duration>PT5M30S</duration>
+    </event>
+  </history>
+</resource>
+```
+
+Option B: Separate history file per resource (better scaling)
+```
+work/lockable-resources/
+  history/
+    resource1.json
+    resource2.json
+```
+
+Option C: Use Jenkins fingerprint system (complex but integrated)
+
+---
+
+## Folder-Scoped Resources
+
+### Issue
+
+[#186](https://github.com/jenkinsci/lockable-resources-plugin/issues/186) /
+[JENKINS-51725](https://issues.jenkins.io/browse/JENKINS-51725) /
+[JENKINS-49004](https://issues.jenkins.io/browse/JENKINS-49004)
+
+### Motivation
+
+Large Jenkins installations use the Folders plugin (`cloudbees-folder`) to
+organize jobs by team or project. Folder admins should be able to manage their
+own lockable resources without requiring global Jenkins admin rights — the same
+way credentials are scoped to folders today.
+
+### How It Fits with Groups
+
+Folder-scoped resources are a **natural extension of the Groups concept**:
+
+- A **Group** is a logical collection of resources (e.g. "plc", "printers").
+- A **Folder scope** determines *where* a group is visible.
+- Combining both: a group can be defined at global level OR at a folder level.
+- Resources in a folder-scoped group are only visible to jobs inside that
+  folder (and its children), following the same hierarchy-walk pattern as
+  credentials.
+
+```
+Jenkins (global)
+├── Group: "common"          ← visible to all jobs
+├── Group: "shared-printers" ← visible to all jobs
+│
+├── Folder: TeamA/
+│   ├── Group: "plc"         ← visible only to TeamA/* jobs
+│   └── Folder: SubTeam/
+│       └── (inherits TeamA's "plc" group + global groups)
+│
+└── Folder: TeamB/
+    └── Group: "plc"         ← separate "plc", visible only to TeamB/*
+```
+
+### Architecture Design
+
+#### Extension Point: `AbstractFolderProperty`
+
+Follow the proven pattern used by credentials, Kubernetes plugin, HashiCorp
+Vault plugin, etc.:
+
+```java
+@Extension
+@OptionalDependency("com.cloudbees.hudson.plugins.folder")
+public class LockableResourcesFolderProperty
+        extends AbstractFolderProperty<AbstractFolder<?>> {
+
+    private List<ResourceGroup> groups = new ArrayList<>();
+
+    // Folder admins can configure lockable resource groups here
+    public List<ResourceGroup> getGroups() { return groups; }
+
+    @Extension
+    public static class DescriptorImpl
+            extends AbstractFolderPropertyDescriptor { }
+}
+```
+
+#### Resource Resolution: Hierarchy Walk
+
+When `lock()` is called, resolve resources by walking up the folder tree
+(like `CredentialsProvider.listCredentialsInItem()`):
+
+```java
+public List<LockableResource> resolveResources(
+        Run<?, ?> run, String group, String label) {
+
+    List<LockableResource> result = new ArrayList<>();
+    ItemGroup<?> parent = run.getParent().getParent();
+
+    // Walk up the folder hierarchy
+    while (parent != null) {
+        if (parent instanceof AbstractFolder<?> folder) {
+            LockableResourcesFolderProperty prop =
+                folder.getProperties()
+                      .get(LockableResourcesFolderProperty.class);
+            if (prop != null) {
+                result.addAll(prop.getMatchingResources(group, label));
+            }
+        }
+        parent = (parent instanceof Item item)
+            ? item.getParent() : null;
+    }
+
+    // Finally, check global resources
+    result.addAll(
+        LockableResourcesManager.get().getMatchingResources(group, label));
+
+    return result;
+}
+```
+
+#### Scope Enum on ResourceGroup
+
+```java
+public enum ResourceScope {
+    GLOBAL,  // visible everywhere (current behavior)
+    FOLDER   // visible only to jobs in this folder and children
+}
+```
+
+#### Optional Dependency
+
+`cloudbees-folder` must be an **optional** dependency so the plugin still
+works without it. Use `@OptionalDependency` or guard with
+`Jenkins.get().getPlugin("cloudbees-folder") != null`.
+
+```xml
+<!-- pom.xml -->
+<dependency>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>cloudbees-folder</artifactId>
+    <optional>true</optional>
+</dependency>
+```
+
+### Pipeline DSL Changes
+
+```groovy
+// Existing — resolves from global + inherited folder groups
+lock(label: 'S7') { ... }
+
+// With explicit group — resolves group "plc" walking up hierarchy
+lock(group: 'plc', label: 'S7') { ... }
+
+// Explicit scope override — only look at the current folder
+lock(group: 'plc', label: 'S7', scope: 'folder') { ... }
+
+// Global only — skip folder hierarchy
+lock(group: 'plc', label: 'S7', scope: 'global') { ... }
+```
+
+### UI Changes
+
+1. **Folder configuration page** — new "Lockable Resources" section under
+   folder properties (similar to "Folder Credentials"):
+   - Add/remove resource groups
+   - Add/remove resources within groups
+   - Folder admins (not just Jenkins admins) can manage
+
+2. **Global configuration** — unchanged, continues to manage global groups
+
+3. **Resource listing page** — show scope indicator (global/folder path)
+   for each resource
+
+### Permissions
+
+Leverage Jenkins folder-level permissions:
+- `Item.CONFIGURE` on a folder → can manage that folder's lockable resources
+- Global `Jenkins.ADMINISTER` → can manage global resources (unchanged)
+- No new permission types needed initially
+
+### Ephemeral Resources
+
+When a `lock('nonexistent')` creates an ephemeral resource, where does it go?
+- **Default:** global level (preserves current behavior)
+- **Future option:** `lock('name', createIn: 'folder')` to create in the
+  calling job's nearest folder scope
+- **Configurable default** via folder property: "Create ephemeral resources
+  in this folder's scope"
+
+### Name Uniqueness
+
+- Resource names must be **unique within a scope** (folder or global)
+- Resources in different folder scopes CAN have the same name
+- Resolution order (closest scope wins): current folder → parent folder →
+  ... → global
+- If ambiguous, `lock()` takes the first match walking up the hierarchy
+- Users can disambiguate with `scope: 'global'` or `scope: 'folder'`
+
+### Open Questions (Folder Scoping)
+
+1. **Cross-folder locking?** Can a job in FolderA lock a resource defined
+   in FolderB? Credentials say no. Same approach recommended.
+
+2. **Move semantics?** When a job is moved between folders, its locks
+   should be re-evaluated. What happens to active locks?
+
+3. **Folder deletion?** When a folder is deleted, its scoped resources
+   should be cleaned up. Need `AbstractFolder` lifecycle hooks.
+
+4. **Should folder-scoped resources appear in the global listing?**
+   Admin might want a full view. Consider a "show all scopes" toggle.
+
+5. **Lock contention across scopes?** Two identically-named resources in
+   different scopes are independent — no contention. Is this intuitive?
+
+---
+
+## Node Integration & lockNode() Step
+
+### Motivation
+
+In most industrial use cases, lockable resources represent **physical nodes**
+(test rigs, PLCs, lab machines). Users must today:
+1. Define a Jenkins agent for the node
+2. Separately create a lockable resource with a matching name
+3. Keep labels in sync manually
+
+This is error-prone and redundant. The plugin should natively understand
+Jenkins nodes.
+
+### Proposed `lockNode()` Step
+
+A new pipeline step with clear semantics — "lock this node exclusively":
+
+```groovy
+// Lock by node name
+lockNode('lab-plc-07') {
+    echo "Running on exclusive node"
+}
+
+// Lock by node label (picks one free node)
+lockNode(label: 'S7-1500', quantity: 1) {
+    node(env.LOCKED_NODE) {
+        echo "Running on ${env.NODE_NAME}"
+    }
+}
+
+// Combine with existing resource labels
+lockNode(label: 'S7-1500', resourceLabel: 'plc', quantity: 1) {
+    echo "Node + resource locked"
+}
+```
+
+**Why a new step instead of extending `lock()`?**
+- Clearer intent: users immediately understand they are locking a *node*
+- Avoids overloading `lock()` with yet more parameters
+- Can provide node-specific environment variables (`LOCKED_NODE`, `LOCKED_NODE_LABEL`)
+- Can leverage Jenkins node availability checks (online/offline)
+
+**Multi-node locking with parallel execution (decided):**
+- When `quantity > 1`, all locked nodes receive the closure as **parallel stages**
+- Offline node handling:
+  - Prefer online nodes first when selecting candidates
+  - Provide an option to exclude offline nodes entirely
+
+### Implementation Options
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| A. Mirror node labels into lockable resource labels | `NodesMirror` already does this partially | Low effort, backward compatible | Still two separate lists |
+| B. First-class node reference on `LockableResource` | Add `nodeName` field, auto-resolve from `Computer` | Single source of truth | Migration needed |
+| C. `lockNode()` delegates to `lock()` internally | New step is syntactic sugar | Quick to implement | Might confuse users (two steps, same queue) |
+| D. Separate node-lock queue | Independent of `lock()` queue | Clean separation | Duplicated locking logic |
+
+**Recommendation:** Start with **Option C** (syntactic sugar) to validate UX,
+then consider **Option B** for deeper integration.
+
+### Node Labels vs Resource Labels
+
+Jenkins already has a label system for nodes (`label: 'linux && x86_64'`).
+We should support **both** independently:
+
+| Feature | Node label | Resource label |
+|---------|-----------|----------------|
+| Defined on | Jenkins agent configuration | Lockable resource configuration |
+| Expression syntax | Same (Jenkins `Label` class) | Same |
+| Use case | Hardware capabilities | Logical grouping |
+| Example | `S7-1500 && linux` | `plc production` |
+
+```groovy
+// Lock a node that matches BOTH a node label AND a resource label
+lockNode(nodeLabel: 'S7-1500 && linux', resourceLabel: 'production') {
+    // ...
+}
+```
+
+---
+
+## Multi-Instance Synchronization
+
+### Problem ([#321](https://github.com/jenkinsci/lockable-resources-plugin/issues/321))
+
+Large environments run multiple Jenkins controllers sharing the same physical
+equipment. Resource state is local to each instance — there is no coordination.
+
+### Architecture Options
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A. REST API (lockable-master)** | Designate one instance as "lockable-master"; slaves call its REST API before acquiring a lock | Simple concept, leverages existing Jenkins API | Single point of failure, network latency on every lock |
+| **B. Shared database backend** | Replace XML config with a shared DB (PostgreSQL, Redis) | Strong consistency, proven technology | Heavy dependency, operational burden |
+| **C. Distributed lock service** | Use etcd / ZooKeeper / Consul for lock coordination | Battle-tested distributed locking | External dependency, complex setup |
+| **D. Peer-to-peer REST** | Each instance exposes a lock-status API; peers poll or push state | No central component | Consistency is hard, split-brain risk |
+
+### Analysis of REST API Approach (Option A)
+
+Original proposal from #321: a "lockable-master" instance holds the
+authoritative state; "lockable-slave" instances interact via HTTP POST.
+
+**Flow:**
+1. `lockable-slave` checks local state — if resource is in use locally, wait
+2. Send lock request to `lockable-master` REST API
+3. If `lockable-master` returns 409 (conflict) → poll/retry
+4. On success → acquire lock locally, run closure
+5. On unlock → POST unlock to `lockable-master`, then free locally
+
+**Concerns:**
+- What happens when `lockable-master` is down? (need fallback / timeout policy)
+- Latency on every lock/unlock adds up under load
+- State can drift if network partitions occur
+- Need heartbeat / lease mechanism to avoid stale locks
+
+**Verdict:** REST API is a reasonable **starting point** because it requires
+no external infrastructure. But it should be designed with a pluggable
+`LockBackend` interface so the backend can later be swapped to a DB or
+distributed lock service.
+
+### Proposed Abstraction
+
+```java
+public interface LockBackend {
+    /** Try to acquire. Returns true if granted. */
+    boolean tryAcquire(String resourceName, String owner, Duration timeout);
+
+    /** Release a previously acquired lock. */
+    void release(String resourceName, String owner);
+
+    /** Query current state. */
+    LockState getState(String resourceName);
+
+    /** Health check. */
+    boolean isAvailable();
+}
+
+// Implementations:
+// - LocalLockBackend       (current behavior, default)
+// - RestMasterLockBackend  (Option A)
+// - DatabaseLockBackend    (Option B, future)
+```
+
+---
+
+## New APIs
+
+### Resource Status API
+
+```java
+// Simple check - is resource completely free?
+public boolean isFree(String resourceName);
+
+// Detailed status
+public ResourceStatus getStatus(String resourceName);
+
+public enum ResourceState {
+    FREE,
+    LOCKED,
+    RESERVED,
+    QUEUED,
+    LOCKED_AND_RESERVED  // stolen case
+}
+
+public class ResourceStatus {
+    ResourceState state;
+    Run<?, ?> build;        // if locked
+    String reservedBy;       // if reserved
+    long queueItemId;        // if queued
+    Date stateChangedAt;
+}
+```
+
+### Statistics API
+
+```java
+public ResourceStats getStats(String resourceName);
+public Map<String, ResourceStats> getStats(String group, String label, ResourceState state);
+
+public class ResourceStats {
+    int lockCount;
+    Duration totalLockTime;
+    Duration avgLockTime;
+    Duration avgQueueTime;
+    Map<String, Integer> lockCountByJob;  // job -> count
+}
+```
+
+### Pipeline Steps
+
+```groovy
+// Check if resource is free (non-blocking)
+def free = lockableResource.isFree('resource1')
+
+// Get resource info
+def info = lockableResource.getInfo('resource1')
+echo "State: ${info.state}, Labels: ${info.labels}"
+
+// Get statistics
+def stats = lockableResource.getStats('resource1')
+echo "Locked ${stats.lockCount} times, avg duration: ${stats.avgLockTime}"
+```
+
+---
+
+## Migration Strategy
+
+### Principles
+
+1. **Automatic migration** - old config loads into new structure seamlessly
+2. **No user action required** - plugin handles upgrade transparently
+3. **Backward compatible save** - consider if older plugin version needs to read
+
+### Migration Code Pattern
+
+```java
+@Override
+public void load() {
+    // Read raw XML
+    XmlFile configFile = getConfigFile();
+    
+    if (configFile.exists()) {
+        Object loaded = configFile.read();
+        
+        if (needsMigration(loaded)) {
+            migrateConfig(loaded);
+            save(); // Write new format
+        }
+    }
+}
+
+private boolean needsMigration(Object config) {
+    // Check for old format markers:
+    // - Has <resources> but no <groups>
+    // - Version field < current version
+    return true; // simplified
+}
+
+private void migrateConfig(Object oldConfig) {
+    // Move all resources to 'common' group
+    ResourceGroup common = new ResourceGroup("common");
+    for (LockableResource r : extractOldResources(oldConfig)) {
+        common.addResource(r);
+    }
+    this.groups.put("common", common);
+}
+```
+
+### Version Field
+
+Add explicit version for future migrations:
+```java
+private int configVersion = 2; // Bump on each breaking change
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Name Index (1-2 days) ✅ Safe to implement
+- Add `resourcesByName` ConcurrentHashMap
+- Update `fromName()` to use index
+- Update add/remove operations to maintain index
+- No config changes, fully backward compatible
+- Write tests
+
+### Phase 2: Resource Pages (1 week)
+- Create LockableResourcePage class (Stapler routable)
+- Add URL routing `/lockable-resources/<name>/`
+- Design detail page layout
+- Implement history storage (start simple)
+- Add basic statistics
+
+### Phase 3: Statistics Collection (3-4 days)
+- Add event tracking on lock/unlock
+- Implement stats aggregation
+- Add stats API
+- Integrate with resource page
+
+### Phase 4: Groups (1-2 weeks) ⚠️ Breaking change
+- Design group data model
+- Implement group management UI
+- Add migration logic
+- Update lock step to support `group:` parameter
+- Update all existing tests
+- Write migration tests
+- Update documentation
+
+### Phase 4b: Folder-Scoped Resources ([#186](https://github.com/jenkinsci/lockable-resources-plugin/issues/186)) (1-2 weeks)
+- Depends on Phase 4 (Groups)
+- Add `cloudbees-folder` as optional dependency
+- Implement `LockableResourcesFolderProperty` (extends `AbstractFolderProperty`)
+- Implement hierarchy-walk resource resolution in `LockStepExecution`
+- Add folder configuration UI (Jelly) for managing folder-scoped groups
+- Add `scope` parameter to `LockStep`
+- Handle ephemeral resource creation in folder context
+- Ensure name uniqueness rules per scope
+- Write integration tests with JenkinsRule + folder hierarchy
+- Document folder-scoping in `src/doc/examples/`
+
+### Phase 5: Performance Optimizations
+- Add benchmarking harness (JMH or integration-level load test)
+- Replace Guava with Caffeine
+- Add label index
+- Add reverse cache index (resource → cache keys) for O(1) `uncacheIfFreeing()`
+- Consider read-write lock instead of single mutex
+- Profile and optimize `proceedNextContext()` hot loop
+- Benchmark at scale — define regression gate for CI
+
+### Phase 6: Node Integration & `lockNode()` Step ⏸️ Low Priority
+- Implement `lockNode()` step as syntactic sugar over `lock()`
+- Add node-specific environment variables (`LOCKED_NODE`)
+- Validate UX with real users
+- Evaluate deeper integration (Option B: `nodeName` field on `LockableResource`)
+- **Decision:** Low priority. May be implemented in a Groovy shared library
+  first. When done as a plugin feature, dependency management works from
+  scratch. Revisit when other phases are complete.
+
+### Phase 7: Multi-Instance Synchronization ([#321](https://github.com/jenkinsci/lockable-resources-plugin/issues/321)) ⏸️ Deferred
+- Define `LockBackend` interface
+- Implement `LocalLockBackend` (current behavior, default)
+- Implement `RestMasterLockBackend` (REST API to a master instance)
+- Add configuration UI for backend selection and master URL
+- Handle failure modes (master down, network partition, stale locks)
+- Write integration tests with two Jenkins instances
+- **Decision:** Skipped for now. Will be implemented in a later cycle.
+
+### Phase 8: AI Engineering
+- Publish APM skills for plugin developers (Microsoft Copilot skill format)
+- Publish APM cookbook skills for plugin users (pipeline recipes)
+- Maintain `.github/copilot-instructions.md` as living context
+- Evaluate AI-assisted resource management (predictive lock scheduling)
+
+---
+
+## Open Questions
+
+### Groups
+
+1. **Should groups have access control?**
+   - E.g., only certain users/jobs can lock resources in a group
+   - Adds complexity but valuable for multi-tenant scenarios
+   - **Decision: Yes.** Access control is needed for groups.
+
+2. **Can a resource belong to multiple groups?**
+   - Simpler: No, exactly one group
+   - Flexible: Yes, like tags
+   - **Decision: Single group.** A resource belongs to exactly one group.
+
+3. **Default group name?**
+   - Options: `common`, `default`, `global`, `_default_`
+   - Must be valid in pipelines: `group: 'global'`
+   - **Decision: `global`.**
+
+4. **How to handle ephemeral resources?**
+   - Create in same group as trigger?
+   - Always in `common`?
+   - Configurable default group?
+   - **Decision:** Start with a dedicated group called `ephemeral`.
+     Later, allow creating ephemeral resources in any group.
+
+### Resource Pages
+
+5. **History retention policy?**
+   - Keep last N events per resource?
+   - Age-based: delete events older than X days?
+   - Configurable per-resource or global setting?
+
+6. **Statistics computation?**
+   - Real-time (computed on page load)?
+   - Pre-aggregated (updated on events)?
+   - Hybrid (recent real-time, old aggregated)?
+
+**Dashboard enhancements (decided):**
+- The main `/lockable-resources/` page is now a dashboard (left: resources,
+  right: queue).
+- Add a **queue size timeline chart** (last 24 hours) to the dashboard.
+- The same chart should also appear at `/lockable-resources/queue/timeLine`
+  as a dedicated sub-page.
+- The `/lockable-resources/labels` page should include a **label expression
+  filter** supporting boolean expressions, e.g. `LabelA && !LabelB && LabelC`.
+
+### Label Expressions
+
+7. **Can we optimize complex expressions?**
+   - `(A && B) || !C` requires understanding all labels
+   - Partial index possible: if expression references single label, use index
+   - Parser to detect simple vs. complex expressions?
+
+### Breaking Changes
+
+8. **How to communicate breaking changes?**
+   - Release notes
+   - Upgrade guide
+   - In-UI warning before upgrade?
+   - Separate major version (3.0)?
+   - **Decision:** Communicate via Release notes AND Upgrade guide.
+
+### Node Integration
+
+9. **Should `lockNode()` be a separate step or an extension of `lock()`?**
+   - Separate step: clearer semantics, easier docs
+   - Extension: single entry point, less API surface
+   - **Decision: Separate step.**
+
+10. **How to handle offline nodes?**
+    - Skip offline nodes when selecting candidates?
+    - Wait for node to come online (with timeout)?
+    - Make behavior configurable?
+
+11. **Should node labels and resource labels be unified?**
+    - Unified: simpler mental model
+    - Separate: more flexible, avoids namespace collisions
+    - Recommendation: keep separate but allow combining in `lockNode()`
+
+### Multi-Instance Sync
+
+12. **Which backend should be the default?**
+    - `LocalLockBackend` (current behavior) — safest default
+    - Must be opt-in to avoid breaking existing setups
+
+13. **How to handle master unavailability?**
+    - Fail-open (allow lock, risk conflicts)
+    - Fail-closed (block, wait for master)
+    - Configurable with timeout
+
+14. **Lock lease / TTL?**
+    - Stale locks from crashed instances need automatic expiration
+    - TTL-based lease with periodic renewal?
+
+### Performance
+
+15. **What is the benchmarking baseline?**
+    - Need to establish current lock-cycle latency (p50, p95, p99)
+    - Need to measure at 100, 500, 1000 resources with 100+ queue items
+    - Should run as part of CI (lightweight variant)
+
+16. **Read-write lock vs single mutex?**
+    - Many operations are read-only (status checks, UI rendering)
+    - `ReadWriteLock` could allow concurrent reads
+    - Risk: harder to reason about, potential subtle bugs
+
+---
+
+## AI Engineering
+
+### Vision
+
+Leverage AI tooling in two directions:
+
+1. **AI for plugin developers** — help contributors understand the codebase,
+   write correct code, and follow conventions.
+2. **AI for plugin users** — help Jenkins administrators and pipeline authors
+   use lockable resources effectively.
+
+### APM Skills for Plugin Developers
+
+Publish reusable skills (Microsoft Copilot APM format) that encode:
+- Codebase conventions (from `.github/copilot-instructions.md`)
+- Common patterns (locking lifecycle, queue processing, test structure)
+- Architecture decisions and rationale
+- Debugging guides (synchronization issues, cache behavior)
+
+Example skill topics:
+- "How to add a new pipeline step parameter"
+- "How the lock queue works"
+- "Writing a JenkinsRule integration test for this plugin"
+- "How `syncResources` synchronization works"
+
+### APM Cookbook for Plugin Users
+
+Publish recipe-style skills for Jenkins pipeline authors:
+- "Lock a resource with timeout" (the #740 pattern)
+- "Lock multiple resources atomically"
+- "Use inversePrecedence for priority builds"
+- "Lock a node exclusively with `lockNode()`" (future)
+- "Dynamic resource pool expansion"
+- "Scripted vs Declarative lock patterns"
+
+These recipes map directly to `src/doc/examples/` and can be kept in sync.
+
+### Maintaining AI Context
+
+- Keep `.github/copilot-instructions.md` up to date with every PR
+- Consider adding `ARCHITECTURE.md` for deeper context
+- Tag key design decisions in code comments for AI discoverability
+- Evaluate GitHub Copilot Workspace for contributor onboarding
+
+---
+
+## Session Notes (2026-04-14)
+
+### What We Learned
+
+1. **Cache Invalidation Pattern**
+   - Current `uncacheIfFreeing()` invalidates cache entries containing freed resources
+   - Must iterate all cache entries to find affected ones
+   - With 1000+ queue items, this becomes expensive
+   - Fixed in #892: only invalidate entries that actually contain the resource
+
+2. **Label Expression Complexity**
+   - Labels can be complex boolean expressions: `(ABC && DD) || !HH`
+   - Cannot simply index by label - need to evaluate expression
+   - Current approach: cache candidates per queueItemId
+   - Cache key: queueItemId (Long)
+   - Cache invalidated when resource freed
+
+3. **Synchronization Challenges**
+   - `syncResources` lock held during many operations
+   - `scheduleQueueMaintenance()` must be called OUTSIDE sync block
+   - Potential deadlock: plugin lock + Jenkins queue lock
+
+4. **Ephemeral Resources**
+   - Resources created dynamically when locked by name but don't exist
+   - Marked with `ephemeral = true`
+   - Auto-deleted when unlocked
+   - New setting `allowEphemeralResources` (default: true)
+
+5. **Stolen Resources**
+   - Resource can be "stolen" from build to user
+   - Both locked AND reserved
+   - Complex state to track
+
+### Issue Triage Summary
+
+From the 2014-2017 cleanup session:
+
+| Category | Issues | Notes |
+|----------|--------|-------|
+| Timeout feature | #30, #849, #866 | Add `lockTimeOut` label, likely duplicates |
+| Matrix builds | #828, #834 | Need clarification, complex use case |
+| Inverse precedence | #861, #864 | Feature exists, needs more tests |
+| Approved | #844, #847, #858 | Ready for implementation, in Milestone 5 |
+| Implemented | #838, #856 | Closed - features already exist |
+
+### Configuration Files
+
+- Main config: `work/org.jenkins.plugins.lockableresources.LockableResourcesManager.xml`
+- Async save: coalesced writes with 1000ms delay (configurable)
+- BulkChange support for batch updates
+
+### Useful System Properties
+
+```
+org.jenkins.plugins.lockableresources.DISABLE_SAVE=true  # Disable saving
+org.jenkins.plugins.lockableresources.ASYNC_SAVE=false   # Sync saves only  
+org.jenkins.plugins.lockableresources.SAVE_COALESCE_MS=1000  # Coalesce window
+org.jenkins.plugins.lockableresources.PRINT_BLOCKED_RESOURCE=2  # Debug output
+org.jenkins.plugins.lockableresources.PRINT_QUEUE_INFO=2  # Debug output
+```
+
+---
+
+## References
+
+- [Jenkins Computer page](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Computer.java) - Inspiration for resource pages
+- [Caffeine Cache](https://github.com/ben-manes/caffeine) - Guava replacement
+- [ConcurrentHashMap](https://docs.oracle.com/javase/17/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html) - For indexes
+
+---
+
+## Next Steps
+
+1. [ ] Create GitHub issue for overall refactoring epic
+2. [ ] Create sub-issues for each phase
+3. [ ] Start with Phase 1 (name index) - low risk, immediate benefit
+4. [ ] Benchmark current performance for baseline
+5. [ ] Design resource page mockups

--- a/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/FreeDeadJobs.java
@@ -24,7 +24,6 @@ public final class FreeDeadJobs {
 
     @Initializer(after = InitMilestone.JOB_LOADED)
     public static void freePostMortemResources() {
-
         LockableResourcesManager lrm = LockableResourcesManager.get();
         boolean freedAny = false;
         synchronized (lrm.syncResources) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -269,7 +269,7 @@ public class LockableResourcesRootAction implements RootAction, AsyncTableConten
         public List<TableColumn> getColumns() {
             return List.of(
                     new TableColumn.ColumnBuilder()
-                    .withHeaderLabel(tr(bundle, "resources.table.column.select"))
+                            .withHeaderLabel("")
                             .withDataPropertyKey("select")
                             .withType(TableColumn.ColumnType.STRING)
                             .withHeaderClass(TableColumn.ColumnCss.NO_SORT)
@@ -536,6 +536,72 @@ public class LockableResourcesRootAction implements RootAction, AsyncTableConten
             return html.toString();
         }
 
+        private String renderActionCell(final LockableResource resource) {
+            String resourceName = resource.getName();
+            StringBuilder html = new StringBuilder();
+
+            if (resource.isLocked()) {
+                if (Jenkins.get().hasPermission(UNLOCK)) {
+                    html.append(button(
+                            "unlock", "jenkins-!-warning-color", "btn.unlock", "btn.unlock.detail", resourceName));
+                }
+                if (Jenkins.get().hasPermission(STEAL)) {
+                    html.append(button(
+                            "steal", "jenkins-!-destructive-color", "btn.steal", "btn.steal.detail", resourceName));
+                }
+                return html.toString();
+            }
+
+            if (resource.getReservedBy() != null) {
+                if (Jenkins.get().hasPermission(RESERVE)) {
+                    if (resource.isReservedByCurrentUser() || Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                        html.append(button(
+                                "unreserve",
+                                "jenkins-!-success-color",
+                                "btn.unReserve",
+                                "btn.unReserve.detail",
+                                resourceName));
+                    }
+                }
+                if (Jenkins.get().hasPermission(STEAL)) {
+                    if (!resource.isReservedByCurrentUser()) {
+                        html.append(button(
+                                "reassign",
+                                "jenkins-button--primary",
+                                "btn.reassign",
+                                "btn.reassign.detail",
+                                resourceName));
+                    }
+                }
+                return html.toString();
+            }
+
+            if (resource.isQueued()) {
+                if (Jenkins.get().hasPermission(UNLOCK)) {
+                    html.append(button(
+                            "reset", "jenkins-!-destructive-color", "btn.reset", "btn.reset.detail", resourceName));
+                }
+                return html.toString();
+            }
+
+            if (Jenkins.get().hasPermission(RESERVE)) {
+                html.append(button(
+                        "reserve", "jenkins-button--primary", "btn.reserve", "btn.reserve.detail", resourceName));
+            }
+            return html.toString();
+        }
+
+        private String button(
+                final String action,
+                final String extraClass,
+                final String labelKey,
+                final String tooltipKey,
+                final String resourceName) {
+            return "<button data-resource-name=\"" + Util.escape(resourceName) + "\" data-action=\""
+                    + Util.escape(action)
+                    + "\" class=\"jenkins-button " + extraClass + " lockable-resources-action-button\" tooltip=\""
+                    + Util.escape(tr(bundle, tooltipKey)) + "\">" + Util.escape(tr(bundle, labelKey)) + "</button>";
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -5,10 +5,13 @@
  */
 package org.jenkins.plugins.lockableresources.actions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.markup.MarkupFormatter;
 import hudson.model.Api;
 import hudson.model.Descriptor;
 import hudson.model.RootAction;
@@ -17,13 +20,24 @@ import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
+import io.jenkins.plugins.datatables.AsyncTableContentProvider;
+import io.jenkins.plugins.datatables.DetailedCell;
+import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableConfiguration;
+import io.jenkins.plugins.datatables.TableModel;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -35,15 +49,17 @@ import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @Extension
 @ExportedBean
-public class LockableResourcesRootAction implements RootAction {
+public class LockableResourcesRootAction implements RootAction, AsyncTableContentProvider {
 
     private static final Logger LOGGER = Logger.getLogger(LockableResourcesRootAction.class.getName());
 
@@ -103,7 +119,423 @@ public class LockableResourcesRootAction implements RootAction {
 
     @Override
     public String getUrlName() {
-        return Jenkins.get().hasPermission(VIEW) ? "lockable-resources" : "";
+        return "lockable-resources";
+    }
+
+    private static final String RESOURCES_TABLE_ID = "lockable-resources";
+
+    @Restricted(NoExternalUse.class) // used by jelly
+    public Summary getSummary() {
+        Jenkins.get().checkPermission(VIEW);
+
+        int locked = 0;
+        int reserved = 0;
+        int queued = 0;
+        int free = 0;
+        int total = 0;
+
+        for (LockableResource r : LockableResourcesManager.get().getReadOnlyResources()) {
+            total++;
+            if (r.getReservedBy() != null) {
+                reserved++;
+            } else if (r.isLocked()) {
+                locked++;
+            } else if (r.isQueued()) {
+                queued++;
+            } else {
+                free++;
+            }
+        }
+
+        int queueItems = 0;
+        for (QueuedContextStruct context : LockableResourcesManager.get().getCurrentQueuedContext()) {
+            queueItems += context.getResources().size();
+        }
+
+        return new Summary(total, locked, reserved, queued, free, queueItems);
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static final class Summary {
+        private final int total;
+        private final int locked;
+        private final int reserved;
+        private final int queued;
+        private final int free;
+        private final int queueItems;
+
+        Summary(
+                final int total,
+                final int locked,
+                final int reserved,
+                final int queued,
+                final int free,
+                final int queueItems) {
+            this.total = total;
+            this.locked = locked;
+            this.reserved = reserved;
+            this.queued = queued;
+            this.free = free;
+            this.queueItems = queueItems;
+        }
+
+        public int getTotal() {
+            return total;
+        }
+
+        public int getLocked() {
+            return locked;
+        }
+
+        public int getReserved() {
+            return reserved;
+        }
+
+        public int getQueued() {
+            return queued;
+        }
+
+        public int getFree() {
+            return free;
+        }
+
+        public int getQueueItems() {
+            return queueItems;
+        }
+    }
+
+    @Restricted(NoExternalUse.class) // used by jelly
+    public TableModel getResourcesTableModel() {
+        return new ResourcesTableModel(getLocale());
+    }
+
+    @Override
+    @JavaScriptMethod
+    public TableModel getTableModel(final String tableId) {
+        Jenkins.get().checkPermission(VIEW);
+        if (RESOURCES_TABLE_ID.equals(tableId)) {
+            return getResourcesTableModel();
+        }
+        throw new IllegalArgumentException("Unknown table model: " + tableId);
+    }
+
+    @Override
+    @JavaScriptMethod
+    public String getTableRows(final String tableId) {
+        Jenkins.get().checkPermission(VIEW);
+        List<Object> rows = getTableModel(tableId).getRows();
+        try {
+            return new ObjectMapper().writeValueAsString(rows);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(String.format("Can't convert table rows '%s' to JSON object", rows), e);
+        }
+    }
+
+    private static Locale getLocale() {
+        StaplerRequest2 current = Stapler.getCurrentRequest2();
+        return current != null ? current.getLocale() : Locale.getDefault();
+    }
+
+    private static ResourceBundle getTableResourcesBundle(final Locale locale) {
+        return ResourceBundle.getBundle(
+                "org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction.tableResources.table",
+                locale,
+                LockableResourcesRootAction.class.getClassLoader());
+    }
+
+    private static String tr(final ResourceBundle bundle, final String key, final Object... args) {
+        String pattern = bundle.getString(key);
+        if (args == null || args.length == 0) {
+            return pattern;
+        }
+        return MessageFormat.format(pattern, args);
+    }
+
+    private static final class ResourcesTableModel extends TableModel {
+        private final Locale locale;
+        private final ResourceBundle bundle;
+
+        ResourcesTableModel(final Locale locale) {
+            this.locale = locale;
+            this.bundle = getTableResourcesBundle(locale);
+        }
+
+        @Override
+        public String getId() {
+            return RESOURCES_TABLE_ID;
+        }
+
+        @Override
+        public List<TableColumn> getColumns() {
+            return List.of(
+                    new TableColumn.ColumnBuilder()
+                    .withHeaderLabel(tr(bundle, "resources.table.column.select"))
+                            .withDataPropertyKey("select")
+                            .withType(TableColumn.ColumnType.STRING)
+                            .withHeaderClass(TableColumn.ColumnCss.NO_SORT)
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.index"))
+                            .withDataPropertyKey("index")
+                            .withType(TableColumn.ColumnType.HTML_NUMBER)
+                            .withDetailedCell()
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.resource"))
+                            .withDataPropertyKey("resource")
+                            .withType(TableColumn.ColumnType.STRING)
+                            .withDetailedCell()
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.status"))
+                            .withDataPropertyKey("status")
+                            .withType(TableColumn.ColumnType.STRING)
+                            .withDetailedCell()
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.timestamp"))
+                            .withDataPropertyKey("timestamp")
+                            .withType(TableColumn.ColumnType.DATE)
+                            .withDetailedCell()
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.labels"))
+                            .withDataPropertyKey("labels")
+                            .withType(TableColumn.ColumnType.STRING)
+                            .withDetailedCell()
+                            .build(),
+                    new TableColumn.ColumnBuilder()
+                            .withHeaderLabel(tr(bundle, "resources.table.column.properties"))
+                            .withDataPropertyKey("properties")
+                            .withType(TableColumn.ColumnType.STRING)
+                            .withHeaderClass(TableColumn.ColumnCss.HIDDEN)
+                            .build());
+        }
+
+        @Override
+        public TableConfiguration getTableConfiguration() {
+            // Ensure required JS/CSS adjuncts are included by the dt:table tag.
+            // The full table config is still provided by getTableConfigurationDefinition().
+            return new TableConfiguration().buttons("colvis").stateSave();
+        }
+
+        @Override
+        public String getTableConfigurationDefinition() {
+            // Keep behavior aligned with the previous Jelly-based configuration, but rely on
+            // data-tables-api defaults for layout and column behaviors.
+            return "{\n"
+                    + "  \"order\": [[1, \"asc\"]],\n"
+                    + "  \"stateSave\": true,\n"
+                    + "  \"buttons\": [{\"extend\": \"colvis\", \"text\": \""
+                    + Util.escape(tr(bundle, "table.buttons.columns")).replace("\"", "\\\"")
+                    + "\", \"columns\": [1,2,3,4,5]}],\n"
+                    + "  \"language\": { \"emptyTable\": \""
+                    + Util.escape(tr(bundle, "table.empty")).replace("\"", "\\\"") + "\" },\n"
+                    + "  \"lengthMenu\": [[10, 25, 50, 100, -1], [10, 25, 50, 100, \""
+                    + Util.escape(tr(bundle, "table.settings.page.length.all")).replace("\"", "\\\"") + "\"]]\n"
+                    + "}";
+        }
+
+        @Override
+        public List<Object> getRows() {
+            List<Object> rows = new ArrayList<>();
+
+            DateFormat dateTime = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, locale);
+            MarkupFormatter markupFormatter = Jenkins.get().getMarkupFormatter();
+
+            int index = 0;
+            for (LockableResource resource : LockableResourcesManager.get().getReadOnlyResources()) {
+                index++;
+                Map<String, Object> row = new LinkedHashMap<>();
+
+                row.put(
+                        "select",
+                        "<input type=\"checkbox\" class=\"lockable-resources-select\" data-resource-name=\""
+                                + Util.escape(resource.getName())
+                                + "\" />");
+
+                String propertiesHtml = renderProperties(resource);
+                String details = TableColumn.renderDetailsColumn(propertiesHtml);
+                row.put("index", new DetailedCell<>(details + " " + index, index));
+
+                row.put(
+                        "resource",
+                        new DetailedCell<>(renderResourceCell(resource, markupFormatter), resource.getName()));
+                row.put("status", new DetailedCell<>(renderStatusCell(resource), renderStatusSortKey(resource)));
+
+                Date reservedTimestamp = resource.getReservedTimestamp();
+                if (reservedTimestamp != null) {
+                    row.put(
+                            "timestamp",
+                            new DetailedCell<>(dateTime.format(reservedTimestamp), reservedTimestamp.getTime()));
+                } else {
+                    row.put("timestamp", new DetailedCell<>("", 0L));
+                }
+
+                row.put(
+                        "labels",
+                        new DetailedCell<>(renderLabels(resource), String.join(",", resource.getLabelsAsList())));
+                row.put("properties", propertiesHtml);
+
+                rows.add(row);
+            }
+
+            return rows;
+        }
+
+        private String renderResourceCell(final LockableResource resource, final MarkupFormatter markupFormatter) {
+            StringBuilder html = new StringBuilder();
+
+            String resourceName = resource.getName();
+            String escapedName = Util.escape(resourceName);
+
+            html.append("<div class=\"row justify-content-end\">");
+            html.append("<div class=\"col-auto\"><strong>").append(escapedName).append("</strong></div>");
+            html.append("<div class=\"col\">");
+            if (resource.isEphemeral()) {
+                html.append("<span class=\"static-label\">")
+                        .append(Util.escape(tr(bundle, "resources.ephemeral")))
+                        .append("</span>");
+            }
+            html.append("</div>");
+
+            if (Jenkins.get().hasPermission(RESERVE)) {
+                html.append("<div class=\"col-auto jenkins-!-margin-right-2\">")
+                        .append(
+                                "<a class=\"jenkins-table__link lockable-resources-replace-note\" data-resource-name=\"")
+                        .append(Util.escape(resourceName))
+                        .append("\" href=\"editNote\">")
+                        .append(Util.escape(tr(bundle, "btn.editNote")))
+                        .append("</a></div>");
+            }
+            html.append("</div>");
+
+            if (resource.getDescription() != null && !resource.getDescription().isEmpty()) {
+                html.append("<div class=\"row\"><div class=\"col\">")
+                        .append(Util.escape(resource.getDescription()))
+                        .append("</div></div>");
+            }
+
+            html.append("<div class=\"row\"><div id=\"note-")
+                    .append(Util.escape(resourceName))
+                    .append("\">");
+            if (resource.getNote() != null && !resource.getNote().isEmpty()) {
+                html.append("<div class=\"note-wrapper jenkins-!-padding-2 jenkins-!-margin-right-1 overflow-auto\">");
+                html.append(translateNote(markupFormatter, resource.getNote()));
+                html.append("</div>");
+            }
+            html.append("</div></div>");
+
+            return html.toString();
+        }
+
+        private static String translateNote(final MarkupFormatter markupFormatter, final String note) {
+            try {
+                StringWriter writer = new StringWriter();
+                markupFormatter.translate(note, writer);
+                return writer.toString();
+            } catch (IOException e) {
+                // Fallback: show escaped raw note if translation fails.
+                return Util.escape(note);
+            }
+        }
+
+        private String renderStatusCell(final LockableResource resource) {
+            StringBuilder html = new StringBuilder();
+
+            if (resource.getReservedBy() != null) {
+                html.append(tr(bundle, "resource.status.reservedBy", Util.escape(resource.getReservedBy())));
+                appendReason(html, resource);
+            } else if (resource.isLocked()) {
+                Run<?, ?> build = resource.getBuild();
+                if (build != null) {
+                    html.append(tr(
+                            bundle,
+                            "resource.status.locked",
+                            Util.escape("/" + build.getUrl()),
+                            Util.escape(build.getFullDisplayName())));
+                } else {
+                    html.append(tr(bundle, "resource.status.locked", "#", "N/A"));
+                }
+                appendReason(html, resource);
+            } else if (resource.isQueued()) {
+                html.append(tr(
+                        bundle,
+                        "resource.status.queuedBy",
+                        Util.escape(resource.getQueueItemProject()),
+                        Util.escape(String.valueOf(resource.getQueueItemId()))));
+            } else {
+                html.append(tr(bundle, "resource.status.free"));
+            }
+
+            Date reservedTimestamp = resource.getReservedTimestamp();
+            if (reservedTimestamp != null) {
+                long delta = Math.max(0L, System.currentTimeMillis() - reservedTimestamp.getTime());
+                String ago = tr(bundle, "ago", Util.getTimeSpanString(delta));
+                html.append("<br />").append(Util.escape(ago));
+            }
+
+            return html.toString();
+        }
+
+        private void appendReason(final StringBuilder html, final LockableResource resource) {
+            if (resource.getLockReason() != null && !resource.getLockReason().isEmpty()) {
+                html.append("<br/>")
+                        .append("<span class=\"jenkins-!-font-weight-normal\">")
+                        .append(Util.escape(tr(bundle, "resource.status.reason")))
+                        .append(": ")
+                        .append(Util.escape(resource.getLockReason()))
+                        .append("</span>");
+            }
+        }
+
+        private static int renderStatusSortKey(final LockableResource resource) {
+            if (resource.getReservedBy() != null) {
+                return 3;
+            }
+            if (resource.isLocked()) {
+                return 2;
+            }
+            if (resource.isQueued()) {
+                return 1;
+            }
+            return 0;
+        }
+
+        private String renderLabels(final LockableResource resource) {
+            StringBuilder html = new StringBuilder();
+            for (String label : resource.getLabelsAsList()) {
+                if (label == null || label.isEmpty()) {
+                    continue;
+                }
+                html.append("<a class=\"jenkins-table__link model-link\" href=\"/label/")
+                        .append(Util.rawEncode(label))
+                        .append("\">")
+                        .append(Util.escape(label))
+                        .append("</a>");
+            }
+            return html.toString();
+        }
+
+        private String renderProperties(final LockableResource resource) {
+            if (resource.getProperties() == null || resource.getProperties().isEmpty()) {
+                return "";
+            }
+
+            StringBuilder html = new StringBuilder();
+            html.append(
+                    "<div class=\"table-responsive\"><table class=\"jenkins-table jenkins-!-margin-0 table-properties\"><tbody>");
+            resource.getProperties().forEach(property -> {
+                html.append("<tr><td>")
+                        .append(Util.escape(property.getName()))
+                        .append("</td><td>")
+                        .append(Util.escape(property.getValue()))
+                        .append("</td></tr>");
+            });
+            html.append("</tbody></table></div>");
+            return html.toString();
+        }
+
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/nodes/NodesMirror.java
@@ -1,4 +1,4 @@
-package org.jenkins.plugins.lockableresources;
+package org.jenkins.plugins.lockableresources.nodes;
 
 import hudson.Extension;
 import hudson.init.InitMilestone;
@@ -10,6 +10,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
+import org.jenkins.plugins.lockableresources.LockableResource;
+import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.util.Constants;
 
 // -----------------------------------------------------------------------------

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.jelly
@@ -1,86 +1,83 @@
 <?jelly escape-by-default='true'?>
-<!--
-  Copyright 2013, 6WIND S.A. All rights reserved.
-  Copyright 2019-2020, TobiX
-
-  This file is part of the Jenkins Lockable Resources Plugin and is
-  published under the MIT license.
-
-  See the "LICENSE.txt" file for more information.
- -->
-<j:jelly
-  xmlns:j="jelly:core"
-  xmlns:l="/lib/layout"
-  xmlns:f="/lib/form"
-  xmlns:i="jelly:fmt"
-  xmlns:st="jelly:stapler"
-  xmlns:t="/lib/hudson"
->
-  <l:layout title="${it.displayName}" type="one-column">
-    <l:app-bar title="${%header.resources}">
-      <t:help href="https://github.com/jenkinsci/lockable-resources-plugin#lockable-resources-overview" />
-    </l:app-bar>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt">
+  <l:layout title="${it.displayName}">
+    <st:include page="sidebar"/>
 
     <l:main-panel>
+      <l:app-bar title="${%nav.overview}">
+        <t:help href="https://github.com/jenkinsci/lockable-resources-plugin#lockable-resources-overview" />
+      </l:app-bar>
+
+      <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+
+      <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
+
+      <j:set var="summary" value="${it.summary}" />
       <j:choose>
-        <j:when test="${it.resources.size() == 0}">
+        <j:when test="${summary.total == 0}">
           <p>
             ${%resources.not_configured}<br />
             <j:if test="${h.hasPermission(app.ADMINISTER)}">
               ${%resources.configure.here(rootURL + "/configure")}
             </j:if>
-        </p>
-      </j:when>
-      <j:otherwise>
-        <!-- translations for javascript -->
-        <template id="i18n"
-                  data-queue-title="${%queue.change.title}"
-                  data-queue-message="${%queue.change.message}"
-                  data-queue-on-success="${%queue.change.on.success}"
-                  data-queue-on-fail="${%queue.change.on.fail}"
-                  data-reserve-title="${%reserve.dialog.title}"
-                  data-reserve-message="${%reserve.dialog.message}"
-                  data-steal-title="${%steal.dialog.title}"
-                  data-steal-message="${%steal.dialog.message}"
-                  data-action-on-success="${%action.on.success}"
-                  data-action-on-fail="${%action.on.fail}"
-        />
-        <div class="fluid-container">
-          <!-- Nav tabs -->
-          <ul class="nav nav-tabs" id="lockable-resources-tab" role="tablist">
-            <li class="nav-item" role="presentation">
-              <button class="nav-link active" id="resources-tab" data-bs-toggle="tab" data-bs-target="#resources"
-                type="button" role="tab" aria-controls="resources" aria-selected="true">${%tab.resources}</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" id="labels-tab" data-bs-toggle="tab" data-bs-target="#labels" type="button"
-                role="tab" aria-controls="labels" aria-selected="false">${%tab.labels}</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" id="queue-tab" data-bs-toggle="tab" data-bs-target="#queue" type="button"
-                role="tab" aria-controls="queue" aria-selected="false">${%tab.queue}</button>
-            </li>
-            <!-- more tabs like logs can be added here -->
-          </ul>
-          <!-- Tab panes -->
-          <div class="tab-content">
-            <div class="tab-pane jenkins-!-margin-top-1 active" id="resources" role="tabpanel" aria-labelledby="resources-tab">
-              <st:include page="tableResources/table"/>
-            </div>
-          </div>
-          <div class="tab-content">
-            <div class="tab-pane jenkins-!-margin-top-1" id="labels" role="tabpanel" aria-labelledby="labels-tab">
-              <st:include page="tableLabels/table"/>
-            </div>
-          </div>
-          <div class="tab-content">
-            <div class="tab-pane jenkins-!-margin-top-1" id="queue" role="tabpanel" aria-labelledby="queue-tab">
-              <st:include page="tableQueue/table"/>
-            </div>
-          </div>
-        </div>
+          </p>
+        </j:when>
+        <j:otherwise>
+          <div class="row g-3 jenkins-!-margin-bottom-4">
+            <div class="col-12 col-md-6">
+              <l:card title="${%summary.resources}" expandable="${rootURL}/lockable-resources/resources">
+                <j:set var="total" value="${summary.total}" />
+                <j:set var="lockedPct" value="${(summary.locked * 100.0) / total}" />
+                <j:set var="reservedPct" value="${(summary.reserved * 100.0) / total}" />
+                <j:set var="queuedPct" value="${(summary.queued * 100.0) / total}" />
+                <j:set var="freePct" value="${(summary.free * 100.0) / total}" />
 
-        <script type="text/javascript" src="${resURL}/plugin/data-tables-api/js/table.js"/>
+                <j:set var="lockedEnd" value="${lockedPct}" />
+                <j:set var="reservedEnd" value="${lockedPct + reservedPct}" />
+                <j:set var="queuedEnd" value="${lockedPct + reservedPct + queuedPct}" />
+
+                <div id="lockable-resources-state-summary">
+                  <div class="lockable-resources-donut-layout">
+                    <div class="lockable-resources-donut-wrap">
+                      <div id="lockable-resources-state-donut"
+                           class="lockable-resources-donut"
+                           style="background: conic-gradient(var(--bs-danger) 0 ${lockedEnd}%, var(--bs-warning) ${lockedEnd}% ${reservedEnd}%, var(--bs-info) ${reservedEnd}% ${queuedEnd}%, var(--bs-success) ${queuedEnd}% 100%);"
+                           aria-label="${%summary.locked}: ${summary.locked} (${lockedPct}%), ${%summary.reserved}: ${summary.reserved} (${reservedPct}%), ${%summary.queued}: ${summary.queued} (${queuedPct}%), ${%summary.free}: ${summary.free} (${freePct}%)">
+                      </div>
+                      <div class="lockable-resources-donut__center" aria-hidden="true">
+                        <div class="jenkins-!-font-size-24">${summary.total}</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row g-2 small jenkins-!-margin-top-2">
+                    <div class="col-6 col-md-3">
+                      <span class="text-danger">${%summary.locked}</span>
+                      <span class="jenkins-!-margin-left-1">${summary.locked} (<i:formatNumber value="${lockedPct}" pattern="0"/>%)</span>
+                    </div>
+                    <div class="col-6 col-md-3">
+                      <span class="text-warning">${%summary.reserved}</span>
+                      <span class="jenkins-!-margin-left-1">${summary.reserved} (<i:formatNumber value="${reservedPct}" pattern="0"/>%)</span>
+                    </div>
+                    <div class="col-6 col-md-3">
+                      <span class="text-info">${%summary.queued}</span>
+                      <span class="jenkins-!-margin-left-1">${summary.queued} (<i:formatNumber value="${queuedPct}" pattern="0"/>%)</span>
+                    </div>
+                    <div class="col-6 col-md-3">
+                      <span class="text-success">${%summary.free}</span>
+                      <span class="jenkins-!-margin-left-1">${summary.free} (<i:formatNumber value="${freePct}" pattern="0"/>%)</span>
+                    </div>
+                  </div>
+                </div>
+              </l:card>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <l:card title="${%summary.queue}" expandable="${rootURL}/lockable-resources/queue">
+                <div class="jenkins-!-font-size-24">${summary.queueItems}</div>
+              </l:card>
+            </div>
+          </div>
         </j:otherwise>
       </j:choose>
     </l:main-panel>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/index.properties
@@ -22,10 +22,19 @@
 
 #headers
 header.resources=Lockable Resources
-# tabs
-tab.resources=Resources
-tab.labels=Labels
-tab.queue=Queue
+
+nav.overview=Overview
+nav.resources=Resources
+nav.labels=Labels
+nav.queue=Queue
+
+summary.resources=Resources
+summary.queue=Queue items
+summary.state=State
+summary.locked=Locked
+summary.reserved=Reserved
+summary.queued=Queued
+summary.free=Free
 #warning resources not configured
 resources.not_configured=There are no resources configured at the moment.
 resources.configure.here=You can configure it <a href="{0}">here</a>.

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/labels.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/labels.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
+  <l:layout title="${it.displayName}">
+    <st:include page="sidebar"/>
+
+    <l:main-panel>
+      <l:app-bar title="${%header.resources}">
+        <t:help href="https://github.com/jenkinsci/lockable-resources-plugin#lockable-resources-overview" />
+      </l:app-bar>
+
+      <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+      <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
+      <st:include page="tableLabels/table"/>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/labels.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/labels.properties
@@ -1,0 +1,6 @@
+header.resources=Lockable Resources
+
+nav.overview=Overview
+nav.resources=Resources
+nav.labels=Labels
+nav.queue=Queue

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/queue.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/queue.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
+  <l:layout title="${it.displayName}">
+    <st:include page="sidebar"/>
+
+    <l:main-panel>
+      <l:app-bar title="${%header.resources}">
+        <t:help href="https://github.com/jenkinsci/lockable-resources-plugin#lockable-resources-overview" />
+      </l:app-bar>
+
+      <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+      <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
+
+      <!-- translations for javascript -->
+      <template id="i18n"
+                data-queue-title="${%queue.change.title}"
+                data-queue-message="${%queue.change.message}"
+                data-queue-on-success="${%queue.change.on.success}"
+                data-queue-on-fail="${%queue.change.on.fail}"
+                data-action-on-success="${%action.on.success}"
+                data-action-on-fail="${%action.on.fail}"
+      />
+
+      <st:include page="tableQueue/table"/>
+      <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"></script>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/queue.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/queue.properties
@@ -1,0 +1,14 @@
+header.resources=Lockable Resources
+
+nav.overview=Overview
+nav.resources=Resources
+nav.labels=Labels
+nav.queue=Queue
+
+# JavaScript i18n messages
+queue.change.title=Change queue position ({0})
+queue.change.message=Type new queue position
+queue.change.on.success=Queue position successfully changed
+queue.change.on.fail=Change queue ({0}) position failed!
+action.on.success=The action '{0}' was successfully performed on '{1}'
+action.on.fail=The action '{0}' on resource '{1}' failed!

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/resources.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/resources.jelly
@@ -1,0 +1,32 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
+  <l:layout title="${it.displayName}">
+    <st:include page="sidebar"/>
+
+    <l:main-panel>
+      <l:app-bar title="${%header.resources}">
+        <t:help href="https://github.com/jenkinsci/lockable-resources-plugin#lockable-resources-overview" />
+      </l:app-bar>
+
+      <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+      <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
+
+    
+          <!-- translations for javascript -->
+          <template id="i18n"
+                    data-queue-title="${%queue.change.title}"
+                    data-queue-message="${%queue.change.message}"
+                    data-queue-on-success="${%queue.change.on.success}"
+                    data-queue-on-fail="${%queue.change.on.fail}"
+                    data-reserve-title="${%reserve.dialog.title}"
+                    data-reserve-message="${%reserve.dialog.message}"
+                    data-steal-title="${%steal.dialog.title}"
+                    data-steal-message="${%steal.dialog.message}"
+                    data-action-on-success="${%action.on.success}"
+                    data-action-on-fail="${%action.on.fail}">
+          </template>
+          <st:include page="tableResources/table"/>
+  
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/resources.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/resources.properties
@@ -1,0 +1,21 @@
+header.resources=Lockable Resources
+
+nav.overview=Overview
+nav.resources=Resources
+nav.labels=Labels
+nav.queue=Queue
+
+resources.not_configured=There are no resources configured at the moment.
+resources.configure.here=You can configure it <a href="{0}">here</a>.
+
+# JavaScript i18n messages
+queue.change.title=Change queue position ({0})
+queue.change.message=Type new queue position
+queue.change.on.success=Queue position successfully changed
+queue.change.on.fail=Change queue ({0}) position failed!
+reserve.dialog.title=Reserve {0}
+reserve.dialog.message=Enter a reason for reserving this resource:
+steal.dialog.title=Steal {0}
+steal.dialog.message=Enter a reason for stealing this resource:
+action.on.success=The action '{0}' was successfully performed on '{1}'
+action.on.fail=The action '{0}' on resource '{1}' failed!

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:side-panel>
+    <l:tasks>
+      <l:task href="${rootURL}/lockable-resources/" icon="symbol-lock-closed" title="${%nav.overview}" />
+      <l:task href="${rootURL}/lockable-resources/resources" icon="symbol-lock-closed" title="${%nav.resources}" />
+      <l:task href="${rootURL}/lockable-resources/labels" icon="symbol-lock-closed" title="${%nav.labels}" />
+      <l:task href="${rootURL}/lockable-resources/queue" icon="symbol-lock-closed" title="${%nav.queue}" />
+    </l:tasks>
+  </l:side-panel>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar.properties
@@ -1,0 +1,4 @@
+nav.overview=Overview
+nav.resources=Resources
+nav.labels=Labels
+nav.queue=Queue

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_cs.properties
@@ -1,0 +1,4 @@
+nav.overview=P\u0159ehled
+nav.resources=Zdroje
+nav.labels=Popisky
+nav.queue=Fronta

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_de.properties
@@ -1,0 +1,4 @@
+nav.overview=\u00dcbersicht
+nav.resources=Ressourcen
+nav.labels=Labels
+nav.queue=Warteschlange

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_fr.properties
@@ -1,0 +1,4 @@
+nav.overview=Aper\u00e7u
+nav.resources=Ressources
+nav.labels=Libell\u00e9s
+nav.queue=File d'attente

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/sidebar_sk.properties
@@ -1,0 +1,4 @@
+nav.overview=Preh\u013ead
+nav.resources=Zdroje
+nav.labels=\u0160t\u00edtky
+nav.queue=Rad

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   <j:set var="allLabels" value="${it.getLabelsList()}" />
   <j:if test="${allLabels.size() != 0}">
     <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+    <st:adjunct includes="io.jenkins.plugins.data-tables-buttons"/>
     <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
 
     <div class="table-responsive">
@@ -39,7 +40,9 @@ THE SOFTWARE.
         data-columns-definition="[null, null, null, null]"
         data-table-configuration='
         {
+        "dom": "lfrtBip",
           "stateSave": true,
+          "buttons": [{"extend": "colvis", "text": "${%table.buttons.columns}", "columns": [0,1,2,3]}],
           "language": { "emptyTable": "${%table.empty}" },
           "lengthMenu": [
             [10, 25, 50, 100, -1],
@@ -48,10 +51,21 @@ THE SOFTWARE.
         }'
       >
         <thead>
-          <th class="width-100">${%labels.table.column.labels}</th>
-          <th>${%labels.table.column.assigned}</th>
-          <th>${%labels.table.column.free}</th>
-          <th>${%labels.table.column.percentage}</th>
+          <tr>
+            <th class="width-100">${%labels.table.column.labels}</th>
+            <th>${%labels.table.column.assigned}</th>
+            <th>${%labels.table.column.free}</th>
+            <th>${%labels.table.column.percentage}</th>
+          </tr>
+          <tr class="lockable-resources-filters">
+            <th>
+              <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="0"
+                     placeholder="${%table.filter.label}" />
+            </th>
+            <th></th>
+            <th></th>
+            <th></th>
+          </tr>
         </thead>
         <tbody>
           <j:forEach var="entry" items="${allLabels.entrySet()}">
@@ -110,6 +124,7 @@ THE SOFTWARE.
           </j:forEach>
         </tbody>
       </table>
+      <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"></script>
     </div>
   </j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -123,7 +123,7 @@ THE SOFTWARE.
           </j:forEach>
         </tbody>
       </table>
-      <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"></script>
+      <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/table-labels-filters.js"></script>
     </div>
   </j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.jelly
@@ -40,7 +40,6 @@ THE SOFTWARE.
         data-columns-definition="[null, null, null, null]"
         data-table-configuration='
         {
-        "dom": "lfrtBip",
           "stateSave": true,
           "buttons": [{"extend": "colvis", "text": "${%table.buttons.columns}", "columns": [0,1,2,3]}],
           "language": { "emptyTable": "${%table.empty}" },

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table.properties
@@ -29,3 +29,12 @@ labels.free.tooltip={0} % free
 # Table settings
 table.settings.page.length.all=ALL
 table.empty=No labels configured
+
+# Column filters
+table.filter.label=Filter label
+table.filter.assigned=Filter assigned
+table.filter.free=Filter free
+table.filter.percentage=Filter percentage
+
+# Column visibility
+table.buttons.columns=Columns

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_cs.properties
@@ -27,3 +27,6 @@ labels.table.column.free=Voln\u00e9
 labels.table.column.assigned=P\u0159i\u0159azen\u00e9 zdroje
 labels.table.column.percentage=Voln\u00fdch v %
 labels.free.tooltip={0} % voln\u00fdch
+
+# Column filters
+table.filter.label=Filtrovat popisek

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_de.properties
@@ -27,3 +27,6 @@ labels.table.column.free=Frei
 labels.table.column.assigned=Zugewiesene Ressourcen
 labels.table.column.percentage=Frei in %
 labels.free.tooltip={0} % frei
+
+# Column filters
+table.filter.label=Label filtern

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_fr.properties
@@ -27,3 +27,6 @@ labels.table.column.free=Libre
 labels.table.column.assigned=Ressources affect\u00e9es
 labels.table.column.percentage=Libre in %
 labels.free.tooltip={0} % libre
+
+# Column filters
+table.filter.label=Filtrer le libell\u00e9

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableLabels/table_sk.properties
@@ -27,3 +27,6 @@ labels.table.column.free=Vo\u013en\u00e9 zdroje
 labels.table.column.assigned=Priraden\u00e9 zdroje
 labels.table.column.percentage=Vo\u013en\u00fdch v %
 labels.free.tooltip={0} % vo\u013en\u00fdch
+
+# Column filters
+table.filter.label=Filtrova\u0165 \u0161t\u00edtok

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
@@ -35,7 +35,9 @@ THE SOFTWARE.
   <div class="row py-3 queuebar">
     <j:set var="oldestQueue" value="${queue.getOldest()}"/>
     <j:choose>
-
+      <j:when test="${oldestQueue == null}">
+        <h2>${%queue.isEmpty}</h2>
+      </j:when>
       <j:otherwise>
         <j:if test="${oldestQueue.takeTooLong()}">
           <span class="lockable-resources-queue-too-long-message"
@@ -60,7 +62,6 @@ THE SOFTWARE.
       data-columns-definition="[null, null, null, null, null, null, null, null, null]"
       data-table-configuration='
       {
-        "dom": "lfrtBip",
         "stateSave": true,
         "buttons": [{"extend": "colvis", "text": "${%table.buttons.columns}", "columns": [0,2,3,4,5,6,7,8]}],
         "language": { "emptyTable": "${%table.empty}" },
@@ -71,49 +72,15 @@ THE SOFTWARE.
       }'
     >
       <thead>
-        <tr>
-          <th>${%queue.table.column.index}</th>
-          <th>${%queue.table.column.action}</th>
-          <th>${%queue.table.column.request.type}</th>
-          <th>${%queue.table.column.request.info}</th>
-          <th class="width-100">${%queue.table.column.reason}</th>
-          <th>${%queue.table.column.requested.by}</th>
-          <th>${%queue.table.column.requested.at}</th>
-          <th>${%queue.table.column.priority}</th>
-          <th>${%queue.table.column.id}</th>
-        </tr>
-        <tr class="lockable-resources-filters">
-          <th></th>
-          <th></th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="2"
-                   placeholder="${%table.filter.type}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="3"
-                   placeholder="${%table.filter.request}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="4"
-                   placeholder="${%table.filter.reason}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="5"
-                   placeholder="${%table.filter.requestedBy}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="6"
-                   placeholder="${%table.filter.requestedAt}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="7"
-                   placeholder="${%table.filter.priority}" />
-          </th>
-          <th>
-            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="8"
-                   placeholder="${%table.filter.queueId}" />
-          </th>
-        </tr>
+        <th>${%queue.table.column.index}</th>
+        <th>${%queue.table.column.action}</th>
+        <th>${%queue.table.column.request.type}</th>
+        <th>${%queue.table.column.request.info}</th>
+        <th class="width-100">${%queue.table.column.reason}</th>
+        <th>${%queue.table.column.requested.by}</th>
+        <th>${%queue.table.column.requested.at}</th>
+        <th>${%queue.table.column.priority}</th>
+        <th>${%queue.table.column.id}</th>
       </thead>
       <tbody>
         <j:forEach var="queuedItem" items="${queue.getAll()}" varStatus="idx">
@@ -242,5 +209,43 @@ THE SOFTWARE.
         </j:forEach>
       </tbody>
     </table>
+    <div id="toolbar-lockable-resources-queue" class="table-toolbar">
+      <div class="row g-2">
+        <div class="col-md-2">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="0"
+                 placeholder="${%table.filter.position}" />
+        </div>
+        <div class="col-md-2">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="2"
+                 placeholder="${%table.filter.type}" />
+        </div>
+        <div class="col-md-3">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="3"
+                 placeholder="${%table.filter.request}" />
+        </div>
+        <div class="col-md-3">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="4"
+                 placeholder="${%table.filter.reason}" />
+        </div>
+        <div class="col-md-2">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="8"
+                 placeholder="${%table.filter.queueId}" />
+        </div>
+      </div>
+      <div class="row g-2 jenkins-!-margin-top-1">
+        <div class="col-md-3">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="5"
+                 placeholder="${%table.filter.requestedBy}" />
+        </div>
+        <div class="col-md-3">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="6"
+                 placeholder="${%table.filter.requestedAt}" />
+        </div>
+        <div class="col-md-3">
+          <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="7"
+                 placeholder="${%table.filter.priority}" />
+        </div>
+      </div>
+    </div>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.jelly
@@ -28,15 +28,14 @@ THE SOFTWARE.
   xmlns:l="/lib/layout"
   xmlns:st="jelly:stapler">
   <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+  <st:adjunct includes="io.jenkins.plugins.data-tables-buttons"/>
 
   <j:set var="queue" value="${it.getQueue()}"/>
 
   <div class="row py-3 queuebar">
     <j:set var="oldestQueue" value="${queue.getOldest()}"/>
     <j:choose>
-      <j:when test="${oldestQueue == null}">
-        <h2>${%queue.isEmpty}</h2>
-      </j:when>
+
       <j:otherwise>
         <j:if test="${oldestQueue.takeTooLong()}">
           <span class="lockable-resources-queue-too-long-message"
@@ -51,8 +50,6 @@ THE SOFTWARE.
     </j:choose>
   </div>
 
-
-  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
   <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
   <div class="table-responsive">
     <table
@@ -63,7 +60,9 @@ THE SOFTWARE.
       data-columns-definition="[null, null, null, null, null, null, null, null, null]"
       data-table-configuration='
       {
+        "dom": "lfrtBip",
         "stateSave": true,
+        "buttons": [{"extend": "colvis", "text": "${%table.buttons.columns}", "columns": [0,2,3,4,5,6,7,8]}],
         "language": { "emptyTable": "${%table.empty}" },
         "lengthMenu": [
           [10, 25, 50, 100, -1],
@@ -72,15 +71,49 @@ THE SOFTWARE.
       }'
     >
       <thead>
-        <th>${%queue.table.column.index}</th>
-        <th>${%queue.table.column.action}</th>
-        <th>${%queue.table.column.request.type}</th>
-        <th>${%queue.table.column.request.info}</th>
-        <th class="width-100">${%queue.table.column.reason}</th>
-        <th>${%queue.table.column.requested.by}</th>
-        <th>${%queue.table.column.requested.at}</th>
-        <th>${%queue.table.column.priority}</th>
-        <th>${%queue.table.column.id}</th>
+        <tr>
+          <th>${%queue.table.column.index}</th>
+          <th>${%queue.table.column.action}</th>
+          <th>${%queue.table.column.request.type}</th>
+          <th>${%queue.table.column.request.info}</th>
+          <th class="width-100">${%queue.table.column.reason}</th>
+          <th>${%queue.table.column.requested.by}</th>
+          <th>${%queue.table.column.requested.at}</th>
+          <th>${%queue.table.column.priority}</th>
+          <th>${%queue.table.column.id}</th>
+        </tr>
+        <tr class="lockable-resources-filters">
+          <th></th>
+          <th></th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="2"
+                   placeholder="${%table.filter.type}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="3"
+                   placeholder="${%table.filter.request}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="4"
+                   placeholder="${%table.filter.reason}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="5"
+                   placeholder="${%table.filter.requestedBy}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="6"
+                   placeholder="${%table.filter.requestedAt}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="7"
+                   placeholder="${%table.filter.priority}" />
+          </th>
+          <th>
+            <input type="search" class="form-control form-control-sm lockable-resources-column-filter" data-dt-column="8"
+                   placeholder="${%table.filter.queueId}" />
+          </th>
+        </tr>
       </thead>
       <tbody>
         <j:forEach var="queuedItem" items="${queue.getAll()}" varStatus="idx">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
@@ -60,6 +60,7 @@ type.groovy=Groovy expression
 table.settings.page.length.all=ALL
 
 # Column filters
+table.filter.position=Filter position
 table.filter.type=Filter type
 table.filter.request=Filter request
 table.filter.reason=Filter reason

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableQueue/table.properties
@@ -59,6 +59,18 @@ type.groovy=Groovy expression
 # Table settings
 table.settings.page.length.all=ALL
 
+# Column filters
+table.filter.type=Filter type
+table.filter.request=Filter request
+table.filter.reason=Filter reason
+table.filter.requestedBy=Filter requested by
+table.filter.requestedAt=Filter requested at
+table.filter.priority=Filter priority
+table.filter.queueId=Filter queue id
+
+# Column visibility
+table.buttons.columns=Columns
+
 # Change queue position
 queue.change.title=Change queue position ({0})
 queue.change.message=Type new queue position

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -28,310 +28,48 @@ THE SOFTWARE.
   xmlns:f="/lib/form"
   xmlns:i="jelly:fmt"
   xmlns:st="jelly:stapler"
+  xmlns:dt="/data-tables"
   >
-  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
-
   <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
 
-  <div class="table-responsive">
-    <table
-      class="jenkins-!-margin-bottom-4 table table-striped display data-table"
-      id="lockable-resources"
-      data-remember-search-text="true"
-      isLoaded="true"
-      data-columns-definition="[null, null, null, null, null, null, null]"
-      data-table-configuration='
-      {
-        "responsive": {
-          "details": {
-            "type": "column"
-          }
-        },
-        "columnDefs": [
-            { "targets": "index", "className": "dt-control" },
-            { "targets": "properties", "visible": false }
-        ],
-        "order": [ 0, "asc" ],
-        "stateSave": true,
-        "language": { "emptyTable": "${%table.empty}" },
-        "lengthMenu": [
-          [10, 25, 50, 100, -1],
-          [10, 25, 50, 100, "${%table.settings.page.length.all}"]
-        ]
-       }'
-    >
-      <thead>
-        <th data-class-name="index">${%resources.table.column.index}</th>
-        <th data-class-name="resource" class="width-100">${%resources.table.column.resource}</th>
-        <th data-class-name="status">${%resources.table.column.status}</th>
-        <th data-class-name="timestamp">${%resources.table.column.timestamp}</th>
-        <th data-class-name="labels" class="width-100">${%resources.table.column.labels}</th>
-        <th data-class-name="properties">${%resources.table.column.properties}</th>
-        <th data-class-name="action">${%resources.table.column.action}</th>
-      </thead>
-      <tbody>
-        <j:forEach var="resource" items="${it.resources}" varStatus="idx">
-          <tr data-resource-name="${resource.name}">
-            <!-- **************************************************************
-                 Index
-            -->
-            <td>${idx.index + 1}</td>
+  <dt:table model="${it.resourcesTableModel}" class="jenkins-!-margin-bottom-4 table-striped display" />
 
-            <!-- **************************************************************
-                 Column with common resource data
-            -->
-            <td>
-              <div class="row justify-content-end">
-                <div class="col-auto">
-                  <strong>${resource.name}</strong>
-                </div>
-                <div class="col">
-                  <j:if test="${resource.ephemeral}">
-                    <span class="static-label">${%resources.ephemeral}</span>
-                  </j:if>
-                </div>
-                <div class="col-auto jenkins-!-margin-right-2">
-                  <l:hasPermission permission="${it.RESERVE}">
-                    <a class="jenkins-table__link lockable-resources-replace-note" data-resource-name="${resource.name}"
-                       id="note-link" href="editNote">
-                      <l:icon class="symbol-edit-note icon-sm" />
-                      ${%btn.editNote}
-                    </a>
-                  </l:hasPermission>
-                </div>
-              <!-- this does not look good when we use bootstrap5
-                <l:copyButton message="${%btn.copy.message}" text="${resource.name}" tooltip="${%btn.copy.detail}"/>
-              -->
-              </div>
-              <j:if test="${resource.description != null and !resource.description.isEmpty()}">
-                <div class="row">
-                  <div class="col">
-                    ${resource.description}
-                  </div>
-                </div>
-              </j:if>
-              <div class="row">
-                <div id="note-${resource.name}">
-                  <j:if test="${resource.note != null and !resource.note.isEmpty()}">
-                  <div class="note-wrapper jenkins-!-padding-2 jenkins-!-margin-right-1 overflow-auto">
-                    <j:out value="${resource.note !=null ? app.markupFormatter.translate(resource.note) : ''}"/>
-                  </div>
-                  </j:if>
-                </div>
-              </div>
-            </td>
+  <div id="lockable-resources-bulk-bar" class="lockable-resources-bulk-bar" aria-hidden="true">
+    <div class="lockable-resources-bulk-bar__content">
+      <span class="lockable-resources-bulk-bar__label">${%bulk.selected}</span>
+      <span class="lockable-resources-bulk-bar__count" id="lockable-resources-selected-count">0</span>
 
+      <l:hasPermission permission="${it.RESERVE}">
+        <button type="button" class="jenkins-button jenkins-button--primary lockable-resources-bulk-action-button" data-action="reserve" disabled="disabled">
+          ${%btn.reserve}
+        </button>
+        <button type="button" class="jenkins-button jenkins-!-success-color lockable-resources-bulk-action-button" data-action="unreserve" disabled="disabled">
+          ${%btn.unReserve}
+        </button>
+      </l:hasPermission>
 
-            <!-- **************************************************************
-                 Status column
-            -->
-            <j:set var="cssClass" value=""/>
-            <j:choose>
-            <!-- Reserved by user, config or API.
-                 It differs to lock() or `queue` that this must be unreserve by some action.
-                 This kind is dangeresous, because it might leads to long blockage.
-                 Therefore we use `danger`color here.
-            -->
-              <j:when test="${resource.reservedBy != null}">
-                <j:set var="cssClass" value="destructive"/>
-              </j:when>
-            <!-- Locked by job. This will be unlock automatically (I hope)
-                 Therefore use `warning`only
-            -->
-              <j:when test="${resource.locked}">
-                <j:set var="cssClass" value="warning"/>
-              </j:when>
-            <!-- Queued by matrix-job. This will be unlock automatically (I hope)
-                 Therefore use `warning`only
-            -->
-              <j:when test="${resource.queued}">
-                <j:set var="cssClass" value="warning"/>
-              </j:when>
-            <!-- Resource is (or it looks so) fre
-            -->
-              <j:otherwise>
-                <j:set var="cssClass" value="success"/>
-              </j:otherwise>
-            </j:choose>
+      <l:hasPermission permission="${it.UNLOCK}">
+        <button type="button" class="jenkins-button jenkins-!-warning-color lockable-resources-bulk-action-button" data-action="unlock" disabled="disabled">
+          ${%btn.unlock}
+        </button>
+        <button type="button" class="jenkins-button jenkins-!-destructive-color lockable-resources-bulk-action-button" data-action="reset" disabled="disabled">
+          ${%btn.reset}
+        </button>
+      </l:hasPermission>
 
-            <td class="jenkins-!-${cssClass}-color">
-              <j:choose>
-            <!-- Reserved by user, config or API.
-                 It differs to lock() or `queue` that this must be unreserve by some action.
-                 This kind is dangeresous, because it might leads to long blockage.
-                 Therefore we use `danger`color here.
-            -->
-              <j:when test="${resource.reservedBy != null}">
-                ${%resource.status.reservedBy(resource.reservedBy)}
-                <j:if test="${resource.lockReason != null and !resource.lockReason.isEmpty()}">
-                  <br/>
-                  <span class="jenkins-!-font-weight-normal">${%resource.status.reason}: ${resource.lockReason}</span>
-                </j:if>
-              </j:when>
-            <!-- Locked by job. This will be unlock automatically (I hope)
-                 Therefore use `warning`only
-            -->
-              <j:when test="${resource.locked}">
-                ${%resource.status.locked(rootURL + '/' + resource.build.url, resource.build.fullDisplayName)}
-                <j:if test="${resource.lockReason != null and !resource.lockReason.isEmpty()}">
-                  <br/>
-                  <span class="jenkins-!-font-weight-normal">${%resource.status.reason}: ${resource.lockReason}</span>
-                </j:if>
-              </j:when>
-            <!-- Queued by matrix-job. This will be unlock automatically (I hope)
-                 Therefore use `warning`only
-            -->
-              <j:when test="${resource.queued}">
-                ${%resource.status.queuedBy(resource.queueItemProject, resource.queueItemId)}
-              </j:when>
-            <!-- Resource is (or it looks so) free
-            -->
-              <j:otherwise>
-                ${%resource.status.free}
-              </j:otherwise>
-            </j:choose>
-
-            <!-- add timestamp when possible -->
-              <j:if test="${resource.reservedTimestamp != null}">
-                <br />
-                ${%ago(h.getTimeSpanString(resource.reservedTimestamp))}
-              </j:if>
-            </td>
-
-
-            <!-- **************************************************************
-                 Reserved / locked timestamp column
-            -->
-            <j:choose>
-              <j:when test="${resource.reservedTimestamp != null}">
-                <td data-order="${resource.reservedTimestamp.time}">
-                  <i:formatDate
-                    value="${resource.reservedTimestamp}"
-                    type="both"
-                    dateStyle="medium"
-                    timeStyle="short"
-                  />
-                </td>
-              </j:when>
-              <j:otherwise>
-                <td></td>
-              </j:otherwise>
-            </j:choose>
-
-
-            <!-- **************************************************************
-                 Labels column
-            -->
-            <td>
-              <!--todo replace it by getLabelsAsList() -->
-              <j:forEach var="label" items="${resource.getLabelsAsList()}">
-                <a class="jenkins-table__link model-link" href="${rootURL}/label/${label}">
-                  ${label}
-                  <button class="jenkins-menu-dropdown-chevron"></button
-                >
-                </a>
-              </j:forEach>
-            </td>
-
-            <!-- **************************************************************
-                 Table with assigned properties
-            -->
-            <td class="jenkins-!-padding-0">
-              <j:if test="${resource.properties.size() gt 0}">
-                <div class="table-responsive">
-                  <table class="jenkins-table jenkins-!-margin-0 table-properties">
-                    <tbody>
-                     <j:forEach var="property" items="${resource.properties}">
-                        <tr>
-                          <td>${property.name}</td>
-                          <td>${property.value}</td>
-                        </tr>
-                      </j:forEach>
-                    </tbody>
-                  </table>
-                </div>
-              </j:if>
-            </td>
-
-            <!-- **************************************************************
-                 Action column
-            -->
-            <td>
-              <j:choose>
-                <j:when test="${resource.locked}">
-                  <l:hasPermission permission="${it.UNLOCK}">
-                    <button
-                      data-action="unlock"
-                      class="jenkins-button j.jenkins-!-warning-color lockable-resources-action-button"
-                      tooltip="${%btn.unlock.detail}"
-                    >
-                      ${%btn.unlock}
-                    </button>
-                  </l:hasPermission>
-                  <l:hasPermission permission="${it.STEAL}">
-                    <button
-                      data-action="steal"
-                      class="jenkins-button jenkins-!-destructive-color lockable-resources-action-button"
-                      tooltip="${%btn.steal.detail}"
-                    >
-                      ${%btn.steal}
-                    </button>
-                  </l:hasPermission>
-                </j:when>
-                <j:when test="${resource.reservedBy != null}">
-                  <l:hasPermission permission="${it.RESERVE}">
-                    <j:if test="${resource.isReservedByCurrentUser() or h.hasPermission(app.ADMINISTER)}">
-                      <button
-                        data-action="unreserve"
-                        class="jenkins-button jenkins-!-success-color lockable-resources-action-button"
-                        tooltip="${%btn.unReserve.detail}"
-                      >
-                        ${%btn.unReserve}
-                      </button>
-                    </j:if>
-                  </l:hasPermission>
-                  <l:hasPermission permission="${it.STEAL}">
-                    <j:if test="${!resource.isReservedByCurrentUser()}">
-                      <button
-                        data-action="reassign"
-                        class="jenkins-button jenkins-button--primary lockable-resources-action-button"
-                        tooltip="${%btn.reassign.detail}"
-                      >
-                        ${%btn.reassign}
-                      </button>
-                    </j:if>
-                  </l:hasPermission>
-                </j:when>
-                <j:when test="${resource.queued}">
-                  <l:hasPermission permission="${it.UNLOCK}">
-                    <button
-                      data-action="reset"
-                      class="jenkins-button jenkins-!-destructive-color lockable-resources-action-button"
-                      tooltip="${%btn.reset.detail}"
-                    >
-                      ${%btn.reset}
-                    </button>
-                  </l:hasPermission>
-                </j:when>
-                <j:otherwise>
-                  <l:hasPermission permission="${it.RESERVE}">
-                    <button
-                      data-action="reserve"
-                      class="jenkins-button jenkins-button--primary lockable-resources-action-button"
-                      tooltip="${%btn.reserve.detail}"
-                    >
-                      ${%btn.reserve}
-                    </button>
-                  </l:hasPermission>
-                </j:otherwise>
-              </j:choose>
-            </td>
-          </tr>
-        </j:forEach>
-      </tbody>
-    </table>
+      <l:hasPermission permission="${it.STEAL}">
+        <button type="button" class="jenkins-button jenkins-!-destructive-color lockable-resources-bulk-action-button" data-action="steal" disabled="disabled">
+          ${%btn.steal}
+        </button>
+        <button type="button" class="jenkins-button jenkins-button--primary lockable-resources-bulk-action-button" data-action="reassign" disabled="disabled">
+          ${%btn.reassign}
+        </button>
+      </l:hasPermission>
+    </div>
   </div>
-  <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"/>
+
+  <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/table-resources-filters.js"></script>
+  <script type="text/javascript" src="${resURL}/plugin/lockable-resources/js/lockable-resources.js"></script>
 
 
 

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -22,6 +22,7 @@
 
 #table resources
 resources.table.column.index=Index
+resources.table.column.select=Select
 resources.table.column.resource=Resource
 resources.table.column.status=Status
 resources.table.column.labels=Labels
@@ -69,3 +70,16 @@ btn.editNote.detail=Edit resource note.
 # Table settings
 table.settings.page.length.all=ALL
 table.empty=No resources configured
+
+# Column filters
+table.filter.index=Filter index
+table.filter.resource=Filter resource
+table.filter.status=Filter status
+table.filter.timestamp=Filter timestamp
+table.filter.labels=Filter labels
+
+# Column visibility
+table.buttons.columns=Columns
+
+# Bulk actions
+bulk.selected=Selected:

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.properties
@@ -22,7 +22,6 @@
 
 #table resources
 resources.table.column.index=Index
-resources.table.column.select=Select
 resources.table.column.resource=Resource
 resources.table.column.status=Status
 resources.table.column.labels=Labels

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_cs.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_cs.properties
@@ -22,6 +22,7 @@
 
 #table resources
 resources.table.column.index=Index
+resources.table.column.select=Vybrat
 resources.table.column.resource=Zdroj
 resources.table.column.status=Stav
 resources.table.column.labels=Popisky

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_de.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_de.properties
@@ -22,6 +22,7 @@
 
 #table resources
 resources.table.column.index=Index
+resources.table.column.select=Auswahl
 resources.table.column.resource=Ressource
 resources.table.column.status=Status
 resources.table.column.labels=Labels

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_fr.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_fr.properties
@@ -22,6 +22,7 @@
 
 #table resources
 resources.table.column.index=Index
+resources.table.column.select=S\u00e9lection
 resources.table.column.resource=Ressource
 resources.table.column.status=Statut
 resources.table.column.labels=Libell\u00e9s

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_sk.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table_sk.properties
@@ -22,6 +22,7 @@
 
 #table resources
 resources.table.column.index=Index
+resources.table.column.select=Vybra\u0165
 resources.table.column.resource=Zdroj
 resources.table.column.status=Stav
 resources.table.column.labels=\u0160t\u00edtky

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockedResourcesBuildAction/index.jelly
@@ -95,7 +95,7 @@ THE SOFTWARE.
             </tbody>
           </table>
       </div>
-      <script type="text/javascript" src="${resURL}/plugin/data-tables-api/js/table.js"/>
+      <script type="text/javascript" src="${resURL}/plugin/data-tables-api/js/table.js"></script>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -58,3 +58,55 @@ table.dataTable td, table.dataTable th {
 .queuebar:empty {
   display: none;
 }
+
+.lockable-resources-bulk-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  background: var(--background);
+  border-top: 1px solid var(--hairline-color);
+  padding: 0.75rem 0;
+}
+
+.lockable-resources-bulk-bar[aria-hidden="true"] {
+  display: none;
+}
+
+.lockable-resources-bulk-bar__content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lockable-resources-bulk-bar__count {
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.lockable-resources-donut-layout {
+  display: flex;
+  justify-content: center;
+}
+
+.lockable-resources-donut-wrap {
+  position: relative;
+  width: 9rem;
+  height: 9rem;
+}
+
+.lockable-resources-donut {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  -webkit-mask: radial-gradient(circle, transparent 0 62%, #000 63% 100%);
+  mask: radial-gradient(circle, transparent 0 62%, #000 63% 100%);
+}
+
+.lockable-resources-donut__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -1,33 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020, Tobias Gruetzmacher
 
-// Jenkins core used to expose a global `crumb` helper. Newer Jenkins pages expose
-// crumb data via <head data-crumb-header/data-crumb-value> instead.
-// The Stapler JS proxy (org/kohsuke/stapler/bind.js) and this plugin both rely on
-// `crumb.wrap(...)` to attach the CSRF crumb to POST requests.
-// Create a minimal compatibility shim if it's missing.
-(function () {
-  if (typeof window.crumb !== 'undefined') {
-    return;
-  }
-  const head = document.querySelector('head');
-  if (!head) {
-    return;
-  }
-  const header = head.getAttribute('data-crumb-header');
-  const value = head.getAttribute('data-crumb-value');
-  if (!header || !value) {
-    return;
-  }
-  window.crumb = {
-    wrap: function (headers) {
-      const merged = headers ? Object.assign({}, headers) : {};
-      merged[header] = value;
-      return merged;
-    }
-  };
-})();
-
 function changeQueueOrder(queueId) {
 
   dialog
@@ -227,79 +200,37 @@ function bulk_resource_action(action) {
   run(null);
 }
 
-function initDataTableColumnFilters(tableEl, api, tableId) {
-  if (!tableEl || !api) {
-    return;
-  }
-
-  const toolbar = tableId ? document.getElementById('toolbar-' + tableId) : null;
-  const container = toolbar || tableEl;
-
-  const inputs = container.querySelectorAll('input.lockable-resources-column-filter[data-dt-column]');
-  if (!inputs || inputs.length === 0) {
-    return;
-  }
-
-  inputs.forEach(function (input) {
-    if (input.dataset.lrBound === 'true') {
-      return;
-    }
-
-    const columnIndex = parseInt(input.dataset.dtColumn, 10);
-    if (Number.isNaN(columnIndex)) {
-      return;
-    }
-
-    // Initialize from restored state (stateSave).
-    const existing = api.column(columnIndex).search();
-    if (existing) {
-      input.value = existing;
-    }
-
-    input.addEventListener('input', function () {
-      api.column(columnIndex).search(input.value || '').draw();
-    });
-
-    // When filters are inside a <th>, prevent triggering sort.
-    input.addEventListener('click', function (e) {
-      e.stopPropagation();
-    });
-
-    input.dataset.lrBound = 'true';
-  });
-}
-
-// Column filters for DataTables instances on LR pages.
-// Prefer the init.dt event, but also handle tables that initialized before this script attached.
-jQuery3(document).on('init.dt', 'table.data-table', function (_event, settings) {
-  try {
-    const tableEl = settings && settings.nTable;
-    if (!tableEl) {
-      return;
-    }
-    const api = new jQuery3.fn.dataTable.Api(settings);
-    initDataTableColumnFilters(tableEl, api, settings.sTableId);
-  } catch (e) {
-    console.warn('[LR] Failed to initialize column filters', e);
-  }
-});
-
 jQuery3(document).ready(function () {
-  try {
-    if (!jQuery3.fn.dataTable || !jQuery3.fn.dataTable.isDataTable) {
-      return;
-    }
-
-    jQuery3('table.data-table').each(function () {
-      if (!jQuery3.fn.dataTable.isDataTable(this)) {
+  // Column filters for DataTables instances on LR pages.
+  // We hook into DataTables' init event (triggered by data-tables-api) to avoid race conditions.
+  jQuery3(document).on('init.dt', 'table.data-table', function (_event, settings) {
+    try {
+      const api = new jQuery3.fn.dataTable.Api(settings);
+      const toolbar = document.getElementById('toolbar-' + settings.sTableId);
+      if (!toolbar) {
         return;
       }
-      const api = jQuery3(this).DataTable();
-      initDataTableColumnFilters(this, api, this.id);
-    });
-  } catch (e) {
-    console.warn('[LR] Failed to initialize existing column filters', e);
-  }
+
+      toolbar.querySelectorAll('input.lockable-resources-column-filter[data-dt-column]').forEach(function (input) {
+        const columnIndex = parseInt(input.dataset.dtColumn, 10);
+        if (Number.isNaN(columnIndex)) {
+          return;
+        }
+
+        // Initialize from restored state (stateSave).
+        const existing = api.column(columnIndex).search();
+        if (existing) {
+          input.value = existing;
+        }
+
+        input.addEventListener('input', function () {
+          api.column(columnIndex).search(input.value || '').draw();
+        });
+      });
+    } catch (e) {
+      console.warn('[LR] Failed to initialize column filters', e);
+    }
+  });
 
   // Delegate clicks since table rows are loaded asynchronously.
   document.addEventListener("click", function (event) {

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -1,6 +1,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020, Tobias Gruetzmacher
 
+// Jenkins core used to expose a global `crumb` helper. Newer Jenkins pages expose
+// crumb data via <head data-crumb-header/data-crumb-value> instead.
+// The Stapler JS proxy (org/kohsuke/stapler/bind.js) and this plugin both rely on
+// `crumb.wrap(...)` to attach the CSRF crumb to POST requests.
+// Create a minimal compatibility shim if it's missing.
+(function () {
+  if (typeof window.crumb !== 'undefined') {
+    return;
+  }
+  const head = document.querySelector('head');
+  if (!head) {
+    return;
+  }
+  const header = head.getAttribute('data-crumb-header');
+  const value = head.getAttribute('data-crumb-value');
+  if (!header || !value) {
+    return;
+  }
+  window.crumb = {
+    wrap: function (headers) {
+      const merged = headers ? Object.assign({}, headers) : {};
+      merged[header] = value;
+      return merged;
+    }
+  };
+})();
+
 function changeQueueOrder(queueId) {
 
   dialog
@@ -38,14 +65,23 @@ function showResponse(rsp, okText, errorText) {
 }
 
 function find_resource_name(element) {
-  var row = element.closest('tr');
-  var resourceName = row.getAttribute('data-resource-name');
-  return resourceName;
+  // With async-loaded DataTables rows, events are delegated and there may be no stable
+  // <tr data-resource-name> attribute. Prefer an explicit data-resource-name on the
+  // clicked element.
+  if (element && element.dataset && element.dataset.resourceName) {
+    return element.dataset.resourceName;
+  }
+  var host = element && element.closest ? element.closest('[data-resource-name]') : null;
+  return host ? host.getAttribute('data-resource-name') : null;
 }
 
 
 function resource_action(button, action) {
   var resourceName = find_resource_name(button);
+  if (!resourceName) {
+    console.warn("[LR] Could not resolve resourceName for action", action);
+    return;
+  }
   console.log("[LR] resource_action called:", action, resourceName);
 
   // For reserve and steal actions, prompt for a reason
@@ -122,89 +158,176 @@ function replaceNote(resourceName) {
   });
 }
 
-function format(d) {
-  // `d` is the original data object for the row
-  // show all the hidden columns in the child row
-  var hiddenRows = getHiddenColumns();
-  return hiddenRows.map(i => d[i]).join("<br>");
-}
-
-function getHiddenColumns() {
-  // returns the indexes of all hidden rows
-  var indexes = new Array();
-
-  jQuery("#lockable-resources").DataTable().columns().every(function () {
-    if (!this.visible())
-      indexes.push(this.index())
-  });
-
-  return indexes;
-}
-
 function i18n(messageId, arg0, arg1) {
   return document.querySelector("#i18n").getAttribute("data-" + messageId).replace("{0}", arg0).replace("{1}", arg1);
 }
 
-jQuery(document).ready(function () {
+function getSelectedResources() {
+  if (window.lockableResourcesSelection && typeof window.lockableResourcesSelection.getSelected === 'function') {
+    return window.lockableResourcesSelection.getSelected();
+  }
+  return [];
+}
 
-  // Add event listener to store last opened tab
-  var triggerTabList = document.querySelectorAll('button[data-bs-toggle="tab"]')
-  triggerTabList.forEach(tabEl => {
-    tabEl.addEventListener('show.bs.tab', function (event) {
-      localStorage.setItem('lockable-resources-active-tab', event.target.dataset.bsTarget);
-    })
+function bulk_resource_action(action) {
+  const selected = getSelectedResources();
+  if (!selected.length) {
+    return;
+  }
+
+  const summaryName = selected.length === 1 ? selected[0] : (selected.length + " resources");
+
+  function run(reason) {
+    let okCount = 0;
+    let failCount = 0;
+
+    return selected.reduce(
+      (p, resourceName) => p.then(() => {
+        let url = action + "?resource=" + encodeURIComponent(resourceName);
+        if (reason !== undefined && reason !== null) {
+          url += "&reason=" + encodeURIComponent(reason || "");
+        }
+        return fetch(url, { method: "post", headers: crumb.wrap({}) }).then((rsp) => {
+          if (rsp.ok) {
+            okCount++;
+          } else {
+            failCount++;
+          }
+        });
+      }),
+      Promise.resolve()
+    ).then(() => {
+      if (failCount === 0) {
+        notificationBar.show(i18n("action-on-success", action, summaryName), notificationBar.SUCCESS);
+      } else {
+        dialog.alert(i18n("action-on-fail", action, summaryName), {
+          message: okCount + " succeeded, " + failCount + " failed"
+        });
+      }
+      if (window.lockableResourcesSelection && typeof window.lockableResourcesSelection.clear === 'function') {
+        window.lockableResourcesSelection.clear();
+      }
+      window.location.reload();
+    });
+  }
+
+  if (action === "reserve" || action === "steal") {
+    const titleKey = action + "-title";
+    const messageKey = action + "-message";
+    dialog
+      .prompt(i18n(titleKey, summaryName), {
+        message: i18n(messageKey, summaryName),
+        minWidth: "450px",
+        maxWidth: "600px"
+      })
+      .then((reason) => run(reason));
+    return;
+  }
+
+  run(null);
+}
+
+function initDataTableColumnFilters(tableEl, api, tableId) {
+  if (!tableEl || !api) {
+    return;
+  }
+
+  const toolbar = tableId ? document.getElementById('toolbar-' + tableId) : null;
+  const container = toolbar || tableEl;
+
+  const inputs = container.querySelectorAll('input.lockable-resources-column-filter[data-dt-column]');
+  if (!inputs || inputs.length === 0) {
+    return;
+  }
+
+  inputs.forEach(function (input) {
+    if (input.dataset.lrBound === 'true') {
+      return;
+    }
+
+    const columnIndex = parseInt(input.dataset.dtColumn, 10);
+    if (Number.isNaN(columnIndex)) {
+      return;
+    }
+
+    // Initialize from restored state (stateSave).
+    const existing = api.column(columnIndex).search();
+    if (existing) {
+      input.value = existing;
+    }
+
+    input.addEventListener('input', function () {
+      api.column(columnIndex).search(input.value || '').draw();
+    });
+
+    // When filters are inside a <th>, prevent triggering sort.
+    input.addEventListener('click', function (e) {
+      e.stopPropagation();
+    });
+
+    input.dataset.lrBound = 'true';
   });
+}
 
-  // activate last opened tab
-  var activeTab;
+// Column filters for DataTables instances on LR pages.
+// Prefer the init.dt event, but also handle tables that initialized before this script attached.
+jQuery3(document).on('init.dt', 'table.data-table', function (_event, settings) {
   try {
-    activeTab = localStorage.getItem('lockable-resources-active-tab');
+    const tableEl = settings && settings.nTable;
+    if (!tableEl) {
+      return;
+    }
+    const api = new jQuery3.fn.dataTable.Api(settings);
+    initDataTableColumnFilters(tableEl, api, settings.sTableId);
   } catch (e) {
-    console.log("localstorage is not allowed");
+    console.warn('[LR] Failed to initialize column filters', e);
   }
-  if (activeTab) {
-    const triggerEL = document.querySelector(`button[data-bs-target="${activeTab}"]`);
-    if (triggerEL) {
-      bootstrap.Tab.getOrCreateInstance(triggerEL).show()
+});
+
+jQuery3(document).ready(function () {
+  try {
+    if (!jQuery3.fn.dataTable || !jQuery3.fn.dataTable.isDataTable) {
+      return;
     }
+
+    jQuery3('table.data-table').each(function () {
+      if (!jQuery3.fn.dataTable.isDataTable(this)) {
+        return;
+      }
+      const api = jQuery3(this).DataTable();
+      initDataTableColumnFilters(this, api, this.id);
+    });
+  } catch (e) {
+    console.warn('[LR] Failed to initialize existing column filters', e);
   }
 
-  // Add event listener for opening and closing details
-  jQuery('#lockable-resources tbody').on('click', 'td.dt-control', function () {
-    var tr = jQuery(this).closest('tr');
-    var row = jQuery("#lockable-resources").DataTable().row(tr);
-
-    // child row example taken from https://datatables.net/examples/api/row_details.html
-    if (row.child.isShown()) {
-      // This row is already open - close it
-      row.child.hide();
-      tr.removeClass('shown');
-    } else {
-      // Open this row
-      row.child(format(row.data())).show();
-      tr.addClass('shown');
+  // Delegate clicks since table rows are loaded asynchronously.
+  document.addEventListener("click", function (event) {
+    const bulkButton = event.target.closest(".lockable-resources-bulk-action-button");
+    if (bulkButton) {
+      const action = bulkButton.dataset.action;
+      bulk_resource_action(action);
+      return;
     }
-  });
 
-  document.querySelectorAll(".lockable-resources-action-button").forEach(function (button) {
-    button.addEventListener("click", function (event) {
-      const target = event.target;
-      const action = target.dataset.action;
-      resource_action(target, action);
-    });
-  });
+    const actionButton = event.target.closest(".lockable-resources-action-button");
+    if (actionButton) {
+      const action = actionButton.dataset.action;
+      resource_action(actionButton, action);
+      return;
+    }
 
-  document.querySelectorAll(".lockable-resources-change-queue-order").forEach(function (button) {
-    button.addEventListener("click", function (event) {
-      changeQueueOrder(event.target.dataset.queueItemId);
-    });
-  });
+    const queueButton = event.target.closest(".lockable-resources-change-queue-order");
+    if (queueButton) {
+      changeQueueOrder(queueButton.dataset.queueItemId);
+      return;
+    }
 
-  document.querySelectorAll(".lockable-resources-replace-note").forEach(function (anchor) {
-    anchor.addEventListener("click", function (event) {
+    const noteLink = event.target.closest(".lockable-resources-replace-note");
+    if (noteLink) {
       event.preventDefault();
-      replaceNote(event.target.dataset.resourceName);
-    });
+      replaceNote(noteLink.dataset.resourceName);
+    }
   });
 });
 

--- a/src/main/webapp/js/table-labels-filters.js
+++ b/src/main/webapp/js/table-labels-filters.js
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2020, Tobias Gruetzmacher
+
+/* global jQuery3 */
+
+(function () {
+  function initColumnFilters(tableEl, api) {
+    if (!tableEl || !api) {
+      return;
+    }
+
+    const inputs = tableEl.querySelectorAll('input.lockable-resources-column-filter[data-dt-column]');
+    if (!inputs || inputs.length === 0) {
+      return;
+    }
+
+    inputs.forEach(function (input) {
+      if (input.dataset.lrBound === 'true') {
+        return;
+      }
+
+      const columnIndex = parseInt(input.dataset.dtColumn, 10);
+      if (Number.isNaN(columnIndex)) {
+        return;
+      }
+
+      // Initialize from restored state (stateSave).
+      const existing = api.column(columnIndex).search();
+      if (existing) {
+        input.value = existing;
+      }
+
+      input.addEventListener('input', function () {
+        api.column(columnIndex).search(input.value || '').draw();
+      });
+
+      // When filters are inside a <th>, prevent triggering sort.
+      input.addEventListener('click', function (e) {
+        e.stopPropagation();
+      });
+
+      input.dataset.lrBound = 'true';
+    });
+  }
+
+  // Prefer init.dt (fires when DataTables initializes), but also handle the case where
+  // DataTables initialized before this script attached.
+  jQuery3(function () {
+    jQuery3(document).on('init.dt', 'table.data-table', function (_event, settings) {
+      const tableEl = settings && settings.nTable;
+      if (!tableEl || tableEl.id !== 'lockable-resources-labels') {
+        return;
+      }
+
+      try {
+        const api = new jQuery3.fn.dataTable.Api(settings);
+        initColumnFilters(tableEl, api);
+      } catch (e) {
+        // Don't break the page.
+        // eslint-disable-next-line no-console
+        console.warn('[LR] Failed to initialize labels column filters', e);
+      }
+    });
+
+    // If the table was initialized before we attached the init handler.
+    try {
+      const tableEl = document.getElementById('lockable-resources-labels');
+      if (!tableEl) {
+        return;
+      }
+      if (!jQuery3.fn.dataTable || !jQuery3.fn.dataTable.isDataTable) {
+        return;
+      }
+      if (jQuery3.fn.dataTable.isDataTable(tableEl)) {
+        initColumnFilters(tableEl, jQuery3(tableEl).DataTable());
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('[LR] Failed to initialize existing labels column filters', e);
+    }
+  });
+})();

--- a/src/main/webapp/js/table-resources-filters.js
+++ b/src/main/webapp/js/table-resources-filters.js
@@ -4,158 +4,6 @@
 /* global jQuery3 */
 
 (function () {
-  function enhanceResourcesTable(tableEl, settings) {
-    if (!tableEl || tableEl.id !== 'lockable-resources') {
-      return;
-    }
-
-    if (tableEl.dataset.lrResourcesEnhanced === 'true') {
-      return;
-    }
-
-    let dataTable;
-    try {
-      if (settings) {
-        dataTable = new jQuery3.fn.dataTable.Api(settings);
-      } else {
-        dataTable = jQuery3(tableEl).DataTable();
-      }
-    } catch (e) {
-      // If DataTables hasn't initialized yet, we'll try again via init.dt.
-      return;
-    }
-
-    tableEl.dataset.lrResourcesEnhanced = 'true';
-
-    const selectedSet = new Set();
-    let lastClickedResourceName = null;
-
-    function setSelected(resourceName, selected) {
-      if (!resourceName) {
-        return;
-      }
-      if (selected) {
-        selectedSet.add(resourceName);
-      } else {
-        selectedSet.delete(resourceName);
-      }
-    }
-
-    function setCheckbox(cb, selected) {
-      if (!cb) {
-        return;
-      }
-      cb.checked = selected;
-      setSelected(cb.getAttribute('data-resource-name'), selected);
-    }
-
-    // Expose selection to other scripts (bulk action handler).
-    window.lockableResourcesSelection = {
-      getSelected: function () {
-        return Array.from(selectedSet);
-      },
-      clear: function () {
-        selectedSet.clear();
-        syncCheckboxesFromSelection(tableEl, selectedSet);
-        updateSelectAllCheckbox(tableEl);
-        updateBulkBar(selectedSet);
-      }
-    };
-
-    const headerRow = tableEl.querySelector('thead tr');
-    if (headerRow) {
-      ensureSelectAllCheckbox(headerRow, tableEl, dataTable, selectedSet);
-    }
-
-    // Only filter the primary "Resource" column.
-    initColumnFilters(tableEl, dataTable, new Set([2]));
-
-    updateBulkBar(selectedSet);
-
-    // Track selection changes (delegated).
-    tableEl.addEventListener('change', function (e) {
-      const cb = e.target && e.target.closest ? e.target.closest('input.lockable-resources-select[data-resource-name]') : null;
-      if (!cb) {
-        return;
-      }
-      const name = cb.getAttribute('data-resource-name');
-      if (!name) {
-        return;
-      }
-      setSelected(name, cb.checked);
-      updateSelectAllCheckbox(tableEl);
-      updateBulkBar(selectedSet);
-    });
-
-    // Improve multi-row selection:
-    // - shift+click a checkbox to select a range (current page only)
-    // - click a row (non-interactive area) to toggle its checkbox
-    tableEl.addEventListener('click', function (e) {
-      const checkbox = e.target && e.target.closest
-        ? e.target.closest('input.lockable-resources-select[data-resource-name]')
-        : null;
-
-      if (checkbox) {
-        const currentName = checkbox.getAttribute('data-resource-name');
-        if (e.shiftKey && lastClickedResourceName && currentName) {
-          const cbs = Array.from(
-            tableEl.querySelectorAll('tbody input.lockable-resources-select[data-resource-name]')
-          );
-          const fromIndex = cbs.findIndex(function (x) {
-            return x.getAttribute('data-resource-name') === lastClickedResourceName;
-          });
-          const toIndex = cbs.findIndex(function (x) {
-            return x.getAttribute('data-resource-name') === currentName;
-          });
-
-          if (fromIndex >= 0 && toIndex >= 0) {
-            const start = Math.min(fromIndex, toIndex);
-            const end = Math.max(fromIndex, toIndex);
-            const selected = checkbox.checked;
-            for (let i = start; i <= end; i++) {
-              setCheckbox(cbs[i], selected);
-            }
-            updateSelectAllCheckbox(tableEl);
-            updateBulkBar(selectedSet);
-          }
-        }
-
-        if (currentName) {
-          lastClickedResourceName = currentName;
-        }
-        return;
-      }
-
-      // Ignore clicks on interactive elements.
-      if (e.target && e.target.closest && e.target.closest('a,button,input,select,textarea,label')) {
-        return;
-      }
-
-      const row = e.target && e.target.closest ? e.target.closest('tbody tr') : null;
-      if (!row) {
-        return;
-      }
-
-      const rowCb = row.querySelector('input.lockable-resources-select[data-resource-name]');
-      if (!rowCb) {
-        return;
-      }
-
-      const selected = !rowCb.checked;
-      setCheckbox(rowCb, selected);
-      lastClickedResourceName = rowCb.getAttribute('data-resource-name');
-      updateSelectAllCheckbox(tableEl);
-      updateBulkBar(selectedSet);
-    });
-
-    // Persist selection across redraws/paging.
-    jQuery3(tableEl).on('draw.dt', function () {
-      syncCheckboxesFromSelection(tableEl, selectedSet);
-      updateSelectAllCheckbox(tableEl);
-      updateBulkBar(selectedSet);
-    });
-  }
-
   function updateBulkBar(selectedSet) {
     const bar = document.getElementById('lockable-resources-bulk-bar');
     if (!bar) {
@@ -295,32 +143,64 @@
     thead.appendChild(filterRow);
   }
 
-  // Prefer init.dt (fires when DataTables initializes), but also handle the case where
-  // DataTables initialized before this script attached.
-  jQuery3(document).on('init.dt', function (_event, settings) {
-    try {
+  jQuery3(function () {
+    jQuery3(document).on('init.dt', function (_event, settings) {
       const tableEl = settings && settings.nTable;
-      enhanceResourcesTable(tableEl, settings);
-    } catch (e) {
-      // Don't break the page.
-      console.warn('[LR] Failed to enhance resources table on init.dt', e);
-    }
-  });
+      if (!tableEl || tableEl.id !== 'lockable-resources') {
+        return;
+      }
 
-  jQuery3(document).ready(function () {
-    try {
-      const tableEl = document.getElementById('lockable-resources');
-      if (!tableEl) {
-        return;
+      const dt = jQuery3(tableEl).DataTable();
+
+      const selectedSet = new Set();
+
+      // Expose selection to other scripts (bulk action handler).
+      window.lockableResourcesSelection = {
+        getSelected: function () {
+          return Array.from(selectedSet);
+        },
+        clear: function () {
+          selectedSet.clear();
+          syncCheckboxesFromSelection(tableEl, selectedSet);
+          updateSelectAllCheckbox(tableEl);
+          updateBulkBar(selectedSet);
+        }
+      };
+
+      const headerRow = tableEl.querySelector('thead tr');
+      if (headerRow) {
+        ensureSelectAllCheckbox(headerRow, tableEl, dt, selectedSet);
       }
-      if (!jQuery3.fn.dataTable || !jQuery3.fn.dataTable.isDataTable) {
-        return;
-      }
-      if (jQuery3.fn.dataTable.isDataTable(tableEl)) {
-        enhanceResourcesTable(tableEl);
-      }
-    } catch (e) {
-      console.warn('[LR] Failed to enhance existing resources table', e);
-    }
+
+      initColumnFilters(tableEl, dt, new Set([1, 2, 3, 4, 5]));
+
+      updateBulkBar(selectedSet);
+
+      // Track selection changes (delegated).
+      tableEl.addEventListener('change', function (e) {
+        const cb = e.target && e.target.closest ? e.target.closest('input.lockable-resources-select[data-resource-name]') : null;
+        if (!cb) {
+          return;
+        }
+        const name = cb.getAttribute('data-resource-name');
+        if (!name) {
+          return;
+        }
+        if (cb.checked) {
+          selectedSet.add(name);
+        } else {
+          selectedSet.delete(name);
+        }
+        updateSelectAllCheckbox(tableEl);
+        updateBulkBar(selectedSet);
+      });
+
+      // Persist selection across redraws/paging.
+      jQuery3(tableEl).on('draw.dt', function () {
+        syncCheckboxesFromSelection(tableEl, selectedSet);
+        updateSelectAllCheckbox(tableEl);
+        updateBulkBar(selectedSet);
+      });
+    });
   });
 })();

--- a/src/main/webapp/js/table-resources-filters.js
+++ b/src/main/webapp/js/table-resources-filters.js
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026
+
+/* global jQuery3 */
+
+(function () {
+  function enhanceResourcesTable(tableEl, settings) {
+    if (!tableEl || tableEl.id !== 'lockable-resources') {
+      return;
+    }
+
+    if (tableEl.dataset.lrResourcesEnhanced === 'true') {
+      return;
+    }
+
+    let dataTable;
+    try {
+      if (settings) {
+        dataTable = new jQuery3.fn.dataTable.Api(settings);
+      } else {
+        dataTable = jQuery3(tableEl).DataTable();
+      }
+    } catch (e) {
+      // If DataTables hasn't initialized yet, we'll try again via init.dt.
+      return;
+    }
+
+    tableEl.dataset.lrResourcesEnhanced = 'true';
+
+    const selectedSet = new Set();
+    let lastClickedResourceName = null;
+
+    function setSelected(resourceName, selected) {
+      if (!resourceName) {
+        return;
+      }
+      if (selected) {
+        selectedSet.add(resourceName);
+      } else {
+        selectedSet.delete(resourceName);
+      }
+    }
+
+    function setCheckbox(cb, selected) {
+      if (!cb) {
+        return;
+      }
+      cb.checked = selected;
+      setSelected(cb.getAttribute('data-resource-name'), selected);
+    }
+
+    // Expose selection to other scripts (bulk action handler).
+    window.lockableResourcesSelection = {
+      getSelected: function () {
+        return Array.from(selectedSet);
+      },
+      clear: function () {
+        selectedSet.clear();
+        syncCheckboxesFromSelection(tableEl, selectedSet);
+        updateSelectAllCheckbox(tableEl);
+        updateBulkBar(selectedSet);
+      }
+    };
+
+    const headerRow = tableEl.querySelector('thead tr');
+    if (headerRow) {
+      ensureSelectAllCheckbox(headerRow, tableEl, dataTable, selectedSet);
+    }
+
+    // Only filter the primary "Resource" column.
+    initColumnFilters(tableEl, dataTable, new Set([2]));
+
+    updateBulkBar(selectedSet);
+
+    // Track selection changes (delegated).
+    tableEl.addEventListener('change', function (e) {
+      const cb = e.target && e.target.closest ? e.target.closest('input.lockable-resources-select[data-resource-name]') : null;
+      if (!cb) {
+        return;
+      }
+      const name = cb.getAttribute('data-resource-name');
+      if (!name) {
+        return;
+      }
+      setSelected(name, cb.checked);
+      updateSelectAllCheckbox(tableEl);
+      updateBulkBar(selectedSet);
+    });
+
+    // Improve multi-row selection:
+    // - shift+click a checkbox to select a range (current page only)
+    // - click a row (non-interactive area) to toggle its checkbox
+    tableEl.addEventListener('click', function (e) {
+      const checkbox = e.target && e.target.closest
+        ? e.target.closest('input.lockable-resources-select[data-resource-name]')
+        : null;
+
+      if (checkbox) {
+        const currentName = checkbox.getAttribute('data-resource-name');
+        if (e.shiftKey && lastClickedResourceName && currentName) {
+          const cbs = Array.from(
+            tableEl.querySelectorAll('tbody input.lockable-resources-select[data-resource-name]')
+          );
+          const fromIndex = cbs.findIndex(function (x) {
+            return x.getAttribute('data-resource-name') === lastClickedResourceName;
+          });
+          const toIndex = cbs.findIndex(function (x) {
+            return x.getAttribute('data-resource-name') === currentName;
+          });
+
+          if (fromIndex >= 0 && toIndex >= 0) {
+            const start = Math.min(fromIndex, toIndex);
+            const end = Math.max(fromIndex, toIndex);
+            const selected = checkbox.checked;
+            for (let i = start; i <= end; i++) {
+              setCheckbox(cbs[i], selected);
+            }
+            updateSelectAllCheckbox(tableEl);
+            updateBulkBar(selectedSet);
+          }
+        }
+
+        if (currentName) {
+          lastClickedResourceName = currentName;
+        }
+        return;
+      }
+
+      // Ignore clicks on interactive elements.
+      if (e.target && e.target.closest && e.target.closest('a,button,input,select,textarea,label')) {
+        return;
+      }
+
+      const row = e.target && e.target.closest ? e.target.closest('tbody tr') : null;
+      if (!row) {
+        return;
+      }
+
+      const rowCb = row.querySelector('input.lockable-resources-select[data-resource-name]');
+      if (!rowCb) {
+        return;
+      }
+
+      const selected = !rowCb.checked;
+      setCheckbox(rowCb, selected);
+      lastClickedResourceName = rowCb.getAttribute('data-resource-name');
+      updateSelectAllCheckbox(tableEl);
+      updateBulkBar(selectedSet);
+    });
+
+    // Persist selection across redraws/paging.
+    jQuery3(tableEl).on('draw.dt', function () {
+      syncCheckboxesFromSelection(tableEl, selectedSet);
+      updateSelectAllCheckbox(tableEl);
+      updateBulkBar(selectedSet);
+    });
+  }
+
+  function updateBulkBar(selectedSet) {
+    const bar = document.getElementById('lockable-resources-bulk-bar');
+    if (!bar) {
+      return;
+    }
+
+    const count = selectedSet.size;
+    const countEl = document.getElementById('lockable-resources-selected-count');
+    if (countEl) {
+      countEl.textContent = String(count);
+    }
+
+    const hidden = count === 0;
+    bar.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+    bar.querySelectorAll('button.lockable-resources-bulk-action-button').forEach(function (btn) {
+      btn.disabled = hidden;
+    });
+  }
+
+  function ensureSelectAllCheckbox(headerRow, tableEl, dataTable, selectedSet) {
+    const firstTh = headerRow.querySelector('th');
+    if (!firstTh) {
+      return;
+    }
+    if (firstTh.querySelector('input.lockable-resources-select-all')) {
+      return;
+    }
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'lockable-resources-select-all';
+    cb.setAttribute('aria-label', 'Select all');
+
+    cb.addEventListener('click', function (e) {
+      // Do not trigger sort.
+      e.stopPropagation();
+    });
+
+    cb.addEventListener('change', function () {
+      const checked = cb.checked;
+
+      // Only affect currently rendered rows (current page).
+      tableEl.querySelectorAll('tbody input.lockable-resources-select[data-resource-name]').forEach(function (rowCb) {
+        const name = rowCb.getAttribute('data-resource-name');
+        if (!name) {
+          return;
+        }
+        rowCb.checked = checked;
+        if (checked) {
+          selectedSet.add(name);
+        } else {
+          selectedSet.delete(name);
+        }
+      });
+
+      updateBulkBar(selectedSet);
+    });
+
+    firstTh.textContent = '';
+    firstTh.appendChild(cb);
+  }
+
+  function syncCheckboxesFromSelection(tableEl, selectedSet) {
+    tableEl.querySelectorAll('tbody input.lockable-resources-select[data-resource-name]').forEach(function (rowCb) {
+      const name = rowCb.getAttribute('data-resource-name');
+      rowCb.checked = !!(name && selectedSet.has(name));
+    });
+  }
+
+  function updateSelectAllCheckbox(tableEl) {
+    const headerCb = tableEl.querySelector('thead input.lockable-resources-select-all');
+    if (!headerCb) {
+      return;
+    }
+    const rowCbs = Array.from(tableEl.querySelectorAll('tbody input.lockable-resources-select[data-resource-name]'));
+    if (rowCbs.length === 0) {
+      headerCb.checked = false;
+      headerCb.indeterminate = false;
+      return;
+    }
+
+    const checkedCount = rowCbs.filter(function (cb) { return cb.checked; }).length;
+    headerCb.checked = checkedCount === rowCbs.length;
+    headerCb.indeterminate = checkedCount > 0 && checkedCount < rowCbs.length;
+  }
+
+  function initColumnFilters(tableEl, dataTable, filterableColumns) {
+    const thead = tableEl.querySelector('thead');
+    if (!thead) {
+      return;
+    }
+
+    if (thead.querySelector('tr.lockable-resources-filters')) {
+      return; // already initialized
+    }
+
+    const headerRow = thead.querySelector('tr');
+    if (!headerRow) {
+      return;
+    }
+
+    const headerCells = Array.from(headerRow.querySelectorAll('th'));
+    const filterRow = document.createElement('tr');
+    filterRow.className = 'lockable-resources-filters';
+
+    headerCells.forEach(function (th, idx) {
+      const filterTh = document.createElement('th');
+
+      if (!filterableColumns.has(idx)) {
+        filterTh.textContent = '';
+        filterRow.appendChild(filterTh);
+        return;
+      }
+
+      const input = document.createElement('input');
+      input.type = 'search';
+      input.className = 'form-control form-control-sm';
+      input.placeholder = (th.textContent || '').trim();
+
+      const existing = dataTable.column(idx).search();
+      if (existing) {
+        input.value = existing;
+      }
+
+      input.addEventListener('input', function () {
+        dataTable.column(idx).search(input.value || '').draw();
+      });
+
+      input.addEventListener('click', function (e) {
+        e.stopPropagation();
+      });
+
+      filterTh.appendChild(input);
+      filterRow.appendChild(filterTh);
+    });
+
+    thead.appendChild(filterRow);
+  }
+
+  // Prefer init.dt (fires when DataTables initializes), but also handle the case where
+  // DataTables initialized before this script attached.
+  jQuery3(document).on('init.dt', function (_event, settings) {
+    try {
+      const tableEl = settings && settings.nTable;
+      enhanceResourcesTable(tableEl, settings);
+    } catch (e) {
+      // Don't break the page.
+      console.warn('[LR] Failed to enhance resources table on init.dt', e);
+    }
+  });
+
+  jQuery3(document).ready(function () {
+    try {
+      const tableEl = document.getElementById('lockable-resources');
+      if (!tableEl) {
+        return;
+      }
+      if (!jQuery3.fn.dataTable || !jQuery3.fn.dataTable.isDataTable) {
+        return;
+      }
+      if (jQuery3.fn.dataTable.isDataTable(tableEl)) {
+        enhanceResourcesTable(tableEl);
+      }
+    } catch (e) {
+      console.warn('[LR] Failed to enhance existing resources table', e);
+    }
+  });
+})();

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConcurrentModificationExceptionTest.java
@@ -91,7 +91,7 @@ class ConcurrentModificationExceptionTest {
             public void run() {
                 System.setProperty(Constants.SYSTEM_PROPERTY_ENABLE_NODE_MIRROR, "true");
                 LOGGER.info("run NodesMirror");
-                org.jenkins.plugins.lockableresources.NodesMirror.createNodeResources();
+                org.jenkins.plugins.lockableresources.nodes.NodesMirror.createNodeResources();
                 LOGGER.info("NodesMirror done");
             }
         };

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockableResourceRootActionSEC1361Test.java
@@ -23,18 +23,14 @@
  */
 package org.jenkins.plugins.lockableresources;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.Util;
+import hudson.security.ACL;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import org.htmlunit.FailingHttpStatusCodeException;
-import org.htmlunit.html.HtmlElement;
-import org.htmlunit.html.HtmlElementUtil;
-import org.htmlunit.html.HtmlPage;
+import org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -57,40 +53,36 @@ class LockableResourceRootActionSEC1361Test {
     private static void checkXssWithResourceName(JenkinsRule j, String resourceName) throws Exception {
         LockableResourcesManager.get().createResource(resourceName);
 
+        // The resources table loads rows asynchronously (DataTables TableModel), so validate XSS safety
+        // via the JSON row HTML: ensure the resource name is escaped inside an HTML attribute.
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new FullControlOnceLoggedInAuthorizationStrategy());
+        org.springframework.security.core.context.SecurityContextHolder.getContext()
+                .setAuthentication(ACL.SYSTEM2);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.login("user");
+        LockableResourcesRootAction action = new LockableResourcesRootAction();
+        String json = action.getTableRows("lockable-resources");
+        JsonNode rows = new ObjectMapper().readTree(json);
 
-        final AtomicReference<String> lastAlertReceived = new AtomicReference<>();
-        wc.setAlertHandler((page, s) -> lastAlertReceived.set(s));
-
-        // disable exceptions, otherwise it will not parse jQuery scripts (used ba DataTable plugin)
-        wc.getOptions().setThrowExceptionOnScriptError(false);
-        HtmlPage htmlPage = wc.goTo("lockable-resources");
-        assertThat(lastAlertReceived.get(), nullValue());
-
-        // currently only one button but perhaps in future version of the core/plugin,
-        // other buttons will be added to the layout
-        List<HtmlElement> allButtons = htmlPage.getDocumentElement().getElementsByTagName("button");
-        assertThat(allButtons.size(), greaterThanOrEqualTo(1));
-
-        HtmlElement reserveButton = null;
-        for (HtmlElement b : allButtons) {
-            String action = b.getAttribute("data-action");
-            if (action != null && action.contains("reserve")) {
-                reserveButton = b;
+        String escapedName = Util.escape(resourceName);
+        String expectedAttr = "data-resource-name=\"" + escapedName + "\"";
+        String unsafeAttr = "data-resource-name=\"" + resourceName + "\"";
+        boolean foundEscapedCheckbox = false;
+        for (JsonNode row : rows) {
+            JsonNode selectCell = row.get("select");
+            if (selectCell == null || !selectCell.isTextual()) {
+                continue;
+            }
+            String selectHtml = selectCell.asText();
+            if (selectHtml.contains(expectedAttr)) {
+                foundEscapedCheckbox = true;
+                assertTrue(selectHtml.contains("lockable-resources-select"), "Expected selection checkbox");
+                if (!resourceName.equals(escapedName)) {
+                    assertTrue(!selectHtml.contains(unsafeAttr), "Expected unsafe attribute value to be escaped");
+                }
             }
         }
-        assertThat(reserveButton, not(nullValue()));
 
-        try {
-            HtmlElementUtil.click(reserveButton);
-        } catch (FailingHttpStatusCodeException e) {
-            // only happen if we have a XSS, but it's managed using the AlertHandler to ensure it's a XSS
-            // and not just an invalid page
-        }
-        assertThat(lastAlertReceived.get(), nullValue());
+        assertTrue(foundEscapedCheckbox, "Expected a selection checkbox for the created resource");
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/NodesMirrorTest.java
@@ -18,7 +18,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class NodesMirrorTest {
 
     private static final Logger LOGGER =
-            Logger.getLogger(org.jenkins.plugins.lockableresources.NodesMirror.class.getName());
+            Logger.getLogger(org.jenkins.plugins.lockableresources.nodes.NodesMirror.class.getName());
 
     @Test
     void mirror_few_nodes(JenkinsRule j) throws Exception {

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -286,46 +286,6 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
     }
 
     @Test
-    void tableModelIncludesSelectionCheckbox() throws Exception {
-        LockableResourcesRootAction action = new LockableResourcesRootAction();
-
-        this.createResource("resource-select");
-
-        SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());
-
-        String json = action.getTableRows("lockable-resources");
-        JsonNode rows = new ObjectMapper().readTree(json);
-        assertTrue(rows.isArray(), "Expected JSON array of rows");
-        assertTrue(rows.size() >= 1, "Expected at least one row");
-
-        JsonNode matched = null;
-        for (JsonNode row : rows) {
-            if (row.toString().contains("resource-select")) {
-                matched = row;
-                break;
-            }
-        }
-        assertNotNull(matched, "Expected to find the resource-select row");
-
-        assertTrue(matched.has("select"), "Expected select column to be present");
-        String selectHtml = matched.get("select").asText();
-        assertTrue(selectHtml.contains("lockable-resources-select"), "Expected selection checkbox in select cell");
-        assertTrue(selectHtml.contains("data-resource-name=\"resource-select\""), "Expected data-resource-name on checkbox");
-
-        assertFalse(matched.has("action"), "Did not expect per-row action column");
-    }
-
-    @Test
-    void resourcesTableColumnsDefinitionIsGenerated() {
-        LockableResourcesRootAction action = new LockableResourcesRootAction();
-
-        String columnsDefinition = action.getResourcesTableModel().getColumnsDefinition();
-        assertNotNull(columnsDefinition);
-        assertFalse(columnsDefinition.isBlank());
-        assertTrue(columnsDefinition.contains("\"select\""), "Expected select column definition");
-    }
-
-    @Test
     void subPagesRenderWithJenkinsSidePanelNavigation() throws Exception {
         // Ensure we're in the "configured" branch of resources.jelly so the sidebar is rendered.
         LockableResource r = this.createResource("ui-smoke-resource");
@@ -354,8 +314,7 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
             if (path.endsWith("/labels")) {
                 assertTrue(html.contains("lockable-resources-labels"), "Expected labels table on " + path);
                 assertTrue(html.contains("colvis"), "Expected column selector (colvis) config on " + path);
-                assertTrue(html.contains("lockable-resources-column-filter"), "Expected labels column filter input on " + path);
-                assertTrue(html.contains("lockable-resources.js"), "Expected shared LR JS on " + path);
+                assertTrue(html.contains("table-labels-filters.js"), "Expected labels filter init JS on " + path);
             }
             if (path.endsWith("/queue")) {
                 assertTrue(html.contains("lockable-resources-queue"), "Expected queue table on " + path);

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.AccessDeniedException3;
@@ -17,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import org.htmlunit.html.HtmlPage;
 import org.jenkins.plugins.lockableresources.LockStepTestBase;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
@@ -258,6 +261,126 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
         action.doReserve(req, rsp);
         assertTrue(resource.isReserved(), "resource should be reserved");
         assertTrue(resource.getLockReason().isEmpty(), "empty reason should be empty string");
+    }
+
+    @Test
+    void tableModelReturnsRowsAsJson() throws Exception {
+        LockableResourcesRootAction action = new LockableResourcesRootAction();
+
+        // Prepare a couple of resources
+        this.createResource("resource-a");
+        this.createResource("resource-b");
+
+        SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());
+
+        String json = action.getTableRows("lockable-resources");
+        JsonNode node = new ObjectMapper().readTree(json);
+
+        assertTrue(node.isArray(), "Expected JSON array of rows");
+        assertTrue(node.size() >= 2, "Expected at least two rows");
+
+        // Ensure our resource names are present somewhere in the rendered cells
+        String all = node.toString();
+        assertTrue(all.contains("resource-a"), "Expected resource-a to be present in JSON");
+        assertTrue(all.contains("resource-b"), "Expected resource-b to be present in JSON");
+    }
+
+    @Test
+    void tableModelIncludesSelectionCheckbox() throws Exception {
+        LockableResourcesRootAction action = new LockableResourcesRootAction();
+
+        this.createResource("resource-select");
+
+        SecurityContextHolder.getContext().setAuthentication(this.admin.impersonate2());
+
+        String json = action.getTableRows("lockable-resources");
+        JsonNode rows = new ObjectMapper().readTree(json);
+        assertTrue(rows.isArray(), "Expected JSON array of rows");
+        assertTrue(rows.size() >= 1, "Expected at least one row");
+
+        JsonNode matched = null;
+        for (JsonNode row : rows) {
+            if (row.toString().contains("resource-select")) {
+                matched = row;
+                break;
+            }
+        }
+        assertNotNull(matched, "Expected to find the resource-select row");
+
+        assertTrue(matched.has("select"), "Expected select column to be present");
+        String selectHtml = matched.get("select").asText();
+        assertTrue(selectHtml.contains("lockable-resources-select"), "Expected selection checkbox in select cell");
+        assertTrue(selectHtml.contains("data-resource-name=\"resource-select\""), "Expected data-resource-name on checkbox");
+
+        assertFalse(matched.has("action"), "Did not expect per-row action column");
+    }
+
+    @Test
+    void resourcesTableColumnsDefinitionIsGenerated() {
+        LockableResourcesRootAction action = new LockableResourcesRootAction();
+
+        String columnsDefinition = action.getResourcesTableModel().getColumnsDefinition();
+        assertNotNull(columnsDefinition);
+        assertFalse(columnsDefinition.isBlank());
+        assertTrue(columnsDefinition.contains("\"select\""), "Expected select column definition");
+    }
+
+    @Test
+    void subPagesRenderWithJenkinsSidePanelNavigation() throws Exception {
+        // Ensure we're in the "configured" branch of resources.jelly so the sidebar is rendered.
+        LockableResource r = this.createResource("ui-smoke-resource");
+        r.setLabels("ui-smoke-label");
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(ADMIN);
+        // DataTables/Bootstrap JS is not relevant for this smoke test.
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+
+        for (String path : List.of(
+                "lockable-resources/",
+                "lockable-resources/resources",
+                "lockable-resources/labels",
+                "lockable-resources/queue")) {
+            HtmlPage page = wc.goTo(path);
+
+            assertNotNull(page.getElementById("side-panel"), "Expected Jenkins side panel for " + path);
+
+            String html = page.asXml();
+            assertTrue(html.contains("/lockable-resources/"), "Expected sidebar overview link on " + path);
+            assertTrue(html.contains("/lockable-resources/resources"), "Expected sidebar resources link on " + path);
+            assertTrue(html.contains("/lockable-resources/labels"), "Expected sidebar labels link on " + path);
+            assertTrue(html.contains("/lockable-resources/queue"), "Expected sidebar queue link on " + path);
+
+            if (path.endsWith("/labels")) {
+                assertTrue(html.contains("lockable-resources-labels"), "Expected labels table on " + path);
+                assertTrue(html.contains("colvis"), "Expected column selector (colvis) config on " + path);
+                assertTrue(html.contains("lockable-resources-column-filter"), "Expected labels column filter input on " + path);
+                assertTrue(html.contains("lockable-resources.js"), "Expected shared LR JS on " + path);
+            }
+            if (path.endsWith("/queue")) {
+                assertTrue(html.contains("lockable-resources-queue"), "Expected queue table on " + path);
+                assertTrue(html.contains("colvis"), "Expected column selector (colvis) config on " + path);
+                assertTrue(html.contains("lockable-resources-column-filter"), "Expected per-column filters on " + path);
+            }
+
+            if (path.endsWith("/")) {
+                assertNotNull(
+                        page.getElementById("lockable-resources-state-summary"),
+                        "Expected combined state summary card on " + path);
+                assertNotNull(
+                        page.getElementById("lockable-resources-state-donut"), "Expected state donut chart on " + path);
+                assertTrue(html.contains("100%"), "Expected a 100% legend entry on " + path);
+            }
+
+            if (path.endsWith("/resources")) {
+                assertNotNull(page.getElementById("lockable-resources"), "Expected resources table element on " + path);
+                // data-tables-api loads rows via JS: tableDataProxy.getTableRows(...)
+                // The proxy only exposes methods annotated with @JavaScriptMethod.
+                assertTrue(html.contains("tableDataProxy"), "Expected Stapler JS proxy binding on " + path);
+                assertTrue(html.contains("getTableRows"), "Expected getTableRows() to be exposed to JS on " + path);
+                assertTrue(html.contains("table-resources-filters.js"), "Expected resources filter init JS on " + path);
+            }
+        }
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- Fix Resources page DataTables rendering and async loading (non-empty header labels + CSRF crumb shim).
- Move per-resource actions into the bottom bulk bar and improve multi-row selection (row click + shift-click range).
- Align Labels/Resources filtering approach; keep Queue header filters behavior.
- Add sidebar/table i18n bundles and regression tests.

Testing:
- mvn -Dtest=LockableResourcesRootActionTest test
- Manual: mvn hpi:run and verified /lockable-resources/resources shows table + rows.

Notes:
- Leaves local workspace-only files (.vscode/, lib/, data-tables/) out of this PR.