### PR TITLE
fix: include build parameters in script-match cache key

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
@@ -428,7 +429,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
     public boolean scriptMatches(@NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)
             throws ExecutionException {
         if (SCRIPT_CACHE_TTL_MS > 0) {
-            String cacheKey = script.getScript();
+            String cacheKey = buildScriptCacheKey(script.getScript(), params);
             ConcurrentHashMap<String, CachedResult> cache = getScriptCache();
             CachedResult cached = cache.get(cacheKey);
             if (cached != null && !cached.isExpired(SCRIPT_CACHE_TTL_MS)) {
@@ -439,6 +440,32 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
             return result;
         }
         return evaluateScript(script, params);
+    }
+
+    /**
+     * Builds the per-resource script-cache key.
+     *
+     * <p>The cached match result depends not only on the script text but also on the build
+     * parameters bound into the script's execution (for example a {@code TARGET_ENVIRONMENT}
+     * parameter referenced by the script). Different jobs commonly share an identical match script
+     * and differ only by their parameters, so the parameters must form part of the key. Keying on
+     * the script text alone causes the first build's result to be reused for every other build,
+     * making them all resolve to the same resource and serialise behind it.
+     *
+     * @param scriptText the Groovy match script text
+     * @param params the parameter bindings supplied to the script (may be {@code null})
+     * @return a key combining the script text with a deterministic encoding of the parameters
+     */
+    private static String buildScriptCacheKey(String scriptText, @CheckForNull Map<String, Object> params) {
+        if (params == null || params.isEmpty()) {
+            return scriptText;
+        }
+        // Sort by key for a deterministic, order-independent encoding.
+        StringBuilder sb = new StringBuilder(scriptText);
+        for (Map.Entry<String, Object> entry : new TreeMap<>(params).entrySet()) {
+            sb.append(' ').append(entry.getKey()).append('=').append(entry.getValue());
+        }
+        return sb.toString();
     }
 
     private boolean evaluateScript(@NonNull SecureGroovyScript script, @CheckForNull Map<String, Object> params)

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -134,12 +134,16 @@ class FreeStyleProjectTest {
      *       dispatch while the latch is held, so peak concurrency stays at 1.</li>
      * </ul>
      *
-     * There are {@code N * 2} executors, so executor availability is never the constraint.
+     * There are {@code N * 2} executors so executor availability is never the constraint. N is kept
+     * small (5) to remain reliable on slow CI agents; it is still sufficient to distinguish peak=1
+     * (serialised, bug present) from peak=N (concurrent, fix working).
      */
     @Test
     @Issue("1052")
     void scriptResourceJobsRunConcurrently(JenkinsRule j) throws Exception {
-        final int N = 12;
+        // N=5 is enough to distinguish serial dispatch (peak=1) from parallel dispatch (peak=N).
+        // A larger value risks spurious timeout failures on slow CI agents (notably Windows).
+        final int N = 5;
         j.jenkins.setNumExecutors(N * 2);
 
         for (int i = 0; i < N; i++) {
@@ -171,7 +175,7 @@ class FreeStyleProjectTest {
                     maxConcurrent.accumulateAndGet(c, Math::max);
                     allStarted.countDown();
                     // Hold the build open so a serialised dispatcher cannot "complete then dispatch next".
-                    release.await(30, TimeUnit.SECONDS);
+                    release.await(90, TimeUnit.SECONDS);
                     concurrent.decrementAndGet();
                     return true;
                 }
@@ -184,13 +188,13 @@ class FreeStyleProjectTest {
 
         // Wait (bounded) for all N builds to be running at once. If the bug serialises dispatch,
         // this times out with only one build ever having started.
-        boolean allRunningTogether = allStarted.await(20, TimeUnit.SECONDS);
+        boolean allRunningTogether = allStarted.await(60, TimeUnit.SECONDS);
         int peak = maxConcurrent.get();
 
         // Let the builds finish regardless of outcome.
         release.countDown();
         for (int i = 0; i < N; i++) {
-            j.assertBuildStatus(Result.SUCCESS, futures.get(i).get(30, TimeUnit.SECONDS));
+            j.assertBuildStatus(Result.SUCCESS, futures.get(i).get(60, TimeUnit.SECONDS));
         }
 
         assertTrue(

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -26,8 +26,10 @@ import hudson.util.OneShotEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.lockableresources.actions.LockableResourcesRootAction;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesQueueTaskDispatcher;
@@ -51,6 +53,151 @@ class FreeStyleProjectTest {
     void setUp() {
         // to speed up the test
         System.setProperty(Constants.SYSTEM_PROPERTY_DISABLE_SAVE, "true");
+    }
+
+    /**
+     * Reproduction test for https://github.com/jenkinsci/lockable-resources-plugin/issues/1052.
+     *
+     * N freestyle jobs each need a distinct, immediately-available resource (by name). When they
+     * are all submitted to the queue together the plugin's {@code canRun()} is evaluated for each
+     * item. All resources are free, so all N should pass and start in quick succession.
+     *
+     * This is the named-resource control case: it exercises the simple {@code required}-list path
+     * rather than the Groovy candidate-selection path.
+     */
+    @Test
+    @Issue("1052")
+    void parallelFreestyleDispatchWithAvailableResources(JenkinsRule j) throws Exception {
+        final int N = 3;
+        j.jenkins.setNumExecutors(N * 2);
+
+        // N distinct resources, all immediately available (no holder builds).
+        for (int i = 0; i < N; i++) {
+            LockableResourcesManager.get().createResource("slot-" + i);
+        }
+
+        // Submit N builds simultaneously, each needing one distinct resource.
+        // All resources are free, so all N should be dispatched in quick succession.
+        List<FreeStyleProject> projects = new ArrayList<>();
+        List<QueueTaskFuture<FreeStyleBuild>> futures = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            FreeStyleProject p = j.createFreeStyleProject("job-" + i);
+            p.addProperty(new RequiredResourcesProperty("slot-" + i, null, null, null, null));
+            projects.add(p);
+        }
+        for (int i = 0; i < N; i++) {
+            futures.add(projects.get(i).scheduleBuild2(0));
+        }
+
+        // All N builds must complete successfully.
+        long deadline = System.currentTimeMillis() + 30_000;
+        for (int i = 0; i < N; i++) {
+            long remaining = deadline - System.currentTimeMillis();
+            assertTrue(remaining > 0, "Build " + i + " did not complete within 30s");
+            j.assertBuildStatus(Result.SUCCESS, futures.get(i).get(remaining, TimeUnit.MILLISECONDS));
+        }
+
+        // All builds should have started close together, not serialised one per maintenance cycle.
+        long firstStart = Long.MAX_VALUE;
+        long lastStart = Long.MIN_VALUE;
+        for (int i = 0; i < N; i++) {
+            long t = futures.get(i).get().getStartTimeInMillis();
+            firstStart = Math.min(firstStart, t);
+            lastStart = Math.max(lastStart, t);
+        }
+        long spreadMs = lastStart - firstStart;
+        assertTrue(spreadMs < 10_000, "Builds should start within 10s of each other; spread was " + spreadMs + "ms");
+    }
+
+    /**
+     * Reproduction of the issue #1052 serialisation using the Groovy-script candidate-selection
+     * path with a parameter-driven match script:
+     *
+     * <ul>
+     *   <li>The match script is run in the Groovy <em>sandbox</em> ({@code sandbox=true}).</li>
+     *   <li>The script reads per-build parameters:
+     *       {@code return LOCK_ENVIRONMENT && resourceName == TARGET_ENVIRONMENT}.</li>
+     *   <li>Each job has distinct parameter values so it matches exactly one distinct, free
+     *       resource.</li>
+     * </ul>
+     *
+     * All jobs share the identical script <em>text</em> and differ only by parameter values — a
+     * common pattern where the resource to lock is selected by a build parameter. The symptom is
+     * that, although each job needs a distinct and immediately-available resource, only one job
+     * runs at a time — the next dispatches only after the previous build completes. A
+     * start-time-spread assertion cannot detect this when builds are instantaneous, so each build
+     * blocks on a shared latch and records peak concurrency:
+     *
+     * <ul>
+     *   <li>Parallel dispatch: all N builds enter {@code perform()} together, peak concurrency N.</li>
+     *   <li>Serialised dispatch: only the first build starts and blocks; the remaining N-1 never
+     *       dispatch while the latch is held, so peak concurrency stays at 1.</li>
+     * </ul>
+     *
+     * There are {@code N * 2} executors, so executor availability is never the constraint.
+     */
+    @Test
+    @Issue("1052")
+    void scriptResourceJobsRunConcurrently(JenkinsRule j) throws Exception {
+        final int N = 12;
+        j.jenkins.setNumExecutors(N * 2);
+
+        for (int i = 0; i < N; i++) {
+            LockableResourcesManager.get().createResource("env-slot-" + i);
+        }
+
+        final AtomicInteger concurrent = new AtomicInteger(0);
+        final AtomicInteger maxConcurrent = new AtomicInteger(0);
+        final CountDownLatch allStarted = new CountDownLatch(N);
+        final CountDownLatch release = new CountDownLatch(1);
+
+        // Match script shared by all jobs, run sandboxed and driven by build parameters.
+        final String script = "return LOCK_ENVIRONMENT && resourceName == TARGET_ENVIRONMENT";
+
+        List<FreeStyleProject> projects = new ArrayList<>();
+        List<QueueTaskFuture<FreeStyleBuild>> futures = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            FreeStyleProject p = j.createFreeStyleProject("env-job-" + i);
+            SecureGroovyScript groovyScript = new SecureGroovyScript(script, true, null);
+            p.addProperty(new RequiredResourcesProperty(null, null, null, null, groovyScript));
+            p.addProperty(new ParametersDefinitionProperty(
+                    new StringParameterDefinition("LOCK_ENVIRONMENT", "true", ""),
+                    new StringParameterDefinition("TARGET_ENVIRONMENT", "env-slot-" + i, "")));
+            p.getBuildersList().add(new TestBuilder() {
+                @Override
+                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                        throws InterruptedException {
+                    int c = concurrent.incrementAndGet();
+                    maxConcurrent.accumulateAndGet(c, Math::max);
+                    allStarted.countDown();
+                    // Hold the build open so a serialised dispatcher cannot "complete then dispatch next".
+                    release.await(30, TimeUnit.SECONDS);
+                    concurrent.decrementAndGet();
+                    return true;
+                }
+            });
+            projects.add(p);
+        }
+        for (int i = 0; i < N; i++) {
+            futures.add(projects.get(i).scheduleBuild2(0));
+        }
+
+        // Wait (bounded) for all N builds to be running at once. If the bug serialises dispatch,
+        // this times out with only one build ever having started.
+        boolean allRunningTogether = allStarted.await(20, TimeUnit.SECONDS);
+        int peak = maxConcurrent.get();
+
+        // Let the builds finish regardless of outcome.
+        release.countDown();
+        for (int i = 0; i < N; i++) {
+            j.assertBuildStatus(Result.SUCCESS, futures.get(i).get(30, TimeUnit.SECONDS));
+        }
+
+        assertTrue(
+                allRunningTogether && peak == N,
+                "Expected all " + N + " script-resource jobs to run concurrently, but peak concurrency "
+                        + "was " + peak + " (allStarted=" + allRunningTogether + "). Peak of 1 reproduces "
+                        + "the issue #1052 serialisation: only one job runs at a time.");
     }
 
     @Test


### PR DESCRIPTION
# fix: include build parameters in script-match cache key

Fixes #1052

## Problem

When many jobs are queued together, each needing a **distinct, immediately-available** lockable resource selected by a Groovy match script, only **one job runs at a time** — the next dispatches only after the previous build completes. A wave of N such jobs serialises instead of running in parallel.

This shows up with the common pattern where the resource to lock is chosen by a build parameter, e.g. a match script:

```groovy
return LOCK_ENVIRONMENT && resourceName == TARGET_ENVIRONMENT
```

…used by many jobs that share the **identical script text** and differ only by their parameter values (`TARGET_ENVIRONMENT`, etc.). Each job needs its own free resource, so all should dispatch at once.

## Root cause

The per-resource Groovy script-match result cache introduced in #966 keys the cache on the **script text only**:

```java
// LockableResource.scriptMatches(...)
String cacheKey = script.getScript();
```

But the match result also depends on the **parameter bindings** passed into evaluation (`resourceName == TARGET_ENVIRONMENT` evaluates differently per job). Because the key ignores parameters:

1. The first job evaluates the script against every resource with *its* parameters and populates each resource's cache (e.g. `slot-0 → true`, all others `→ false`).
2. Every subsequent job, sharing the identical script text, gets **cache hits computed with the first job's parameters**. They are all told they match the first job's resource (now locked) and that their own resource does *not* match.
3. So every job queues behind the single resource the first job took, and they serialise — for the duration of the cache TTL (default 30s), repeating as entries expire.

It manifests as a queue/dispatch serialisation but is actually a cache-correctness bug; queued items show "Waiting for resources identified by custom script".

## Fix

Build the cache key from the script text **plus a deterministic, order-independent encoding of the parameter bindings**, so evaluations with different parameters are cached as distinct entries:

```java
String cacheKey = buildScriptCacheKey(script.getScript(), params);
```

Resources whose match script ignores parameters still share cache entries (key collapses to the script text when there are no params), preserving the original caching benefit.

## Test

Adds `FreeStyleProjectTest#scriptResourceJobsRunConcurrently`: submits N jobs sharing one parameter-driven, sandboxed match script, each matching a distinct free resource. Because instantaneous builds can't reveal serialisation via start-time spread, each build blocks on a latch and the test records **peak concurrency**:

- With the bug: only the first build starts and blocks; peak concurrency = 1.
- With the fix: all N run together; peak concurrency = N.

Verified the test **fails without** this change and **passes with** it (Jenkins 2.567, N=12).

## Workaround (no plugin upgrade required)

Setting the controller JVM option `-Dorg.jenkins.plugins.lockableresources.SCRIPT_CACHE_TTL_MS=0` disables the cache and avoids the serialisation, at the cost of evaluating the match script on every queue-maintenance pass. The cache-key fix is the durable solution that keeps the caching benefit.
