### PR TITLE
Restore filtered/total row count in Jenkins table view

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -45,6 +45,20 @@
   gap: 0.25rem;
 }
 
+.lr-table-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: var(--jenkins-border--subtle);
+  color: var(--text-color-secondary, #666);
+  font-size: 0.75rem;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
 tr.lr-filtered-out,
 tr.lr-col-filtered-out,
 tr.lr-global-search-hidden {

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -567,31 +567,51 @@ function initPagination() {
     // Place pagination in the toolbar (right of the eye icon) if available
     const controls = document.createElement("div");
     controls.className = "lr-pagination";
+    const countBadge = document.createElement("span");
+    countBadge.className = "lr-table-count";
     const tabPane = table.closest(".lr-tab-pane");
     const toolbar = tabPane ? tabPane.querySelector(".lr-toolbar__actions") : null;
     if (toolbar) {
+      toolbar.appendChild(countBadge);
       toolbar.appendChild(controls);
     } else {
+      scrollWrapper.parentNode.insertBefore(countBadge, scrollWrapper.nextSibling);
       scrollWrapper.parentNode.insertBefore(controls, scrollWrapper.nextSibling);
     }
 
-    function getRows() {
+    function getAllRows() {
       const tbody = table.querySelector("tbody");
       return tbody
         ? Array.from(tbody.children).filter(function (row) {
-            return row.matches("tr")
-              && !row.classList.contains("lr-filtered-out")
-              && !row.classList.contains("lr-col-filtered-out");
+            return row.matches("tr");
           })
         : [];
+    }
+
+    function isRowFilteredOut(row) {
+      return row.classList.contains("lr-filtered-out")
+        || row.classList.contains("lr-col-filtered-out")
+        || row.classList.contains("lr-global-search-hidden");
+    }
+
+    function getRows() {
+      return getAllRows().filter(function (row) {
+        return !isRowFilteredOut(row);
+      });
     }
 
     function render() {
       const rows = getRows();
       const total = rows.length;
+      const totalRows = getAllRows().length;
       const totalPages = pageSize === 0 ? 1 : Math.ceil(total / pageSize);
       if (currentPage > totalPages) currentPage = totalPages;
       if (currentPage < 1) currentPage = 1;
+
+      // Show filtered/total row count, e.g. 12/57 when filters are active.
+      if (countBadge) {
+        countBadge.textContent = total === totalRows ? String(totalRows) : (total + "/" + totalRows);
+      }
 
       // Show/hide rows
       rows.forEach(function (row, i) {


### PR DESCRIPTION
## Summary
This PR restores the filtered row counter in the Lockable Resources UI after the Jenkins table migration.

When no filter is active, the table shows the total number of rows.
When filters are active, it shows filtered vs total (for example: `12/57`).

## Changes
- Added a count badge in the table toolbar near pagination controls.
- Implemented row counting based on:
  - all table rows
  - currently visible rows after filtering
- Updated filtering logic to include rows hidden by global search as filtered-out for counting.
- Added lightweight styling for the new count badge.

## Validation
- Ran focused UI-related tests:
  - `ResourceManagementTest`
- Result:
  - 28 tests run
  - 0 failures
  - 0 errors
  - Build successful

## Notes
- This is a UI behavior restoration only.
- No server-side API or backend behavior changes are included.