### PR TITLE
Allow reserve action without a reason

### DIFF
--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -190,6 +190,18 @@ function deleteResource(button) {
 function resource_action(button, action) {
   const resourceName = button.closest('tr').getAttribute('data-resource-name');
 
+  function allowEmptyReasonInPrompt() {
+    setTimeout(function () {
+      const input = document.querySelector("dialog.jenkins-dialog input, dialog.jenkins-dialog textarea");
+      if (!input) return;
+      input.required = false;
+      input.removeAttribute("required");
+      if (!input.value) {
+        input.value = " ";
+      }
+    }, 0);
+  }
+
   if (action === "reserve" || action === "steal") {
     dialog
       .prompt(i18n(action + "-title", resourceName), {
@@ -209,6 +221,9 @@ function resource_action(button, action) {
           });
         }
       );
+    if (action === "reserve") {
+      allowEmptyReasonInPrompt();
+    }
     return;
   }
 
@@ -713,6 +728,18 @@ window.updateFilterMode = function (tabId) {
   });
 
   function bulkResourceAction(action, resources) {
+    function allowEmptyReasonInPrompt() {
+      setTimeout(function () {
+        const input = document.querySelector("dialog.jenkins-dialog input, dialog.jenkins-dialog textarea");
+        if (!input) return;
+        input.required = false;
+        input.removeAttribute("required");
+        if (!input.value) {
+          input.value = " ";
+        }
+      }, 0);
+    }
+
     if (action === "reserve" || action === "steal" || action === "reassign") {
       dialog
         .prompt(i18n(action + "-title", resources.join(", ")), {
@@ -723,6 +750,9 @@ window.updateFilterMode = function (tabId) {
         .then(function (reason) {
           executeBulk(action, resources, reason || "");
         });
+      if (action === "reserve") {
+        allowEmptyReasonInPrompt();
+      }
       return;
     }
     executeBulk(action, resources, null);

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -258,6 +258,13 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
         action.doReserve(req, rsp);
         assertTrue(resource.isReserved(), "resource should be reserved");
         assertTrue(resource.getLockReason().isEmpty(), "empty reason should be empty string");
+
+        // Reserve without reason (whitespace-only input from UI)
+        action.doUnreserve(req, rsp);
+        when(req.getParameter("reason")).thenReturn("   ");
+        action.doReserve(req, rsp);
+        assertTrue(resource.isReserved(), "resource should be reserved");
+        assertTrue(resource.getLockReason().isEmpty(), "whitespace-only reason should be treated as empty");
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow submitting the reserve action with an empty reason in the management UI
- keep reserve behavior by sending an empty reason when no text is provided
- add a regression assertion for whitespace-only reason handling in RootAction reserve tests

## Testing
- mvn -Dtest=LockableResourcesRootActionTest test *(fails in this environment during Jenkins test bootstrap with unrelated LockableResourcesManager registration errors before test execution)*

Related to #1040