### PR TITLE
Add label expression filter to resources table

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -42,6 +42,7 @@ import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.GET;
 
 @Extension
 @ExportedBean
@@ -926,6 +927,45 @@ public class LockableResourcesRootAction implements RootAction {
     }
 
     // ---------------------------------------------------------------------------
+    /** Returns resource names matching a Jenkins label expression as JSON. */
+    @Restricted(NoExternalUse.class)
+    @GET
+    public void doGetResourcesByLabelExpression(final StaplerRequest2 req, final StaplerResponse2 rsp)
+            throws IOException {
+        Jenkins.get().checkPermission(VIEW);
+
+        String expr = Util.fixEmptyAndTrim(req.getParameter("expr"));
+
+        final List<LockableResource> resources;
+        try {
+            resources = (expr == null)
+                    ? LockableResourcesManager.get().getReadOnlyResources()
+                    : LockableResourcesManager.get().getResourcesWithLabel(expr);
+        } catch (IllegalArgumentException e) {
+            rsp.sendError(400, "Invalid label expression: " + e.getMessage());
+            return;
+        }
+
+        net.sf.json.JSONArray items = new net.sf.json.JSONArray();
+        for (LockableResource r : resources) {
+            if (r == null || r.getName().isEmpty()) {
+                continue;
+            }
+            net.sf.json.JSONObject obj = new net.sf.json.JSONObject();
+            obj.put("name", r.getName());
+            items.add(obj);
+        }
+
+        net.sf.json.JSONObject result = new net.sf.json.JSONObject();
+        result.put("expr", expr == null ? "" : expr);
+        result.put("total", items.size());
+        result.put("items", items);
+
+        rsp.setContentType("application/json;charset=UTF-8");
+        rsp.getWriter().write(result.toString());
+    }
+
+    // ---------------------------------------------------------------------------
     /** Change queue order (item position) */
     @Restricted(NoExternalUse.class) // used by jelly
     @RequirePOST
@@ -1123,6 +1163,7 @@ public class LockableResourcesRootAction implements RootAction {
         rsp.setContentType("application/json;charset=UTF-8");
         rsp.getWriter().write(result.toString());
     }
