### PR TITLE
Allow auto-label workflow on fork PRs

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -4,12 +4,15 @@
 name: Auto-label PR
 
 on:
-  pull_request:
+  # Use pull_request_target so the workflow has write permissions even for fork PRs.
+  # SECURITY: Do not check out or execute code from the PR in this workflow.
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   auto-label:


### PR DESCRIPTION
## Problem

The Auto-label PR workflow fails on pull requests from forks with:

Resource not accessible by integration (403) when calling the Issues Labels API (POST /repos/.../issues/<pr>/labels)
This happens because workflows triggered by pull_request are intentionally given a read-only GITHUB_TOKEN on fork PRs, so labels cannot be applied automatically.

## Change

Switch trigger from pull_request to pull_request_target
Grant issues: write permission (labeling uses the Issues Labels endpoint)
Security
pull_request_target runs in the base-repo context, so it must not execute untrusted PR code. This workflow remains safe because it:

Does not check out the PR
Does not run any scripts from the PR
Uses only PR metadata from [context.payload.pull_request](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

## Testing

N/A (workflow change). Verified the previous failure mode from GitHub Actions logs and that the new trigger/permissions are required to label fork PRs.