### PR TITLE
Allow empty reason when reserving a resource

### DIFF
--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -190,24 +190,13 @@ function deleteResource(button) {
 function resource_action(button, action) {
   const resourceName = button.closest('tr').getAttribute('data-resource-name');
 
-  function allowEmptyReasonInPrompt() {
-    setTimeout(function () {
-      const input = document.querySelector("dialog.jenkins-dialog input, dialog.jenkins-dialog textarea");
-      if (!input) return;
-      input.required = false;
-      input.removeAttribute("required");
-      if (!input.value) {
-        input.value = " ";
-      }
-    }, 0);
-  }
-
   if (action === "reserve" || action === "steal") {
     dialog
       .prompt(i18n(action + "-title", resourceName), {
         message: i18n(action + "-message", resourceName),
         minWidth: "450px",
-        maxWidth: "600px"
+        maxWidth: "600px",
+        allowEmpty: action === "reserve",
       })
       .then(
         (reason) => {
@@ -221,9 +210,6 @@ function resource_action(button, action) {
           });
         }
       );
-    if (action === "reserve") {
-      allowEmptyReasonInPrompt();
-    }
     return;
   }
 
@@ -748,31 +734,17 @@ window.updateFilterMode = function (tabId) {
   });
 
   function bulkResourceAction(action, resources) {
-    function allowEmptyReasonInPrompt() {
-      setTimeout(function () {
-        const input = document.querySelector("dialog.jenkins-dialog input, dialog.jenkins-dialog textarea");
-        if (!input) return;
-        input.required = false;
-        input.removeAttribute("required");
-        if (!input.value) {
-          input.value = " ";
-        }
-      }, 0);
-    }
-
     if (action === "reserve" || action === "steal" || action === "reassign") {
       dialog
         .prompt(i18n(action + "-title", resources.join(", ")), {
           message: i18n(action + "-message", resources.join(", ")),
           minWidth: "450px",
-          maxWidth: "600px"
+          maxWidth: "600px",
+          allowEmpty: action === "reserve",
         })
         .then(function (reason) {
           executeBulk(action, resources, reason || "");
         });
-      if (action === "reserve") {
-        allowEmptyReasonInPrompt();
-      }
       return;
     }
     executeBulk(action, resources, null);


### PR DESCRIPTION
<!-- Link related issue(s): Fixes #XXXXX or See JENKINS-XXXXX -->

### What does this PR do?

<!-- Brief description of the change. The PR title is used as the changelog entry. -->
Allow an empty reason when reserving a resource. The changes from #1053 are not working for us. I noticed a similar dialog in the job-config-history plugin, which is optional (https://github.com/jenkinsci/job-config-history-plugin/blob/c8fab15101dce336a8f17f10edd10c7221b860c0/src/main/resources/hudson/plugins/jobConfigHistory/mandatory-config-reason.js#L58), so I asked copilot to apply the same here.

### Testing done

<!-- How was this tested? Automated tests, manual steps, screenshots, etc. -->
Manually tested:
- click reserve button (both single and in bulk)
- the OK button is active without entering anything
- clicking OK reserves the resource, clicking Cancel does not
- when entering a reason, the resource is reserved with that reason

<img width="452" height="214" alt="image" src="https://github.com/user-attachments/assets/bfa48032-d102-46f3-9020-ad6e781650a1" />
<img width="447" height="205" alt="image" src="https://github.com/user-attachments/assets/06c066d0-3403-40fb-a522-925fe9dc89da" />


### Checklist

- [ ] Automated tests added or existing tests cover the change
- [ ] PR title is a clear, imperative-mood changelog entry
- [ ] Breaking changes or upgrade steps are documented below

Related to #1040 