+
 
     private String getQueueItemType(final Queue.QueueStruct item) {
         if (item.resourcesMatch()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -1164,7 +1164,6 @@ public class LockableResourcesRootAction implements RootAction {
         rsp.getWriter().write(result.toString());
     }
 
-
     private String getQueueItemType(final Queue.QueueStruct item) {
         if (item.resourcesMatch()) {
             return "resources";

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
@@ -251,6 +251,7 @@
                 </div>
                 <input type="text" class="jenkins-input lr-col-filter" id="lr-filter-held-by" placeholder="${%filter.heldBy}" />
                 <input type="text" class="jenkins-input lr-col-filter" id="lr-filter-label" placeholder="${%filter.resources.labels}" />
+                <input type="text" class="jenkins-input lr-col-filter" id="lr-filter-label-expression" placeholder="${%filter.resources.labelExpression}" />
               </div>
               <div class="lr-toolbar__actions">
                 <div class="lr-global-search-wrapper" data-tab="resources">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
@@ -105,6 +105,7 @@ filter.advanced.tooltip=Advanced filter
 filter.columns.tooltip=Show/hide columns
 filter.name=Resource Name
 filter.resources.labels=Labels
+filter.resources.labelExpression=Label expression (e.g. A && !B)
 filter.heldBy=Held by
 filter.labels.name=Labels
 filter.assigned=Assigned Resources

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableResources/table.jelly
@@ -34,6 +34,7 @@ THE SOFTWARE.
     <table
       class="jenkins-table sortable"
       id="lockable-resources"
+      data-resources-by-label-expression-url="getResourcesByLabelExpression"
     >
       <thead>
         <tr>

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -356,10 +356,12 @@ document.addEventListener("DOMContentLoaded", function () {
     var statusSelect = document.getElementById("lr-filter-status");
     var heldByInput = document.getElementById("lr-filter-held-by");
     var labelInput = document.getElementById("lr-filter-label");
+    var labelExprInput = document.getElementById("lr-filter-label-expression");
     if (quickInput) quickInput.value = "";
     if (statusSelect) statusSelect.value = "";
     if (heldByInput) heldByInput.value = "";
     if (labelInput) labelInput.value = "";
+    if (labelExprInput) labelExprInput.value = "";
   }
 
   // Legend status pills navigate to resources tab with status filter
@@ -947,30 +949,163 @@ function initColumnVisibility(config) {
 
 // ============ Instantiate filters & column visibility for all tabs ============
 (function () {
+  var resourcesExprState = {
+    pendingExpr: null,
+    loadedExpr: null,
+    inflight: false,
+    timer: null,
+    allowedNames: null,
+  };
+
+  function isProbablyCompleteLabelExpression(expr) {
+    // Heuristic to prevent calling the server on intermediate/incomplete inputs while typing.
+    // We still rely on the server for actual validation.
+    if (!expr) return true;
+
+    // Must contain at least one label-ish character.
+    try {
+      if (!/[\p{L}\p{N}_\-\.]/u.test(expr)) return false;
+    } catch (e) {
+      // Fallback for older JS engines without unicode property escapes.
+      if (!/[A-Za-z0-9_\-\.]/.test(expr)) return false;
+    }
+
+    // Parentheses must be balanced.
+    var depth = 0;
+    for (var i = 0; i < expr.length; i++) {
+      var ch = expr.charAt(i);
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth < 0) return false;
+      }
+    }
+    if (depth !== 0) return false;
+
+    // Trailing operators are incomplete.
+    if (/(&&|\|\||[&|])\s*$/.test(expr)) return false;
+    if (/!\s*$/.test(expr)) return false;
+    if (/\(\s*$/.test(expr)) return false;
+
+    return true;
+  }
+
+  function scheduleResourcesExpressionReload(table, expr, afterReload) {
+    if (!table) return;
+    var trimmed = (expr || "").trim();
+
+    // Empty expression = no server-side restriction.
+    if (!trimmed) {
+      resourcesExprState.pendingExpr = "";
+      resourcesExprState.loadedExpr = "";
+      resourcesExprState.allowedNames = null;
+      return;
+    }
+
+    // Don't query the server for intermediate input while the user is typing.
+    if (!isProbablyCompleteLabelExpression(trimmed)) {
+      resourcesExprState.pendingExpr = trimmed;
+      resourcesExprState.loadedExpr = "";
+      resourcesExprState.allowedNames = null;
+      return;
+    }
+
+    resourcesExprState.pendingExpr = trimmed;
+
+    if (resourcesExprState.timer) {
+      clearTimeout(resourcesExprState.timer);
+    }
+
+    resourcesExprState.timer = setTimeout(function () {
+      if (resourcesExprState.inflight) {
+        return;
+      }
+
+      if (resourcesExprState.loadedExpr === resourcesExprState.pendingExpr) {
+        return;
+      }
+
+      resourcesExprState.inflight = true;
+      var endpoint = table.dataset.resourcesByLabelExpressionUrl || "getResourcesByLabelExpression";
+      var url = endpoint + "?expr=" + encodeURIComponent(resourcesExprState.pendingExpr);
+
+      fetch(url, { headers: { "Accept": "application/json" } })
+        .then(function (rsp) {
+          if (rsp.ok) return rsp.json();
+          return rsp.text().then(function (t) {
+            throw new Error(t || ("HTTP " + rsp.status));
+          });
+        })
+        .then(function (data) {
+          var set = new Set();
+          (data.items || []).forEach(function (it) {
+            if (it && it.name) set.add(it.name);
+          });
+          resourcesExprState.allowedNames = set;
+          resourcesExprState.loadedExpr = resourcesExprState.pendingExpr;
+          if (typeof afterReload === "function") afterReload();
+        })
+        .catch(function (err) {
+          if (typeof notificationBar !== "undefined" && notificationBar && notificationBar.show) {
+            notificationBar.show(
+              "Failed to apply label expression filter: " + (err && err.message ? err.message : err),
+              notificationBar.ERROR);
+          }
+        })
+        .finally(function () {
+          resourcesExprState.inflight = false;
+          if (resourcesExprState.loadedExpr !== resourcesExprState.pendingExpr) {
+            scheduleResourcesExpressionReload(table, resourcesExprState.pendingExpr, afterReload);
+          }
+        });
+    }, 250);
+  }
+
+  function applyResourcesFilters(table) {
+    var quickInput = document.getElementById("lr-filter-quick");
+    var statusSelect = document.getElementById("lr-filter-status");
+    var heldByInput = document.getElementById("lr-filter-held-by");
+    var labelInput = document.getElementById("lr-filter-label");
+    var labelExprInput = document.getElementById("lr-filter-label-expression");
+
+    var nameVal = quickInput ? quickInput.value.trim().toLowerCase() : "";
+    var statusVal = statusSelect ? statusSelect.value : "";
+    var heldByVal = heldByInput ? heldByInput.value.trim().toLowerCase() : "";
+    var labelVal = labelInput ? labelInput.value.trim().toLowerCase() : "";
+    var labelExprVal = labelExprInput ? labelExprInput.value.trim() : "";
+
+    scheduleResourcesExpressionReload(table, labelExprVal, function () {
+      applyResourcesFilters(table);
+    });
+
+    var allowedSet = null;
+    if (labelExprVal && resourcesExprState.loadedExpr === labelExprVal) {
+      allowedSet = resourcesExprState.allowedNames;
+    }
+
+    var tbody = table.querySelector("tbody");
+    if (!tbody) return;
+
+    Array.from(tbody.querySelectorAll(":scope > tr")).forEach(function (row) {
+      var resourceName = row.dataset.resourceName || "";
+      var exprOk = !labelExprVal || !allowedSet || allowedSet.has(resourceName);
+      var show = exprOk
+        && (!nameVal || resourceName.toLowerCase().indexOf(nameVal) !== -1)
+        && (!statusVal || (row.dataset.resourceStatus || "") === statusVal)
+        && (!heldByVal || (row.dataset.resourceOwner || "").toLowerCase().indexOf(heldByVal) !== -1)
+        && (!labelVal || (row.dataset.resourceLabels || "").toLowerCase().indexOf(labelVal) !== -1);
+      row.classList.toggle("lr-col-filtered-out", !show);
+    });
+    table.dispatchEvent(new CustomEvent("lr-filter-changed"));
+  }
+
   // Resources tab filters
   initColumnFilters({
     storageKey: "lockable-resources-col-filters",
     tableId: "lockable-resources",
     filterClass: "lr-col-filter",
     applyFn: function (table) {
-      var quickInput = document.getElementById("lr-filter-quick");
-      var statusSelect = document.getElementById("lr-filter-status");
-      var heldByInput = document.getElementById("lr-filter-held-by");
-      var labelInput = document.getElementById("lr-filter-label");
-      var nameVal = quickInput ? quickInput.value.trim().toLowerCase() : "";
-      var statusVal = statusSelect ? statusSelect.value : "";
-      var heldByVal = heldByInput ? heldByInput.value.trim().toLowerCase() : "";
-      var labelVal = labelInput ? labelInput.value.trim().toLowerCase() : "";
-      var tbody = table.querySelector("tbody");
-      if (!tbody) return;
-      Array.from(tbody.querySelectorAll(":scope > tr")).forEach(function (row) {
-        var show = (!nameVal || (row.dataset.resourceName || "").toLowerCase().indexOf(nameVal) !== -1)
-          && (!statusVal || (row.dataset.resourceStatus || "") === statusVal)
-          && (!heldByVal || (row.dataset.resourceOwner || "").toLowerCase().indexOf(heldByVal) !== -1)
-          && (!labelVal || (row.dataset.resourceLabels || "").toLowerCase().indexOf(labelVal) !== -1);
-        row.classList.toggle("lr-col-filtered-out", !show);
-      });
-      table.dispatchEvent(new CustomEvent("lr-filter-changed"));
+      applyResourcesFilters(table);
     }
   });
 
@@ -986,6 +1121,7 @@ function initColumnVisibility(config) {
       var assignedVal = assignedInput ? assignedInput.value.trim() : "";
       var tbody = table.querySelector("tbody");
       if (!tbody) return;
+
       Array.from(tbody.querySelectorAll(":scope > tr")).forEach(function (row) {
         var show = (!nameVal || (row.dataset.labelName || "").toLowerCase().indexOf(nameVal) !== -1)
           && (!assignedVal || (row.dataset.labelAssigned || "") === assignedVal);

--- a/src/test/java/org/jenkins/plugins/lockableresources/ResourceManagementTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ResourceManagementTest.java
@@ -75,7 +75,8 @@ class ResourceManagementTest {
         return JSONObject.fromObject(wc.getPage(req).getWebResponse().getContentAsString());
     }
 
-    private JSONObject getResourcesByLabelExpression(JenkinsRule j, JenkinsRule.WebClient wc, String expr) throws Exception {
+    private JSONObject getResourcesByLabelExpression(JenkinsRule j, JenkinsRule.WebClient wc, String expr)
+            throws Exception {
         String query = expr == null ? "" : "expr=" + URLEncoder.encode(expr, StandardCharsets.UTF_8);
         String path = "lockable-resources/getResourcesByLabelExpression" + (query.isEmpty() ? "" : "?" + query);
         URL url = new URL(j.getURL(), path);

--- a/src/test/java/org/jenkins/plugins/lockableresources/ResourceManagementTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ResourceManagementTest.java
@@ -9,6 +9,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +70,14 @@ class ResourceManagementTest {
 
     private JSONObject getQueuePage(JenkinsRule j, JenkinsRule.WebClient wc, String query) throws Exception {
         String path = "lockable-resources/getQueuePage" + (query == null || query.isEmpty() ? "" : "?" + query);
+        URL url = new URL(j.getURL(), path);
+        WebRequest req = new WebRequest(url, HttpMethod.GET);
+        return JSONObject.fromObject(wc.getPage(req).getWebResponse().getContentAsString());
+    }
+
+    private JSONObject getResourcesByLabelExpression(JenkinsRule j, JenkinsRule.WebClient wc, String expr) throws Exception {
+        String query = expr == null ? "" : "expr=" + URLEncoder.encode(expr, StandardCharsets.UTF_8);
+        String path = "lockable-resources/getResourcesByLabelExpression" + (query.isEmpty() ? "" : "?" + query);
         URL url = new URL(j.getURL(), path);
         WebRequest req = new WebRequest(url, HttpMethod.GET);
         return JSONObject.fromObject(wc.getPage(req).getWebResponse().getContentAsString());
@@ -462,6 +472,27 @@ class ResourceManagementTest {
         JSONObject combined = getQueuePage(j, wc, "type=resources&filter=queue-filter-resource");
         assertThat(combined.getInt("total"), is(3));
         assertThat(combined.getJSONArray("items").getJSONObject(0).getString("type"), is("resources"));
+    }
+
+    @Test
+    void resourcesByLabelExpressionEndpointAppliesExpression(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResourceWithLabel("expr-r1", "A B");
+        LockableResourcesManager.get().createResourceWithLabel("expr-r2", "A");
+        LockableResourcesManager.get().createResourceWithLabel("expr-r3", "B C");
+
+        JenkinsRule.WebClient wc = loginAsAdmin(j);
+        JSONObject response = getResourcesByLabelExpression(j, wc, "A && B");
+
+        JSONArray items = response.getJSONArray("items");
+        List<String> names = new ArrayList<>();
+        for (Object o : items) {
+            names.add(((JSONObject) o).getString("name"));
+        }
+
+        assertThat(response.getInt("total"), is(1));
+        assertThat(names.contains("expr-r1"), is(true));
+        assertThat(names.contains("expr-r2"), is(false));
+        assertThat(names.contains("expr-r3"), is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a new **Resources** tab filter that evaluates **Jenkins label expressions** (e.g. `A && !B`) and filters the resources table accordingly.

## Motivation

The existing Resources filters support substring matching. This change adds a dedicated label-expression filter so users can apply the same semantics they already use in Pipeline `lock(label: ...)` / Jenkins node label expressions.

## Changes

- UI: Adds a new Resources toolbar input: **Label expression (e.g. `A && !B`)**.
- Backend: Adds a GET endpoint `getResourcesByLabelExpression` returning matching resource names as JSON.
- Frontend: Debounced fetch + row visibility update; combines expression results with existing client-side filters (name/status/held-by/labels substring).
- UX polish: Clears the expression filter together with other resource filters to avoid “empty table” surprises due to stale persisted state.
- Typing experience: Avoids server calls for obviously incomplete expressions while typing (still fully validated server-side when complete).

## Demo

MP4 recording uploaded in PR comments:

- https://github.com/user-attachments/assets/c09b050d-593c-47f9-80c3-54cf12455783

(Comment: https://github.com/jenkinsci/lockable-resources-plugin/pull/1047#issuecomment-4583005597)

## Testing

- `mvn -ntp -DskipITs -Dtest=ResourceManagementTest test`

## Notes

- The endpoint is GET-only and requires the existing `VIEW` permission (same as the page).
- No demo artifacts were added to the repository.