### PR TITLE
[#1025] Add the client-side view of remote lockable resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
 }
 ```
 
+> *Note:* The combined variable joins the names with commas, so splitting it is only safe while no
+resource name contains a comma. Resource names may contain one. Prefer the numbered variables
+(`LOCKED_RESOURCE0`, `LOCKED_RESOURCE1`, …) whenever a lock can resolve to more than one resource.
+
 #### Skip executing the block if there is a queue
 
 ```groovy
@@ -328,6 +332,71 @@ System.setProperty("org.jenkins.plugins.lockableresources.ENABLE_NODE_MIRROR", "
 
 ----
 
+## Remote lockable resources
+
+A resource can be locked from a *different* Jenkins controller. This is for hardware that only one
+controller owns but several need to use - a test rig, a licence dongle, a PLC - without duplicating
+the resource definition on every controller and hoping the duplicates never disagree.
+
+The controller that owns the resource is the **server**. Any controller that locks it is a **client**.
+A controller can be both. From the pipeline it is one extra argument:
+
+```groovy
+lock(resource: 'plc-01', serverId: 'server-a') {
+  echo 'This build holds plc-01, which lives on server-a'
+}
+```
+
+Everything else about `lock()` behaves as it does locally: `label`, `quantity`, `variable`, `extra`,
+`priority`, `skipIfLocked`, `inversePrecedence` and the allocate timeout all work the same way, and
+the queue on the server is shared between local and remote waiters. A remote lock **fails closed**:
+if the server cannot be reached, the step fails rather than running the block unlocked.
+
+### On the server (the controller that owns the resource)
+
+1. *Manage Jenkins* → *Configure System* → *Lockable Resources (Server)* → **Enable remote API**.
+2. Set **Expose label(s)** - one or more labels, separated by spaces. Only resources carrying one of
+   them can be seen or locked remotely. It is empty by default, which exposes nothing: an enabled
+   API on its own hands out no resources.
+3. Create a Jenkins user for the clients, give it the **Lockable Resources / RemoteUse** permission,
+   and generate an API token for it (*User* → *Security* → *API Token*).
+
+A client holding a lock heartbeats while it works. If the heartbeats stop for 60 seconds the server
+marks the lease `STALE` and says so on the lockable resources page, but it does **not** release it:
+a client that has gone quiet may still be driving the hardware, and handing the resource to someone
+else on that guess is the one outcome a lock exists to prevent. Releasing a stale lease is an
+administrator's decision, taken from that page.
+
+### On the client (the controller that locks it)
+
+Add the server under *Lockable Resources (Client)* → **Remote servers**: a **Server ID** (the name
+used in `serverId:`), the **Remote Jenkins URL**, and a **Credentials ID** - a username/password
+credential holding the server user's name and API token. Set **Client ID** to something that
+identifies this controller; it is what the server shows next to the lock.
+
+### Delegated mode
+
+Setting **Forced server ID** on a client sends *every* `lock()` on that controller to the named
+server, including locks that name no `serverId` at all. It also **overrides a `serverId` a pipeline
+did name**, which is the point of it - the administrator decides where locks go - but it does mean a
+pipeline cannot opt out. The override is logged in the build log.
+
+### Maintenance
+
+Turning off **Accept new acquire requests** on a server refuses new acquires while leaving locks
+already held alone: heartbeats and releases keep working, and waiting clients retry rather than
+fail. Use it to drain a server before taking it down.
+
+A remote can also be switched off from the client side (**Enabled** on the entry) without deleting
+its configuration.
+
+### Locking from something that is not Jenkins
+
+The same locks are reachable over REST, so scripts and non-Jenkins tools can take them too. See
+[remote-api-curl.md](src/doc/examples/remote-api-curl.md) for the endpoints and a worked example.
+
+----
+
 ## Improve performance
 
 To be safe thread over all jobs and resources, need to be all operations synchronized.
@@ -392,6 +461,39 @@ Properties *description*, *labels* and *properties* are optional.
 
 Fields like *reservedBy*, *reservedTimestamp* or *note* are not supported, they will be ignored.
 
+### Remote locking
+
+[Remote locking](#remote-lockable-resources) is configured under the same key. A controller may act
+as a server, as a client, or as both, so the two groups are independent:
+
+```yml
+unclassified:
+  lockableResourcesManager:
+    # Server side: this controller lets others lock its resources
+    remoteApiEnabled: true
+    exposeLabel: "remote-enabled"
+    acceptNewAcquires: true      # maintenance switch; default is true
+
+    # Client side: this controller locks resources on others
+    clientId: "jenkins-client-1"
+    forcedServerId: ""           # non-empty enables delegated mode
+    remotes:
+      - serverId: "server-a"
+        url: "http://jenkins-server-a:8080/jenkins"
+        credentialsId: "server-a-token"
+      - serverId: "server-b"
+        url: "https://jenkins-server-b.example.com/"
+        credentialsId: "server-b-token"
+        enabled: false           # configured but not used; default is true
+
+    declaredResources:
+      - name: "plc-01"
+        labels: "plc remote-enabled"
+```
+
+Only resources whose labels include one of the *exposeLabel* labels are reachable remotely, so
+`plc-01` above is, and a resource labelled only `plc` is not.
+
 ----
 
 ## lockable-resources overview
@@ -455,6 +557,7 @@ Unlock | Jenkins.ADMINISTER | Manually unlock a resource.
 Reserve | Jenkins.ADMINISTER | Reserve or unreserve a resource.
 Steal | Jenkins.ADMINISTER | Steal a lock from another build.
 Queue | Jenkins.ADMINISTER | Reorder the lock wait queue.
+RemoteUse | Jenkins.ADMINISTER | Acquire and release locks through the [remote lock REST API](#remote-lockable-resources). Grant it to the machine users whose API tokens remote client controllers use.
 
 All mutating permissions default to `ADMINISTER`, preserving existing behavior. Admins can delegate individual permissions to specific roles without granting full admin access.
 

--- a/src/doc/examples/remote-api-curl.md
+++ b/src/doc/examples/remote-api-curl.md
@@ -3,12 +3,16 @@
 The Remote Lock REST API lets external applications or non-Jenkins scripts acquire a
 lockable resource on a Jenkins controller without a Pipeline step.
 
+Another Jenkins controller does not need any of this: it uses `lock(..., serverId: '…')`, described
+under [Remote lockable resources](../../../README.md#remote-lockable-resources) in the README. This
+page is for everything that is not a Jenkins controller.
+
 ### Prerequisites
 
 | Item | Where to configure |
 |---|---|
-| **Remote API enabled** | Manage Jenkins → Configure System → Lockable Resources → Enable Remote API |
-| **Resource exposed** | The resource must carry one of the labels listed in *Expose Label* |
+| **Remote API enabled** | Manage Jenkins → Configure System → Lockable Resources (Server) → *Enable remote API* |
+| **Resource exposed** | The resource must carry one of the labels listed in *Expose label(s)* |
 | **User with API token** | The user must have **Lockable Resources / RemoteUse** permission |
 | **API token** | User → Security → API Token |
 
@@ -69,7 +73,7 @@ while true; do
     ACQUIRED) echo "Lock acquired!"; break ;;
     QUEUED)   sleep "${POLL_INTERVAL}" ;;
     SKIPPED)  echo "Resource busy, skipIfLocked=true → skipping"; exit 0 ;;
-    FAILED|EXPIRED|CANCELLED|UNKNOWN)
+    FAILED)
       echo "ERROR: acquire failed with state=${STATE}" >&2
       echo "Response: ${STATUS}" >&2
       exit 1 ;;
@@ -161,12 +165,13 @@ If not acquired within 5 minutes the state becomes `FAILED` with `errorCode: LOC
 
 ### Queue ordering: `priority` and `inversePrecedence`
 
-Current remote API behavior:
+Remote waiters share one queue with local ones on the server, and both fields mean what they mean
+for a local `lock()`:
 
-- `priority` is applied. Larger number wins queue position.
-- `inversePrecedence` is accepted in the payload, but is not currently applied to remote queue ordering.
-
-For now, use `priority` if you need ordering control for remote waiters.
+- `priority` — larger number wins queue position.
+- `inversePrecedence` — the request jumps to the front of the queue, so the newest waiter is served
+  first. It applies only when `priority` is left at its default; giving both falls back to the
+  ordinary priority insert, exactly as a local lock does.
 
 Priority example:
 
@@ -185,7 +190,7 @@ curl -s -u "${USER}:${TOKEN}" \
   "${JENKINS}/lockable-resources/remote/v1/acquire/"
 ```
 
-Inverse precedence payload example (currently informational for remote queueing):
+Inverse precedence example (newest waiter first):
 
 ```bash
 curl -s -u "${USER}:${TOKEN}" \
@@ -219,12 +224,21 @@ Request body (JSON):
 | `lockRequest.timeoutForAllocateResource` | long | no | max wait time (default: unlimited) |
 | `lockRequest.timeoutUnit` | string | no | `MINUTES` (default), `SECONDS`, `HOURS` |
 | `lockRequest.priority` | int | no | higher number = higher queue priority |
-| `lockRequest.inversePrecedence` | bool | no | accepted field; currently not applied to remote queue ordering |
-| `lockRequest.variable` | string | no | env var name for acquired resource name |
+| `lockRequest.inversePrecedence` | bool | no | serve the newest waiter first; ignored when `priority` is also set |
+| `lockRequest.resourceSelectStrategy` | string | no | `SEQUENTIAL` (default) or `RANDOM` |
+| `lockRequest.variable` | string | no | env var name prefix for the acquired resource names |
 | `lockRequest.reason` | string | no | human-readable lock reason |
 | `lockRequest.extra` | array | no | additional resources to lock atomically |
 | `clientId` | string | no | identifier shown in server dashboard |
-| `heartbeatIntervalSeconds` | int | no | must be > 0 when provided |
+| `heartbeatIntervalSeconds` | int | no | must be > 0 when provided. Validated, then **ignored** — the server applies its own stale threshold (see heartbeat below) |
+
+`resource` and `label` are mutually exclusive, and so are `priority` and `inversePrecedence`; the
+canonical `lock()` refuses either combination and so does this endpoint. Whether a request with no
+target at all is legal follows the server's *Allow empty or null values* setting.
+
+Values that cannot be interpreted are rejected rather than quietly defaulted: a non-numeric
+`quantity` or an unknown `timeoutUnit` returns 400 `INVALID_FIELD_VALUE`. Numeric strings (`"2"`)
+are still accepted, and JSON `null` counts as absent.
 
 Response `202 Accepted`:
 ```json
@@ -235,11 +249,22 @@ Error responses:
 
 | HTTP | errorCode | Meaning |
 |---|---|---|
-| 400 | `MISSING_TARGET` | No resource/label/extra in request |
+| 400 | `INVALID_JSON` | Body is not valid JSON |
+| 400 | `MISSING_LOCK_REQUEST` | No `lockRequest` object in the body |
+| 400 | `INVALID_REQUEST` | The request is not a legal `lock()`: no target, `resource` with `label`, `priority` with `inversePrecedence` |
+| 400 | `INVALID_FIELD_VALUE` | A field's value cannot be interpreted (non-numeric `quantity`, unknown `timeoutUnit`, …) |
+| 400 | `INVALID_EXTRA` | An `extra[i]` entry names neither `resource` nor `label` |
+| 400 | `INVALID_HEARTBEAT_INTERVAL` | `heartbeatIntervalSeconds` is not a positive integer |
+| 400 | `ACQUIRE_FAILED` | The request was rejected for some other reason |
 | 403 | `REMOTE_API_DISABLED` | Remote API not enabled on server |
 | 403 | *(no body)* | Authentication failure or missing RemoteUse permission |
 | 404 | `UNKNOWN_RESOURCE` | Resource does not exist or is not exposed by exposeLabel |
 | 404 | `UNKNOWN_LABEL` | Label does not match any exposed resource |
+| 413 | `PAYLOAD_TOO_LARGE` | Request body is over 1 MiB |
+| 503 | `ACQUIRES_PAUSED` | The server is not accepting new acquires (maintenance). Retry later — locks already held are unaffected |
+
+`UNKNOWN_RESOURCE` and `UNKNOWN_LABEL` are both returned as a plain 404 whether the target is
+absent or merely not exposed, so the API does not reveal what exists on the server.
 
 ---
 
@@ -262,16 +287,28 @@ States:
 | `ACQUIRED` | Lock held — safe to do work and send heartbeats |
 | `SKIPPED` | `skipIfLocked` was true and resource was busy |
 | `FAILED` | Acquire rejected or timed out (see `errorCode`) |
-| `EXPIRED` | Allocation timeout elapsed |
+| `STALE` | Held, but the heartbeats stopped — see heartbeat below |
+
+A lock that reaches `SKIPPED` or `FAILED` stays readable for 120 seconds and is then forgotten;
+polling afterwards returns 404 `LOCK_NOT_FOUND`.
 
 ---
 
 #### `POST /lockable-resources/remote/v1/lease/{lockId}/heartbeat`
 
-Must be sent every `heartbeatIntervalSeconds` while holding the lock.
-If missed too many times the server marks the lock as `STALE` and an admin can force-release it.
+Send this while holding the lock. Every 10 seconds matches what the Jenkins client does, and is well
+inside the threshold below.
 
-Response: `204 No Content` on success, `410 Gone` if lock is not active.
+If nothing arrives for 60 seconds the server marks the lock `STALE`. It does **not** release it: a
+client that has gone quiet may still be using the resource, so handing it to the next waiter on that
+guess is exactly what a lock is for preventing. A stale lease is released by an administrator, from
+the lockable resources page.
+
+The threshold is the server's, not the client's — `heartbeatIntervalSeconds` in the acquire request
+is validated and then ignored in this version.
+
+Response: `204 No Content` on success, `410 Gone` if the lock is no longer active
+(`LOCK_STALE` once it has gone stale, `LOCK_NOT_FOUND` if it is already released or unknown).
 
 ---
 
@@ -280,6 +317,39 @@ Response: `204 No Content` on success, `410 Gone` if lock is not active.
 Releases the lock. Idempotent — safe to call even if already released.
 
 Response: `204 No Content`.
+
+---
+
+#### `GET /lockable-resources/remote/v1/resources/`
+
+Lists what this server exposes, so a client can discover names and labels instead of having them
+configured by hand on both sides.
+
+```bash
+curl -s -u "${USER}:${TOKEN}" \
+  "${JENKINS}/lockable-resources/remote/v1/resources/"
+```
+
+Response `200 OK`:
+```json
+{
+  "acceptNewAcquires": true,
+  "resources": [
+    { "name": "r1", "labels": ["gpu", "remote-enabled"], "description": "", "state": "FREE" },
+    { "name": "r2", "labels": ["gpu", "remote-enabled"], "description": "", "state": "LOCKED",
+      "heldByKind": "REMOTE_CLIENT", "heldByClientId": "my-script", "since": 1723526400000 }
+  ]
+}
+```
+
+Only resources carrying one of the server's *expose label(s)* appear. `state` is `FREE`, `QUEUED`,
+`LOCKED` or `RESERVED`; when it is held, `heldByKind` says by what — `LOCAL_BUILD`, `REMOTE_CLIENT`
+or `ADMIN` — and `since` is an epoch-milliseconds timestamp. The build name, its reason and the
+resource note are deliberately not included: which resources exist and whether they are busy is what
+a borrower needs, and nothing more is disclosed.
+
+`acceptNewAcquires` mirrors the maintenance switch, so a client can tell a paused server from an
+unreachable one before it tries to acquire.
 
 ---
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -163,9 +163,11 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Remo
             PauseAction.endCurrentPause(node);
 
             BodyInvoker bodyInvoker = getContext().newBodyInvoker().withCallback(new RemoteCallback(displayTarget));
-            if (lockEnvVars != null && !lockEnvVars.isEmpty()) {
-                Map<String, String> envWithRemoteMetadata =
-                        withRemoteMetadata(lockEnvVars, step.variable, remoteSession, lockId);
+            // The bridge metadata (X_SERVER_ID / X_LOCK_ID) does not depend on what the server returned:
+            // gating it on a non-empty lockEnvVars dropped it whenever the response carried none.
+            Map<String, String> envWithRemoteMetadata = withRemoteMetadata(
+                    lockEnvVars == null ? Collections.emptyMap() : lockEnvVars, step.variable, remoteSession, lockId);
+            if (!envWithRemoteMetadata.isEmpty()) {
                 bodyInvoker.withContext(EnvironmentExpander.merge(
                         getContext().get(EnvironmentExpander.class), new EnvVarsExpander(envWithRemoteMetadata)));
             }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResource.java
@@ -618,10 +618,7 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      */
     @CheckForNull
     public String getRemoteLockClientId() {
-        if (remoteLockedBy == null) {
-            return null;
-        }
-        RemoteLockRecord record = RemoteLockManager.get().find(remoteLockedBy);
+        RemoteLockRecord record = getRemoteLockRecord();
         return record != null ? record.getClientId() : null;
     }
 
@@ -632,7 +629,9 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
      */
     @CheckForNull
     public RemoteLockRecord getRemoteLockRecord() {
-        if (remoteLockedBy == null) {
+        // The lock cause is also rendered outside a running Jenkins (plain unit tests, deserialized
+        // resources), so resolve the manager defensively rather than through Jenkins.get().
+        if (remoteLockedBy == null || Jenkins.getInstanceOrNull() == null) {
             return null;
         }
         return RemoteLockManager.get().find(remoteLockedBy);
@@ -655,10 +654,29 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
         if (isReserved()) {
             return String.format("[%s] is reserved by %s at %s", name, reservedBy, timestamp);
         }
+        if (remoteLockedBy != null) {
+            // A remote lock has no build and no reservedTimestamp; both live on the remote lock record.
+            RemoteLockRecord record = getRemoteLockRecord();
+            return String.format("[%s] is locked by %s at %s", name, remoteHolder(record), remoteSince(record, format));
+        }
         if (isLocked()) {
             return String.format("[%s] is locked by %s at %s", name, buildExternalizableId, timestamp);
         }
         return null;
+    }
+
+    /** Holder of the current remote lock: the client id when known, otherwise the lock id. */
+    @NonNull
+    private String remoteHolder(@CheckForNull RemoteLockRecord record) {
+        String clientId = record == null ? null : record.getClientId();
+        return clientId != null ? "remote client " + clientId : "remote lockId " + remoteLockedBy;
+    }
+
+    /** When the current remote lock was acquired, or {@code <unknown>} if the record is gone. */
+    @NonNull
+    private static String remoteSince(@CheckForNull RemoteLockRecord record, @NonNull DateFormat format) {
+        long acquiredAt = record == null ? 0L : record.getAcquiredAt();
+        return acquiredAt <= 0 ? "<unknown>" : format.format(new Date(acquiredAt));
     }
 
     /**
@@ -687,8 +705,12 @@ public class LockableResource extends AbstractDescribableImpl<LockableResource> 
                         name, lockBuild.getFullDisplayName() + " " + ModelHyperlinkNote.encodeTo(lockBuild), timestamp);
             }
             if (remoteLockedBy != null) {
+                // Shown to a locally waiting job, so name the holder rather than the opaque lock id.
+                // The lock id is kept as well: it is what correlates this wait with the remote server's logs.
+                RemoteLockRecord record = getRemoteLockRecord();
                 return String.format(
-                        "The resource [%s] is locked by remote lockId %s since %s.", name, remoteLockedBy, timestamp);
+                        "The resource [%s] is locked by %s (lockId %s) since %s.",
+                        name, remoteHolder(record), remoteLockedBy, remoteSince(record, format));
             }
         }
         return null;

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -78,6 +78,35 @@ public class LockableResourcesManager extends GlobalConfiguration {
             CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
     private static final Logger LOGGER = Logger.getLogger(LockableResourcesManager.class.getName());
 
+    /**
+     * One line per resource state change, for working out who held what and when.
+     *
+     * <p>Separate from {@link #LOGGER} so it can be turned on by itself: switching the main logger to
+     * FINE to see holdings would bury them in unrelated debug output.
+     *
+     * <p>The line is written where the state actually changes, under the same lock that guards it, so
+     * the order of these lines is the order the resources really changed hands. That is the whole
+     * point of it: a client can only timestamp its own call to release, which returns after the server
+     * has already freed the resource and possibly handed it to someone else - so two clients' logs can
+     * appear to overlap on a resource that was never held twice. Reconstructing exclusion from the
+     * clients therefore cannot distinguish a real double-grant from a slow round trip, and this can.
+     *
+     * <p>Format: {@code LRA|<epochMs>|<LOCAL|REMOTE>|<ACQUIRED|RELEASED>|<resource>|<holder>}, where
+     * holder is the lock id for a remote hold and the build id for a local one.
+     */
+    private static final Logger AUDIT = Logger.getLogger("org.jenkins.plugins.lockableresources.audit");
+
+    /**
+     * Records a resource changing hands. Costs one level check when the logger is off, which is the
+     * normal case - a load test can afford the lines, ordinary use should not pay for them.
+     */
+    private static void audit(String kind, String event, String resourceName, String holder) {
+        if (AUDIT.isLoggable(Level.FINE)) {
+            AUDIT.fine(
+                    "LRA|" + System.currentTimeMillis() + "|" + kind + "|" + event + "|" + resourceName + "|" + holder);
+        }
+    }
+
     private boolean allowEmptyOrNullValues;
 
     /**
@@ -929,6 +958,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
             if (reason != null && !reason.isEmpty()) {
                 r.setLockReason(reason);
             }
+            audit("LOCAL", "ACQUIRED", r.getName(), build.getExternalizableId());
         }
 
         LockedResourcesBuildAction.findAndInitAction(build).addUsedResources(getResourcesNames(resourcesToLock));
@@ -959,6 +989,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
             resource.unqueue();
             resource.setBuild(null);
             resource.setLockReason(null);
+            audit("LOCAL", "RELEASED", resource.getName(), build.getExternalizableId());
             uncacheIfFreeing(resource, true, false);
 
             if (resource.isEphemeral()) {
@@ -2025,6 +2056,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
         for (LockableResource r : resources) {
             r.unqueue();
             r.setRemoteLockedBy(lockId);
+            audit("REMOTE", "ACQUIRED", r.getName(), lockId);
         }
         save();
         return true;
@@ -2041,6 +2073,7 @@ public class LockableResourcesManager extends GlobalConfiguration {
                 LockableResource r = fromName(name);
                 if (r != null && lockId.equals(r.getRemoteLockedBy())) {
                     r.setRemoteLockedBy(null);
+                    audit("REMOTE", "RELEASED", name, lockId);
                 }
             }
             while (proceedNextContext()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1151,10 +1151,37 @@ public class LockableResourcesManager extends GlobalConfiguration {
             this.queuedContexts.removeAll(toRemove);
         }
 
-        // reschedule for the next earliest deadline
+        // reschedule for the next earliest deadline, across both queues.
+        //
+        // There is one timeout task, and scheduleTimeoutAt() cancels whatever is pending before it
+        // schedules again. Computing the deadline from the local queue alone therefore does not just
+        // ignore remote entries - it cancels a wake-up a remote entry was relying on and never puts
+        // it back, so remote requests only ever time out when something else happens to run a
+        // maintenance pass.
+        earliestDeadline = Math.min(earliestDeadline, earliestRemoteDeadline());
         scheduleTimeoutAt(earliestDeadline);
 
         return nextEntry;
+    }
+
+    // ---------------------------------------------------------------------------
+    /**
+     * Earliest allocate-timeout deadline among the queued remote requests, or {@link Long#MAX_VALUE}
+     * when none of them is waiting against a deadline.
+     * Must be called under {@link #syncResources}.
+     */
+    private long earliestRemoteDeadline() {
+        long earliest = Long.MAX_VALUE;
+        for (RemoteQueueEntry entry : getRemoteQueueEntries()) {
+            if (!entry.isValid()) {
+                continue;
+            }
+            long deadline = entry.getTimeoutDeadlineMillis();
+            if (deadline > 0 && deadline < earliest) {
+                earliest = deadline;
+            }
+        }
+        return earliest;
     }
 
     // ---------------------------------------------------------------------------
@@ -1924,6 +1951,16 @@ public class LockableResourcesManager extends GlobalConfiguration {
             list.add(insertAt, entry);
             LOGGER.fine("Remote acquire queued: lockId=" + entry.getLockId() + " priority=" + entry.getPriority()
                     + " position=" + insertAt);
+
+            // Same as queueContext(): if this entry has a timeout and its deadline is earlier than the
+            // currently scheduled one, (re)schedule so it fires on time. Without this a remote request
+            // computes a deadline that nothing ever wakes up to enforce, so timeoutForAllocateResource
+            // stops being an upper bound on the wait - it only takes effect when a maintenance pass
+            // happens to run for some other reason, such as the holder releasing.
+            long deadline = entry.getTimeoutDeadlineMillis();
+            if (deadline > 0 && (nextTimeoutDeadline == 0 || deadline < nextTimeoutDeadline)) {
+                scheduleTimeoutAt(deadline);
+            }
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -107,6 +107,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
     private boolean remoteApiEnabled = false;
 
     /**
+     * Maintenance switch. While false the remote API keeps serving every endpoint except
+     * {@code POST /acquire}, so leases already held can heartbeat and release undisturbed while no new
+     * ones are handed out. Requests already queued keep their place and are still promoted.
+     */
+    private boolean acceptNewAcquires = true;
+
+    /**
      * Only resources that carry this label are exposed via the remote API.
      * When empty or null, no resources are exposed (opt-in: must explicitly set a label).
      */
@@ -209,6 +216,15 @@ public class LockableResourcesManager extends GlobalConfiguration {
 
     public boolean isRemoteApiEnabled() {
         return remoteApiEnabled;
+    }
+
+    @DataBoundSetter
+    public void setAcceptNewAcquires(boolean acceptNewAcquires) {
+        this.acceptNewAcquires = acceptNewAcquires;
+    }
+
+    public boolean isAcceptNewAcquires() {
+        return acceptNewAcquires;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -47,6 +47,7 @@ import net.sf.json.JSONObject;
 import org.jenkins.plugins.lockableresources.actions.LockedResourcesBuildAction;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
+import org.jenkins.plugins.lockableresources.remote.RemoteCatalogCache;
 import org.jenkins.plugins.lockableresources.remote.RemoteQueueEntry;
 import org.jenkins.plugins.lockableresources.remote.RemoteResolver;
 import org.jenkins.plugins.lockableresources.util.Constants;
@@ -394,6 +395,9 @@ public class LockableResourcesManager extends GlobalConfiguration {
         }
         this.remotes = validatedRemotes;
         save();
+        // The catalog snapshots belong to the previous configuration; a changed URL, credential or
+        // enabled flag makes them meaningless.
+        RemoteCatalogCache.get().invalidateAll();
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -1940,12 +1940,21 @@ public class LockableResourcesManager extends GlobalConfiguration {
     public void queueRemote(@NonNull RemoteQueueEntry entry) {
         synchronized (syncResources) {
             List<RemoteQueueEntry> list = getRemoteQueueEntries();
-            int insertAt = list.size();
-            for (int i = list.size() - 1; i >= 0; i--) {
-                if (list.get(i).getPriority() < entry.getPriority()) {
-                    insertAt = i;
-                } else {
-                    break;
+            int insertAt;
+            if (entry.getLockRequest().isInversePrecedence() && entry.getPriority() == 0) {
+                // Same rule as queueContext(): with the default priority, inversePrecedence means "take the
+                // first position". The flag travels on the wire and is kept on the request, but this queue
+                // used to ignore it, so the very parameter that makes a local lock() jump the queue did
+                // nothing once the request arrived over the bridge.
+                insertAt = 0;
+            } else {
+                insertAt = list.size();
+                for (int i = list.size() - 1; i >= 0; i--) {
+                    if (list.get(i).getPriority() < entry.getPriority()) {
+                        insertAt = i;
+                    } else {
+                        break;
+                    }
                 }
             }
             list.add(insertAt, entry);

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockableResourcesManager.java
@@ -286,8 +286,13 @@ public class LockableResourcesManager extends GlobalConfiguration {
         if (trimmed == null) {
             return FormValidation.ok();
         }
-        if (!getRemotesAsMap().containsKey(trimmed)) {
+        RemoteConnection target = getRemotesAsMap().get(trimmed);
+        if (target == null) {
             return FormValidation.warning(Messages.warning_forcedServerIdNotConfigured(trimmed));
+        }
+        if (!target.isEnabled()) {
+            // Delegated mode routes every lock() here, so a disabled target fails all of them.
+            return FormValidation.warning(Messages.warning_forcedServerIdDisabled(trimmed));
         }
         return FormValidation.ok();
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/RemoteConnection.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/RemoteConnection.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Objects;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
@@ -32,11 +33,31 @@ public class RemoteConnection extends AbstractDescribableImpl<RemoteConnection> 
     private final String url;
     private final String credentialsId;
 
+    /**
+     * Whether this controller may use the connection. Turning it off is the borrower's counterpart of
+     * the server-side maintenance switch: the entry keeps its URL and credentials binding, but no new
+     * lock is requested through it. Leases already held are unaffected - dropping them would strand
+     * the resources on the other side.
+     *
+     * <p>Set through a {@link DataBoundSetter} rather than the constructor so that configuration
+     * written before this existed - JCasC yaml with only the three connection fields - still loads.
+     */
+    private boolean enabled = true;
+
     @DataBoundConstructor
     public RemoteConnection(String serverId, String url, String credentialsId) {
         this.serverId = serverId;
         this.url = url;
         this.credentialsId = credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 
     public String getServerId() {
@@ -83,19 +104,21 @@ public class RemoteConnection extends AbstractDescribableImpl<RemoteConnection> 
             return false;
         }
         RemoteConnection that = (RemoteConnection) o;
-        return Objects.equals(serverId, that.serverId)
+        return enabled == that.enabled
+                && Objects.equals(serverId, that.serverId)
                 && Objects.equals(url, that.url)
                 && Objects.equals(credentialsId, that.credentialsId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serverId, url, credentialsId);
+        return Objects.hash(serverId, url, credentialsId, enabled);
     }
 
     @Override
     public String toString() {
-        return "RemoteConnection{" + "serverId='" + serverId + '\'' + ", url='" + url + '\'' + "}";
+        return "RemoteConnection{" + "serverId='" + serverId + '\'' + ", url='" + url + '\'' + ", enabled=" + enabled
+                + "}";
     }
 
     @Extension

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -33,8 +33,10 @@ import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourceProperty;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.Messages;
+import org.jenkins.plugins.lockableresources.RemoteConnection;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
+import org.jenkins.plugins.lockableresources.remote.RemoteClientRegistry;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
 import org.jenkins.plugins.lockableresources.remote.RemoteQueueEntry;
@@ -545,6 +547,62 @@ public class LockableResourcesRootAction implements RootAction {
                 + method
                 + " has been deprecated due performance issues. When you see this message, please inform plugin developers:"
                 + buf);
+    }
+
+    // ---------------------------------------------------------------------------
+    /**
+     * Remote locks this controller currently holds or waits for on other controllers.
+     *
+     * <p>This is the client side of the picture: the resources listed elsewhere on this page belong to
+     * this controller, while these belong to someone else. The state shown here is what this controller
+     * last observed, not the remote's own record - the view says so.
+     */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public List<RemoteClientRegistry.Entry> getRemoteLocks() {
+        Jenkins.get().checkPermission(VIEW);
+        return RemoteClientRegistry.get().getAll();
+    }
+
+    /** True when a connection exists for this serverId but has been switched off. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public boolean isServerDisabled(String serverId) {
+        RemoteConnection remote =
+                LockableResourcesManager.get().getRemotesAsMap().get(serverId);
+        return remote != null && !remote.isEnabled();
+    }
+
+    /** Human-readable age of a timestamp, for the remote view. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public String getElapsedSince(long timestampMillis) {
+        if (timestampMillis <= 0) {
+            return "";
+        }
+        return formatDuration(System.currentTimeMillis() - timestampMillis);
+    }
+
+    /** True when this controller has any remote relation at all - server side or client side. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public boolean isRemoteConfigured() {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        return lrm.isRemoteApiEnabled() || !lrm.getRemotes().isEmpty();
+    }
+
+    /** The serverId every lock() on this controller is routed to, or empty when not delegating. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public String getForcedServerId() {
+        return LockableResourcesManager.get().getForcedServerId();
+    }
+
+    /** Base URL of the delegated target, for the badge; empty when not delegating or unknown. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public String getForcedServerUrl() {
+        String forced = getForcedServerId();
+        if (forced == null || forced.isEmpty()) {
+            return "";
+        }
+        RemoteConnection remote =
+                LockableResourcesManager.get().getRemotesAsMap().get(forced);
+        return remote != null ? remote.getUrl() : "";
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -36,6 +36,8 @@ import org.jenkins.plugins.lockableresources.Messages;
 import org.jenkins.plugins.lockableresources.RemoteConnection;
 import org.jenkins.plugins.lockableresources.queue.LockableResourcesStruct;
 import org.jenkins.plugins.lockableresources.queue.QueuedContextStruct;
+import org.jenkins.plugins.lockableresources.remote.RemoteCatalog;
+import org.jenkins.plugins.lockableresources.remote.RemoteCatalogCache;
 import org.jenkins.plugins.lockableresources.remote.RemoteClientRegistry;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
@@ -561,6 +563,28 @@ public class LockableResourcesRootAction implements RootAction {
     public List<RemoteClientRegistry.Entry> getRemoteLocks() {
         Jenkins.get().checkPermission(VIEW);
         return RemoteClientRegistry.get().getAll();
+    }
+
+    /** True when this controller delegates every lock() to one remote server. */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public boolean isDelegatedMode() {
+        String forced = getForcedServerId();
+        return forced != null && !forced.isEmpty();
+    }
+
+    /**
+     * What the delegated target publishes, as last observed, or {@code null} when nothing has been
+     * fetched yet. Never blocks: a stale snapshot is refreshed in the background.
+     */
+    @CheckForNull
+    @Restricted(NoExternalUse.class) // used by jelly
+    public RemoteCatalog getDelegatedCatalog() {
+        Jenkins.get().checkPermission(VIEW);
+        String forced = getForcedServerId();
+        if (forced == null || forced.isEmpty()) {
+            return null;
+        }
+        return RemoteCatalogCache.get().get(forced);
     }
 
     /** True when a connection exists for this serverId but has been switched off. */

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -17,6 +17,7 @@ import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -563,6 +564,7 @@ public class LockableResourcesRootAction implements RootAction {
             queue.add(remoteEntry);
         }
 
+        queue.sortByPromotionOrder();
         return queue;
     }
 
@@ -604,6 +606,21 @@ public class LockableResourcesRootAction implements RootAction {
             if (oldest == null || oldest.getQueuedAt() > queueStruct.getQueuedAt()) {
                 oldest = queueStruct;
             }
+        }
+
+        // -------------------------------------------------------------------------
+        /**
+         * Orders the merged local and remote entries the way they will actually be promoted.
+         *
+         * <p>Local and remote entries arrive as two separately ordered lists, so simply concatenating
+         * them showed every remote entry behind every local one no matter its priority. Promotion
+         * ({@code LockableResourcesManager#proceedNextContext}) compares the heads of both queues and
+         * takes the higher priority, favouring local on a tie - which is exactly a stable sort by
+         * descending priority over "locals first, then remotes".
+         */
+        @Restricted(NoExternalUse.class)
+        public void sortByPromotionOrder() {
+            this.queue.sort(Comparator.comparingInt(QueueStruct::getPriority).reversed());
         }
 
         // -------------------------------------------------------------------------
@@ -1205,6 +1222,16 @@ public class LockableResourcesRootAction implements RootAction {
                                 && b.getFullDisplayName()
                                         .toLowerCase(Locale.ENGLISH)
                                         .contains(lowerFilter)) {
+                            return true;
+                        }
+                        // Remote rows have no resource list, no label and no build, so without these two
+                        // the free-text filter could only ever match their lock id.
+                        if (getQueueItemRequestText(item)
+                                .toLowerCase(Locale.ENGLISH)
+                                .contains(lowerFilter)) {
+                            return true;
+                        }
+                        if (item.getRequestedBy().toLowerCase(Locale.ENGLISH).contains(lowerFilter)) {
                             return true;
                         }
                         return item.getId().toLowerCase(Locale.ENGLISH).contains(lowerFilter);

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction.java
@@ -565,6 +565,18 @@ public class LockableResourcesRootAction implements RootAction {
         return RemoteClientRegistry.get().getAll();
     }
 
+    /**
+     * True when this controller serves resources remotely but has stopped handing out new locks.
+     *
+     * <p>Only interesting while the remote API is on: with it off, nothing is being served either way,
+     * and a banner about paused acquires would be noise.
+     */
+    @Restricted(NoExternalUse.class) // used by jelly
+    public boolean isRemoteAcquiresPaused() {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        return lrm.isRemoteApiEnabled() && !lrm.isAcceptNewAcquires();
+    }
+
     /** True when this controller delegates every lock() to one remote server. */
     @Restricted(NoExternalUse.class) // used by jelly
     public boolean isDelegatedMode() {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -294,6 +294,11 @@ public class RemoteApiV1Action {
             if (record.getErrorCode() != null) {
                 response.put("errorCode", record.getErrorCode());
             }
+            if (record.getAcquiredResourceNames() != null) {
+                // The client shows what it holds on its own lockable resources page, and this is the only
+                // place it can learn the names: lockEnvVars only carries them when a variable was asked for.
+                response.put("resources", JSONArray.fromObject(record.getAcquiredResourceNames()));
+            }
             if (record.getLockEnvVars() != null) {
                 JSONObject envVarsJson = new JSONObject();
                 envVarsJson.putAll(record.getLockEnvVars());

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -8,6 +8,7 @@ package org.jenkins.plugins.lockableresources.actions;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -16,11 +17,13 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
+import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRecord;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockState;
+import org.jenkins.plugins.lockableresources.remote.RemoteResolver;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -60,6 +63,8 @@ public class RemoteApiV1Action {
                 return new AcquireRouter();
             case "lease":
                 return new LeaseRouter();
+            case "resources":
+                return new ResourcesResource();
             default:
                 return null;
         }
@@ -355,6 +360,85 @@ public class RemoteApiV1Action {
 
             RemoteLockManager.get().release(lockId); // idempotent
             rsp.setStatus(204);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Serves GET /resources
+    // -----------------------------------------------------------------------
+
+    /**
+     * Lists what this server exposes, plus whether it is currently accepting new acquires.
+     *
+     * <p>The two travel together on purpose: split across endpoints, two client-side caches could
+     * disagree and the page would claim a resource is free while the server has stopped handing out
+     * leases. Resource state stays truthful while paused - saying "you cannot take this right now" is
+     * the client page's job.
+     *
+     * <p>Holder details stop at the kind. The server's admin published resources, not the names of the
+     * builds using them, and this list is rendered on a controller whose viewers may have no account
+     * here at all.
+     */
+    public static final class ResourcesResource {
+
+        public void doIndex(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+            Jenkins.get().checkPermission(LockableResourcesRootAction.REMOTE);
+
+            LockableResourcesManager lrm = LockableResourcesManager.get();
+            if (!lrm.isRemoteApiEnabled()) {
+                sendJsonError(rsp, 403, "REMOTE_API_DISABLED", "Remote API is not enabled");
+                return;
+            }
+
+            JSONArray resources = new JSONArray();
+            synchronized (LockableResourcesManager.syncResources) {
+                for (LockableResource r : new RemoteResolver(lrm).exposedResources()) {
+                    resources.add(describe(r));
+                }
+            }
+
+            JSONObject response = new JSONObject();
+            response.put("acceptNewAcquires", lrm.isAcceptNewAcquires());
+            response.put("resources", resources);
+
+            rsp.setStatus(200);
+            rsp.setContentType("application/json;charset=UTF-8");
+            rsp.getWriter().write(response.toString());
+        }
+
+        private static JSONObject describe(LockableResource r) {
+            JSONObject json = new JSONObject();
+            json.put("name", r.getName());
+            json.put("labels", JSONArray.fromObject(r.getLabelsAsList()));
+            json.put("description", r.getDescription() == null ? "" : r.getDescription());
+
+            if (r.getReservedBy() != null) {
+                json.put("state", "RESERVED");
+                json.put("heldByKind", "ADMIN");
+                Date since = r.getReservedTimestamp();
+                if (since != null) {
+                    json.put("since", since.getTime());
+                }
+            } else if (r.isLocked()) {
+                json.put("state", "LOCKED");
+                RemoteLockRecord record = r.getRemoteLockRecord();
+                if (r.getRemoteLockedBy() != null) {
+                    json.put("heldByKind", "REMOTE_CLIENT");
+                    if (record != null && record.getClientId() != null) {
+                        json.put("heldByClientId", record.getClientId());
+                    }
+                    if (record != null && record.getAcquiredAt() > 0) {
+                        json.put("since", record.getAcquiredAt());
+                    }
+                } else {
+                    json.put("heldByKind", "LOCAL_BUILD");
+                }
+            } else if (r.isQueued()) {
+                json.put("state", "QUEUED");
+            } else {
+                json.put("state", "FREE");
+            }
+            return json;
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -8,7 +8,6 @@ package org.jenkins.plugins.lockableresources.actions;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +17,6 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
-import org.jenkins.plugins.lockableresources.ResourceSelectStrategy;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRecord;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
@@ -107,16 +105,10 @@ public class RemoteApiV1Action {
             String resource = stringField(lockRequestJson, "resource");
             String label = stringField(lockRequestJson, "label");
 
-            // extra-only requests are valid (local lock() allows them when extra is present),
-            // so only reject when there is no main target AND no extra.
-            JSONArray extraPeek = lockRequestJson.optJSONArray("extra");
-            boolean hasExtra = extraPeek != null && !extraPeek.isEmpty();
-            if (resource == null && label == null && !hasExtra) {
-                sendJsonError(
-                        rsp, 400, "MISSING_TARGET", "lockRequest must contain at least one of: resource, label, extra");
-                return;
-            }
-
+            // Whether a request without any target is acceptable depends on allowEmptyOrNullValues, and
+            // whether the parameters make sense together is lock() semantics - both are canonical rules,
+            // checked inside enqueue() rather than re-implemented here (see LockStepResource.validate).
+            //
             // Exposure/existence is enforced by the admission check inside enqueue (validateRemoteSelectors):
             // a selector referencing something this client can't lock (unknown/unexposed) comes back
             // as a terminal UNKNOWN_* record, which we map to HTTP 404 below. This endpoint only parses the
@@ -142,16 +134,6 @@ public class RemoteApiV1Action {
             boolean inversePrecedence = lockRequestJson.optBoolean("inversePrecedence", false);
             String resourceSelectStrategy = stringField(lockRequestJson, "resourceSelectStrategy");
             if (resourceSelectStrategy == null) resourceSelectStrategy = "SEQUENTIAL";
-            try {
-                ResourceSelectStrategy.valueOf(resourceSelectStrategy.toUpperCase(Locale.ENGLISH));
-            } catch (IllegalArgumentException e) {
-                sendJsonError(
-                        rsp,
-                        400,
-                        "INVALID_SELECT_STRATEGY",
-                        "resourceSelectStrategy must be one of " + Arrays.toString(ResourceSelectStrategy.values()));
-                return;
-            }
             String reason = stringField(lockRequestJson, "reason");
 
             // Parse extra resources (optional - additional resources to lock atomically)
@@ -223,7 +205,17 @@ public class RemoteApiV1Action {
                     timeoutUnit,
                     reason);
 
-            RemoteLockRecord record = RemoteLockManager.get().enqueue(lockRequest, clientId);
+            RemoteLockRecord record;
+            try {
+                record = RemoteLockManager.get().enqueue(lockRequest, clientId);
+            } catch (IllegalArgumentException ex) {
+                // The canonical validator rejected the request (lock() semantics: no target while
+                // allowEmptyOrNullValues is off, resource and label together, priority with
+                // inversePrecedence, an unknown select strategy). Its message is the same one a local
+                // lock() would print, so pass it through rather than inventing a remote-only wording.
+                sendJsonError(rsp, 400, "INVALID_REQUEST", ex.getMessage());
+                return;
+            }
             String logTarget = resource != null ? resource : "label:" + label;
             LOGGER.fine("POST /acquire target=" + logTarget + " lockId=" + record.getLockId() + " clientId="
                     + record.getClientId() + " state=" + record.getState());
@@ -231,7 +223,7 @@ public class RemoteApiV1Action {
             // Admission rejected the request - nothing this client can lock (unknown/unexposed).
             // Uniform 404 (errorCode distinguishes resource vs label); existence is not otherwise revealed.
             // Any other terminal FAILED from enqueue must map to a 4xx, never fall through to a
-            // 202 success (defensive - MISSING_TARGET is already rejected at the boundary above).
+            // 202 success (defensive - malformed requests are already rejected as INVALID_REQUEST).
             if (record.getState() == RemoteLockState.FAILED) {
                 String ec = record.getErrorCode();
                 if ("UNKNOWN_RESOURCE".equals(ec) || "UNKNOWN_LABEL".equals(ec)) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.ResourceSelectStrategy;
@@ -102,13 +104,8 @@ public class RemoteApiV1Action {
                 return;
             }
 
-            String resource = lockRequestJson.optString("resource", null);
-            if (resource != null) resource = resource.trim();
-            if (resource != null && resource.isEmpty()) resource = null;
-
-            String label = lockRequestJson.optString("label", null);
-            if (label != null) label = label.trim();
-            if (label != null && label.isEmpty()) label = null;
+            String resource = stringField(lockRequestJson, "resource");
+            String label = stringField(lockRequestJson, "label");
 
             // extra-only requests are valid (local lock() allows them when extra is present),
             // so only reject when there is no main target AND no extra.
@@ -128,11 +125,23 @@ public class RemoteApiV1Action {
             boolean skipIfLocked = lockRequestJson.optBoolean("skipIfLocked", false);
             // quantity 0 (or absent) means "all matching" for label requests, matching local lock()
             // (LockableResourcesManager "0 means all"); must NOT default to 1.
-            int quantity = lockRequestJson.optInt("quantity", 0);
-            String variable = lockRequestJson.optString("variable", null);
-            if (variable != null && variable.isEmpty()) variable = null;
+            int quantity;
+            int priority;
+            long timeoutForAllocateResource;
+            String timeoutUnit;
+            try {
+                quantity = intField(lockRequestJson, "quantity", 0);
+                priority = intField(lockRequestJson, "priority", 0);
+                timeoutForAllocateResource = longField(lockRequestJson, "timeoutForAllocateResource", 0);
+                timeoutUnit = timeUnitField(lockRequestJson);
+            } catch (InvalidFieldException e) {
+                sendJsonError(rsp, 400, "INVALID_FIELD_VALUE", e.getMessage());
+                return;
+            }
+            String variable = stringField(lockRequestJson, "variable");
             boolean inversePrecedence = lockRequestJson.optBoolean("inversePrecedence", false);
-            String resourceSelectStrategy = lockRequestJson.optString("resourceSelectStrategy", "SEQUENTIAL");
+            String resourceSelectStrategy = stringField(lockRequestJson, "resourceSelectStrategy");
+            if (resourceSelectStrategy == null) resourceSelectStrategy = "SEQUENTIAL";
             try {
                 ResourceSelectStrategy.valueOf(resourceSelectStrategy.toUpperCase(Locale.ENGLISH));
             } catch (IllegalArgumentException e) {
@@ -143,11 +152,7 @@ public class RemoteApiV1Action {
                         "resourceSelectStrategy must be one of " + Arrays.toString(ResourceSelectStrategy.values()));
                 return;
             }
-            int priority = lockRequestJson.optInt("priority", 0);
-            long timeoutForAllocateResource = lockRequestJson.optLong("timeoutForAllocateResource", 0);
-            String timeoutUnit = lockRequestJson.optString("timeoutUnit", "MINUTES");
-            String reason = lockRequestJson.optString("reason", null);
-            if (reason != null && reason.isEmpty()) reason = null;
+            String reason = stringField(lockRequestJson, "reason");
 
             // Parse extra resources (optional - additional resources to lock atomically)
             List<RemoteLockRequest.ExtraResource> extra = null;
@@ -156,12 +161,8 @@ public class RemoteApiV1Action {
                 extra = new ArrayList<>(extraArray.size());
                 for (int i = 0; i < extraArray.size(); i++) {
                     JSONObject extraEntry = extraArray.getJSONObject(i);
-                    String extraResource = extraEntry.optString("resource", null);
-                    if (extraResource != null) extraResource = extraResource.trim();
-                    if (extraResource != null && extraResource.isEmpty()) extraResource = null;
-                    String extraLabel = extraEntry.optString("label", null);
-                    if (extraLabel != null) extraLabel = extraLabel.trim();
-                    if (extraLabel != null && extraLabel.isEmpty()) extraLabel = null;
+                    String extraResource = stringField(extraEntry, "resource");
+                    String extraLabel = stringField(extraEntry, "label");
                     if (extraResource == null && extraLabel == null) {
                         sendJsonError(
                                 rsp,
@@ -171,19 +172,19 @@ public class RemoteApiV1Action {
                         return;
                     }
                     // Exposure/existence of this extra selector is checked by admission in enqueue (see above).
-                    int extraQuantity = extraEntry.optInt("quantity", 0); // 0/absent = all (label)
+                    int extraQuantity; // 0/absent = all (label)
+                    try {
+                        extraQuantity = intField(extraEntry, "quantity", 0);
+                    } catch (InvalidFieldException e) {
+                        sendJsonError(rsp, 400, "INVALID_FIELD_VALUE", "extra[" + i + "]: " + e.getMessage());
+                        return;
+                    }
                     extra.add(new RemoteLockRequest.ExtraResource(extraResource, extraLabel, extraQuantity));
                 }
             }
 
             // clientId is optional - identifies the calling Jenkins instance (e.g. root URL)
-            String clientId = body.optString("clientId", null);
-            if (clientId != null) {
-                clientId = clientId.trim();
-                if (clientId.isEmpty()) {
-                    clientId = null;
-                }
-            }
+            String clientId = stringField(body, "clientId");
 
             // heartbeatIntervalSeconds is optional but must be a positive integer when present
             if (body.containsKey("heartbeatIntervalSeconds")) {
@@ -360,6 +361,103 @@ public class RemoteApiV1Action {
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Typed field parsing
+    //
+    // The lock() DSL gets its types from Java: a pipeline cannot pass "abc" where an int is declared,
+    // and LockStep#setTimeoutUnit rejects a unit that is not a TimeUnit. JSON has no such guarantee,
+    // and reading these fields with optInt/optLong/optString means an uninterpretable value silently
+    // becomes the default instead of being refused. That is not a smaller version of the same
+    // behaviour - it changes what the request means, in the direction of doing more:
+    //
+    //   * quantity that is not a number becomes 0, and 0 on a label means "every match", so a typo
+    //     asks for the whole pool rather than the one machine that was meant;
+    //   * timeoutForAllocateResource that is not a number becomes 0, and a timeoutUnit that is not a
+    //     TimeUnit disables the deadline outright, so a bounded wait silently becomes unbounded.
+    //
+    // Neither is reachable through a local lock(), so both arrived with this endpoint. Parse strictly
+    // instead, and let the caller hear about it.
+    //
+    // Strict does not mean brittle. A numeric string ("2") still parses, because json-lib accepts it
+    // and clients in the wild send it; an explicit null is treated as absent, because serialisers
+    // routinely emit null for an unset field and refusing those would break callers over nothing.
+    // -----------------------------------------------------------------------
+
+    /** Signals a field whose value cannot be interpreted as its type; mapped to HTTP 400. */
+    private static final class InvalidFieldException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        InvalidFieldException(String message) {
+            super(message);
+        }
+    }
+
+    /** True when the key is absent or explicitly null - both mean "not supplied". */
+    private static boolean isAbsent(JSONObject json, String key) {
+        return !json.containsKey(key) || JSONNull.getInstance().equals(json.get(key));
+    }
+
+    /**
+     * A string field, where absent, explicitly null, and blank all mean "not supplied".
+     *
+     * <p>The null case is why this exists rather than a bare optString: json-lib hands back the
+     * four-character string {@code "null"} for a JSON null, so {@code "resource": null} would ask for
+     * a resource actually named "null", and {@code "variable": null} would export an environment
+     * variable by that name.
+     */
+    @edu.umd.cs.findbugs.annotations.CheckForNull
+    private static String stringField(JSONObject json, String key) {
+        if (isAbsent(json, key)) {
+            return null;
+        }
+        String value = json.optString(key, null);
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    private static int intField(JSONObject json, String key, int defaultValue) throws InvalidFieldException {
+        if (isAbsent(json, key)) {
+            return defaultValue;
+        }
+        try {
+            return json.getInt(key);
+        } catch (RuntimeException e) {
+            throw new InvalidFieldException(key + " must be an integer, got: " + json.get(key));
+        }
+    }
+
+    private static long longField(JSONObject json, String key, long defaultValue) throws InvalidFieldException {
+        if (isAbsent(json, key)) {
+            return defaultValue;
+        }
+        try {
+            return json.getLong(key);
+        } catch (RuntimeException e) {
+            throw new InvalidFieldException(key + " must be a number, got: " + json.get(key));
+        }
+    }
+
+    /**
+     * Reads {@code timeoutUnit} the way {@link org.jenkins.plugins.lockableresources.LockStep#setTimeoutUnit}
+     * does: blank falls back to the default, anything else must name a {@link TimeUnit} and is upper-cased.
+     */
+    private static String timeUnitField(JSONObject json) throws InvalidFieldException {
+        String value = stringField(json, "timeoutUnit");
+        if (value == null) {
+            return "MINUTES";
+        }
+        String normalized = value.toUpperCase(Locale.ENGLISH);
+        try {
+            TimeUnit.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFieldException("Invalid timeoutUnit: " + value);
+        }
+        return normalized;
+    }
 
     /** Cap on the POST body size (in characters) to avoid unbounded reads. */
     static final int MAX_BODY_CHARS = 1024 * 1024; // 1 MiB

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -79,6 +79,14 @@ public class RemoteApiV1Action {
                 sendJsonError(rsp, 403, "REMOTE_API_DISABLED", "Remote API is not enabled on this server");
                 return;
             }
+            if (!lrm.isAcceptNewAcquires()) {
+                // Maintenance switch: only new acquires are refused. Status, heartbeat and release stay
+                // available so leases in flight are undisturbed, and 503 tells the client to come back
+                // rather than to give up.
+                sendJsonError(
+                        rsp, 503, "ACQUIRES_PAUSED", "This server is not accepting new acquire requests right now");
+                return;
+            }
 
             JSONObject body;
             try {

--- a/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1Action.java
@@ -386,6 +386,9 @@ public class RemoteApiV1Action {
      */
     public static final class ResourcesResource {
 
+        // Read-only: this lists what the server exposes and changes nothing. Annotated so Stapler
+        // refuses anything but GET, matching the acquire status endpoint (#1076).
+        @GET
         public void doIndex(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
             Jenkins.get().checkPermission(LockableResourcesRootAction.REMOTE);
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteAcquireStatus.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteAcquireStatus.java
@@ -6,6 +6,7 @@
 package org.jenkins.plugins.lockableresources.remote;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,12 +22,26 @@ public class RemoteAcquireStatus {
     @CheckForNull
     private final Map<String, String> lockEnvVars;
 
+    @CheckForNull
+    private final List<String> resourceNames;
+
     public RemoteAcquireStatus(
             String lockId,
             RemoteAcquireState state,
             String errorCode,
             String message,
             @CheckForNull Map<String, String> lockEnvVars) {
+        this(lockId, state, errorCode, message, lockEnvVars, null);
+    }
+
+    public RemoteAcquireStatus(
+            String lockId,
+            RemoteAcquireState state,
+            String errorCode,
+            String message,
+            @CheckForNull Map<String, String> lockEnvVars,
+            @CheckForNull List<String> resourceNames) {
+        this.resourceNames = resourceNames;
         this.lockId = lockId;
         this.state = state != null ? state : RemoteAcquireState.UNKNOWN;
         this.errorCode = errorCode;
@@ -55,5 +70,11 @@ public class RemoteAcquireStatus {
     @CheckForNull
     public Map<String, String> getLockEnvVars() {
         return lockEnvVars;
+    }
+
+    /** Resources the remote handed over, when it reported them. */
+    @CheckForNull
+    public List<String> getResourceNames() {
+        return resourceNames;
     }
 }

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteApiClient.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteApiClient.java
@@ -15,6 +15,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -161,12 +162,22 @@ public class RemoteApiClient {
             }
             lockEnvVars = Collections.unmodifiableMap(map);
         }
+        List<String> resourceNames = null;
+        net.sf.json.JSONArray resourcesJson = response.optJSONArray("resources");
+        if (resourcesJson != null) {
+            List<String> names = new ArrayList<>(resourcesJson.size());
+            for (int i = 0; i < resourcesJson.size(); i++) {
+                names.add(resourcesJson.getString(i));
+            }
+            resourceNames = Collections.unmodifiableList(names);
+        }
         return new RemoteAcquireStatus(
                 extractLockId(response, lockId),
                 RemoteAcquireState.fromString(response.optString("state", null)),
                 response.optString("errorCode", null),
                 response.optString("message", null),
-                lockEnvVars);
+                lockEnvVars,
+                resourceNames);
     }
 
     /**

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteApiClient.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteApiClient.java
@@ -181,6 +181,52 @@ public class RemoteApiClient {
     }
 
     /**
+     * GET /resources - what the remote publishes, plus whether it is accepting new acquires.
+     */
+    @NonNull
+    public RemoteCatalog listResources(@NonNull RemoteConnection remote, @NonNull String authorizationHeader)
+            throws RemoteApiException {
+        String path = "/resources/";
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(resolve(remote, path))
+                .header("Accept", "application/json")
+                .timeout(requestTimeout)
+                .GET();
+        applyAuthorizationHeader(requestBuilder, authorizationHeader);
+
+        DecodedJsonResponse decoded = sendAndDecodeJson(remote.getServerId(), "GET", path, requestBuilder.build());
+        JSONObject response = decoded.body;
+
+        List<RemoteCatalog.Resource> resources = new ArrayList<>();
+        net.sf.json.JSONArray array = response.optJSONArray("resources");
+        if (array != null) {
+            for (int i = 0; i < array.size(); i++) {
+                JSONObject r = array.getJSONObject(i);
+                List<String> labels = new ArrayList<>();
+                net.sf.json.JSONArray labelsJson = r.optJSONArray("labels");
+                if (labelsJson != null) {
+                    for (int k = 0; k < labelsJson.size(); k++) {
+                        labels.add(labelsJson.getString(k));
+                    }
+                }
+                resources.add(new RemoteCatalog.Resource(
+                        r.optString("name", ""),
+                        labels,
+                        r.optString("description", ""),
+                        r.optString("state", ""),
+                        r.optString("heldByKind", ""),
+                        r.optString("heldByClientId", ""),
+                        r.optLong("since", 0)));
+            }
+        }
+        return new RemoteCatalog(
+                remote.getServerId(),
+                resources,
+                response.optBoolean("acceptNewAcquires", true),
+                System.currentTimeMillis(),
+                null);
+    }
+
+    /**
      * POST /lease/{lockId}/heartbeat.
      */
     public void heartbeatLease(

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalog.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalog.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * What a remote server publishes, as this controller last saw it.
+ *
+ * <p>A snapshot, not a live view: the remote is the source of truth for its own resources and this is
+ * a copy that was accurate when it was fetched. {@link #getFetchedAt()} says when that was, and
+ * {@link #getError()} says why a refresh did not happen, so the page can show an honest age rather
+ * than implying the numbers are current.
+ */
+@Restricted(NoExternalUse.class)
+public final class RemoteCatalog {
+
+    private final String serverId;
+    private final List<Resource> resources;
+    private final boolean acceptNewAcquires;
+    private final long fetchedAt;
+
+    @CheckForNull
+    private final String error;
+
+    RemoteCatalog(
+            String serverId,
+            List<Resource> resources,
+            boolean acceptNewAcquires,
+            long fetchedAt,
+            @CheckForNull String error) {
+        this.serverId = serverId;
+        this.resources = resources == null ? Collections.emptyList() : List.copyOf(resources);
+        this.acceptNewAcquires = acceptNewAcquires;
+        this.fetchedAt = fetchedAt;
+        this.error = error;
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    @NonNull
+    public List<Resource> getResources() {
+        return resources;
+    }
+
+    /** Whether the remote is currently handing out new locks at all. */
+    public boolean isAcceptNewAcquires() {
+        return acceptNewAcquires;
+    }
+
+    /** When this snapshot was taken, or 0 if nothing has ever been fetched. */
+    public long getFetchedAt() {
+        return fetchedAt;
+    }
+
+    /** Why the last refresh failed, or {@code null} if it succeeded. */
+    @CheckForNull
+    public String getError() {
+        return error;
+    }
+
+    public boolean isStale(long ttlMillis) {
+        return System.currentTimeMillis() - fetchedAt > ttlMillis;
+    }
+
+    /** One resource as published by the remote. State is the remote's, at fetch time. */
+    @Restricted(NoExternalUse.class)
+    public static final class Resource {
+
+        private final String name;
+        private final List<String> labels;
+        private final String description;
+        private final String state;
+        private final String heldByKind;
+        private final String heldByClientId;
+        private final long since;
+
+        Resource(
+                String name,
+                List<String> labels,
+                String description,
+                String state,
+                String heldByKind,
+                String heldByClientId,
+                long since) {
+            this.name = name;
+            this.labels = labels == null ? Collections.emptyList() : List.copyOf(labels);
+            this.description = description == null ? "" : description;
+            this.state = state == null ? "" : state;
+            this.heldByKind = heldByKind == null ? "" : heldByKind;
+            this.heldByClientId = heldByClientId == null ? "" : heldByClientId;
+            this.since = since;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @NonNull
+        public List<String> getLabels() {
+            return labels;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public String getHeldByKind() {
+            return heldByKind;
+        }
+
+        public String getHeldByClientId() {
+            return heldByClientId;
+        }
+
+        public long getSince() {
+            return since;
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCache.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCache.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+import org.jenkins.plugins.lockableresources.RemoteConnection;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Short-lived cache of what other servers publish, so the page can show it without waiting on them.
+ *
+ * <p>Rendering never performs the HTTP call: a page render hands back whatever snapshot exists and,
+ * if it has aged past the TTL, asks for a refresh in the background. A remote that is slow or down
+ * therefore costs a stale age indicator, not a page that hangs - display is best-effort, unlike lock
+ * acquisition, which stays fail-closed.
+ *
+ * <p>The TTL is deliberately short. The catalog carries live state (free, locked, reserved) and
+ * whether the remote is accepting new acquires, so a minute-old copy would be shown as if current.
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class RemoteCatalogCache {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoteCatalogCache.class.getName());
+
+    /** How long a snapshot is served before a refresh is triggered. */
+    static final long TTL_MILLIS = 10_000L;
+
+    private final ConcurrentHashMap<String, RemoteCatalog> catalogs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Boolean> refreshing = new ConcurrentHashMap<>();
+
+    public static RemoteCatalogCache get() {
+        return Jenkins.get().getExtensionList(RemoteCatalogCache.class).get(0);
+    }
+
+    /**
+     * The last snapshot for this server, refreshing in the background when it has gone stale.
+     *
+     * @return {@code null} when nothing has been fetched yet (a refresh has been started), or when the
+     *     connection is unknown or switched off.
+     */
+    @CheckForNull
+    public RemoteCatalog get(@NonNull String serverId) {
+        RemoteConnection remote =
+                LockableResourcesManager.get().getRemotesAsMap().get(serverId);
+        if (remote == null || !remote.isEnabled()) {
+            // A disabled connection is not contacted at all - that is what disabling it means.
+            catalogs.remove(serverId);
+            return null;
+        }
+        RemoteCatalog current = catalogs.get(serverId);
+        if (current == null || current.isStale(TTL_MILLIS)) {
+            requestRefresh(remote);
+        }
+        return current;
+    }
+
+    /** Fetches now, on the calling thread. Used by tests and by the background refresh. */
+    @NonNull
+    RemoteCatalog fetch(@NonNull RemoteConnection remote) {
+        RemoteCatalog fetched;
+        try {
+            String authorizationHeader = RemoteCredentials.basicAuthHeader(remote, null);
+            fetched = new RemoteApiClient().listResources(remote, authorizationHeader);
+        } catch (Exception ex) {
+            // Keep whatever we had: an outage should age the view, not empty it.
+            RemoteCatalog previous = catalogs.get(remote.getServerId());
+            LOGGER.log(Level.FINE, "Could not refresh the remote catalog for {0}: {1}", new Object[] {
+                remote.getServerId(), ex.getMessage()
+            });
+            fetched = new RemoteCatalog(
+                    remote.getServerId(),
+                    previous == null ? Collections.emptyList() : previous.getResources(),
+                    previous != null && previous.isAcceptNewAcquires(),
+                    previous == null ? 0 : previous.getFetchedAt(),
+                    ex.getMessage() == null ? ex.toString() : ex.getMessage());
+        }
+        catalogs.put(remote.getServerId(), fetched);
+        return fetched;
+    }
+
+    private void requestRefresh(@NonNull RemoteConnection remote) {
+        String serverId = remote.getServerId();
+        if (refreshing.putIfAbsent(serverId, Boolean.TRUE) != null) {
+            return; // one in flight is enough; page renders are frequent, remotes are not fast
+        }
+        jenkins.util.Timer.get().submit(() -> {
+            try {
+                fetch(remote);
+            } catch (Exception ex) {
+                LOGGER.log(Level.FINE, "Remote catalog refresh failed for " + serverId, ex);
+            } finally {
+                refreshing.remove(serverId);
+            }
+        });
+    }
+
+    /** Drops every snapshot - used when the remote configuration changes, and by tests. */
+    public void invalidateAll() {
+        catalogs.clear();
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteClientRegistry.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteClientRegistry.java
@@ -1,0 +1,178 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Run;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * What this controller currently holds or waits for on other controllers.
+ *
+ * <p>The client side of a remote lock lives in a {@link RemoteLockSession} per {@code lock()} step,
+ * which is enough to run the step but leaves nobody able to answer "what is this controller doing
+ * remotely right now?" - the question the lockable resources page exists to answer for local
+ * resources. This registry is that answer: the client-side counterpart of the server-side
+ * {@link RemoteLockManager}.
+ *
+ * <p>It is deliberately not persisted. A remote lock does not survive a restart of this controller
+ * (the session either resumes polling or fails closed), so a stale entry read from disk could only
+ * ever be wrong; {@code RemoteLockSession.onResume} re-registers what genuinely survived.
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class RemoteClientRegistry {
+
+    private final ConcurrentHashMap<String, Entry> entries = new ConcurrentHashMap<>();
+
+    public static RemoteClientRegistry get() {
+        return Jenkins.get().getExtensionList(RemoteClientRegistry.class).get(0);
+    }
+
+    /** Records a request that has been accepted by the remote and is waiting for its resources. */
+    public void queued(
+            @NonNull String lockId, @NonNull String serverId, @NonNull String request, @CheckForNull Run<?, ?> build) {
+        entries.put(lockId, new Entry(lockId, serverId, request, build));
+    }
+
+    /** Promotes a waiting entry to held, naming the resources the remote handed over. */
+    public void acquired(@NonNull String lockId, @CheckForNull List<String> resourceNames) {
+        Entry entry = entries.get(lockId);
+        if (entry != null) {
+            entry.markAcquired(resourceNames);
+        }
+    }
+
+    /** Forgets an entry once the lock is released, skipped or failed. */
+    public void forget(@CheckForNull String lockId) {
+        if (lockId != null) {
+            entries.remove(lockId);
+        }
+    }
+
+    /** Everything this controller holds or waits for, held entries first, then oldest first. */
+    @NonNull
+    public List<Entry> getAll() {
+        List<Entry> all = new ArrayList<>(entries.values());
+        all.sort(Comparator.comparing((Entry e) -> e.isAcquired() ? 0 : 1).thenComparingLong(Entry::getEnqueuedAt));
+        return Collections.unmodifiableList(all);
+    }
+
+    @NonNull
+    public Collection<Entry> forServer(@NonNull String serverId) {
+        List<Entry> matching = new ArrayList<>();
+        for (Entry e : getAll()) {
+            if (serverId.equals(e.getServerId())) {
+                matching.add(e);
+            }
+        }
+        return matching;
+    }
+
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    /** One remote lock this controller holds or waits for. */
+    @Restricted(NoExternalUse.class)
+    public static final class Entry {
+
+        private final String lockId;
+        private final String serverId;
+        private final String request;
+        private final long enqueuedAt;
+        private volatile long acquiredAt;
+        private volatile List<String> resourceNames;
+
+        /**
+         * The build is held weakly and its name copied: the page must keep rendering a lock whose build
+         * has since been deleted, and must not be the reason a finished build stays in memory.
+         */
+        private final WeakReference<Run<?, ?>> build;
+
+        private final String buildName;
+        private final String buildUrl;
+
+        private Entry(String lockId, String serverId, String request, @CheckForNull Run<?, ?> build) {
+            this.lockId = lockId;
+            this.serverId = serverId;
+            this.request = request;
+            this.enqueuedAt = System.currentTimeMillis();
+            this.build = new WeakReference<>(build);
+            this.buildName = build != null ? build.getFullDisplayName() : "";
+            this.buildUrl = build != null ? build.getUrl() : "";
+        }
+
+        private void markAcquired(@CheckForNull List<String> names) {
+            this.resourceNames = names == null ? Collections.emptyList() : List.copyOf(names);
+            this.acquiredAt = System.currentTimeMillis();
+        }
+
+        public String getLockId() {
+            return lockId;
+        }
+
+        public String getServerId() {
+            return serverId;
+        }
+
+        /** Human-readable description of what was asked for, e.g. {@code plc-01} or {@code label:plc}. */
+        public String getRequest() {
+            return request;
+        }
+
+        public boolean isAcquired() {
+            return acquiredAt > 0;
+        }
+
+        public String getState() {
+            return isAcquired() ? "ACQUIRED" : "QUEUED";
+        }
+
+        public long getEnqueuedAt() {
+            return enqueuedAt;
+        }
+
+        public long getAcquiredAt() {
+            return acquiredAt;
+        }
+
+        /** Since when this entry has been in its current state. */
+        public long getSince() {
+            return isAcquired() ? acquiredAt : enqueuedAt;
+        }
+
+        @NonNull
+        public List<String> getResourceNames() {
+            List<String> names = resourceNames;
+            return names == null ? Collections.emptyList() : names;
+        }
+
+        @CheckForNull
+        public Run<?, ?> getBuild() {
+            return build.get();
+        }
+
+        public String getBuildName() {
+            return buildName;
+        }
+
+        public String getBuildUrl() {
+            return buildUrl;
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManager.java
@@ -165,9 +165,14 @@ public class RemoteLockManager extends PeriodicWork {
     // -----------------------------------------------------------------------
     /**
      * Releases a lock, freeing the underlying resource(s). Idempotent.
+     *
+     * <p>The record is kept as a terminal {@code FAILED}/{@code RELEASED} entry until its TTL rather
+     * than being dropped here, so a {@code GET /acquire/{lockId}} right after the release reports what
+     * happened instead of a 404 that cannot be told apart from "the server restarted". The sweep in
+     * {@link #maybeScanStale()} owns removal.
      */
     public void release(String lockId) {
-        RemoteLockRecord record = records.remove(lockId);
+        RemoteLockRecord record = records.get(lockId);
         if (record == null) {
             return;
         }
@@ -186,10 +191,15 @@ public class RemoteLockManager extends PeriodicWork {
                 if (names != null && !names.isEmpty()) {
                     namesToUnlock = names;
                 }
+                record.markFailed("RELEASED");
             } else if (state == RemoteLockState.QUEUED) {
                 // Terminal-mark before unqueue so a not-yet-run promotion is excluded.
                 record.markFailed("RELEASED");
                 lrm.unqueueRemote(lockId);
+            } else {
+                // Already terminal - a repeated release. The first call freed whatever was held, so
+                // there is nothing left to do; the record waits out its TTL.
+                return;
             }
         }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManager.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManager.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -100,13 +101,29 @@ public class RemoteLockManager extends PeriodicWork {
                 LOGGER.fine("Remote acquire rejected: lockId=" + lockId + " errorCode=" + errorCode);
                 return record;
             }
+            // Whether the parameters make sense together is lock() semantics, so ask the canonical
+            // validator rather than re-implementing its rules at the REST boundary. It runs after
+            // admission on purpose: it also rejects labels that do not exist, and answering that with a
+            // 400 while an existing-but-unexposed label answers 404 would tell a client which names are
+            // real. Admission has already reduced both to a uniform 404 by the time we get here.
+            // Throws IllegalArgumentException, which the endpoint maps to 400 INVALID_REQUEST.
+            RemoteResolver.validateAsLocalStep(lockRequest, lrm.isAllowEmptyOrNullValues());
+
             // Resolve through the SAME canonical path local lock() uses (no re-implementation of lock()
             // semantics), with the exposeLabel set as candidate filter. extra / label / quantity(0=all) /
             // resourceSelectStrategy / property env vars all come from the canonical path. A request whose
             // (exposed, existing) targets are merely busy stays QUEUED, exactly like local.
             List<LockableResourcesStruct> structs = resolver.toRemoteStructs(lockRequest);
             if (structs.isEmpty()) {
-                record.markFailed("MISSING_TARGET");
+                if (lrm.isAllowEmptyOrNullValues()) {
+                    // Local lock() with nothing to lock runs the body holding nothing when the instance
+                    // allows empty values; the bridge grants the same no-op lease instead of failing.
+                    record.markAcquired(Collections.emptyList(), Collections.emptyMap());
+                } else {
+                    // Unreachable: the canonical validator above rejects a target-less request in this
+                    // configuration. Kept so a future change cannot fall through to a 202 with no lease.
+                    record.markFailed("MISSING_TARGET");
+                }
             } else {
                 List<LockableResource> available = resolver.availableForRemote(structs, lockRequest);
                 if (available != null && !available.isEmpty()) {

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRecord.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRecord.java
@@ -73,19 +73,6 @@ public final class RemoteLockRecord {
         return lockRequest;
     }
 
-    /**
-     * Returns the first acquired resource name, or the requested resource name if not yet acquired.
-     * Returns {@code null} for label-only requests that have not yet been acquired.
-     */
-    @CheckForNull
-    public String getResourceName() {
-        List<String> names = acquiredResourceNames;
-        if (names != null && !names.isEmpty()) {
-            return names.get(0);
-        }
-        return lockRequest.getResource();
-    }
-
     @CheckForNull
     public List<String> getAcquiredResourceNames() {
         return acquiredResourceNames;

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRouting.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRouting.java
@@ -65,6 +65,12 @@ public final class RemoteLockRouting {
         if (remote == null) {
             throw new AbortException("Remote connection not found for serverId=" + serverId);
         }
+        if (!remote.isEnabled()) {
+            // Fail rather than fall back to a local resource of the same name: locking the wrong thing
+            // quietly is the accident delegated mode was made strict to avoid.
+            throw new AbortException("Remote connection is disabled for serverId=" + serverId
+                    + " (enable it in Manage Jenkins > System, or remove the serverId from this lock())");
+        }
         return remote;
     }
 

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
@@ -252,34 +252,23 @@ public final class RemoteLockSession implements Serializable {
             if (ex instanceof RemoteApiException) {
                 int httpStatus = ((RemoteApiException) ex).getHttpStatus();
                 if (httpStatus == 404 || httpStatus == 410) {
-                    if (!bodyStarted) {
-                        // Still acquiring: the QUEUED record is gone. We hold a lockId (admission passed at
-                        // POST) and skipIfLocked is resolved synchronously at POST (never polled), so a
-                        // never-acquired record vanishing means the server-side allocation wait timed out.
-                        // Normalize to LOCK_WAIT_TIMEOUT - the same outcome as observing a FAILED state -
-                        // instead of mislabeling a legitimate timeout as a transport/communication failure.
-                        LOGGER.log(
-                                Level.WARNING,
-                                "Remote acquire wait ended (HTTP {0}); treating as LOCK_WAIT_TIMEOUT. "
-                                        + "serverId={1}, lockId={2}",
-                                new Object[] {httpStatus, serverId, lockId});
-                        finishFailure(
-                                host,
-                                new AbortException("Remote acquire failed (serverId=" + serverId + ", lockId=" + lockId
-                                        + ", state=FAILED, errorCode=LOCK_WAIT_TIMEOUT)"));
-                        return;
-                    }
-                    // An already-ACQUIRED lease vanished (server restart / forced release): irrecoverable.
+                    // The server has no record of this lock. This used to be split on bodyStarted, with the
+                    // still-acquiring side reported as LOCK_WAIT_TIMEOUT - but polling stops the instant the
+                    // lock is acquired, so the bodyStarted side is unreachable, and a legitimate allocation
+                    // timeout arrives as a terminal FAILED state rather than a 404 (the record now lives for
+                    // its terminal TTL, and so does a released queued request). Reaching here therefore means
+                    // the record is genuinely gone: the server restarted, the record outlived its TTL, or the
+                    // lock id is not one this server issued. Reporting that as a timeout would mislabel it.
                     LOGGER.log(
                             Level.WARNING,
-                            "Remote lock not found on server (HTTP {0}); server may have restarted. "
-                                    + "serverId={1}, lockId={2}",
+                            "Remote lock record not found (HTTP {0}); server may have restarted or the record "
+                                    + "expired. serverId={1}, lockId={2}",
                             new Object[] {httpStatus, serverId, lockId});
                     finishFailure(
                             host,
-                            new AbortException(
-                                    "Remote lock not found (HTTP " + httpStatus + "), server may have restarted. "
-                                            + "serverId=" + serverId + ", lockId=" + lockId));
+                            new AbortException("Remote lock record not found (HTTP " + httpStatus
+                                    + "), server may have restarted or the record expired. " + "serverId=" + serverId
+                                    + ", lockId=" + lockId));
                     return;
                 }
             }

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
@@ -78,6 +78,9 @@ public final class RemoteLockSession implements Serializable {
 
     private volatile String serverId;
     private volatile String lockId;
+    /** What was asked for, kept so the page (and a resumed session) can still name it. */
+    private volatile String requestDescription;
+
     private volatile RemoteAcquireState lastState = RemoteAcquireState.UNKNOWN;
     private volatile boolean bodyStarted;
     private volatile int consecutivePollFailures;
@@ -177,6 +180,8 @@ public final class RemoteLockSession implements Serializable {
         this.serverId = remote.getServerId();
         this.lockId = acquiredLockId;
         this.acquirePaused = false;
+        this.requestDescription = displayTarget;
+        RemoteClientRegistry.get().queued(acquiredLockId, remote.getServerId(), displayTarget, run);
         LOGGER.log(Level.FINE, "Remote acquire enqueued: serverId={0}, serverUrl={1}, lockId={2}", new Object[] {
             remote.getServerId(), remote.getUrl(), acquiredLockId
         });
@@ -328,6 +333,7 @@ public final class RemoteLockSession implements Serializable {
                     }
                     lockId = statusLockId;
                     bodyStarted = true;
+                    RemoteClientRegistry.get().acquired(statusLockId, status.getResourceNames());
                     cancelPollTask();
                     startHeartbeat(remote, authorizationHeader, client);
                     host.runBody(remoteResource, status.getLockEnvVars(), statusLockId);
@@ -335,6 +341,7 @@ public final class RemoteLockSession implements Serializable {
                 case SKIPPED:
                     cancelPollTask();
                     completionSignaled.set(true);
+                    RemoteClientRegistry.get().forget(lockId);
                     PauseAction.endCurrentPause(host.context().get(FlowNode.class));
                     LockedResourcesBuildAction.addLog(
                             run,
@@ -459,6 +466,7 @@ public final class RemoteLockSession implements Serializable {
         if (!completionSignaled.compareAndSet(false, true)) {
             return;
         }
+        RemoteClientRegistry.get().forget(lockId);
         cancelPollTaskAndRetries();
         cancelHeartbeatTask();
         // Fail-closed: do not attempt release on communication/state failures.
@@ -469,12 +477,14 @@ public final class RemoteLockSession implements Serializable {
     /** Called by the step's body callback when the lock body finishes - cancel heartbeat and release the lease. */
     public void onBodyFinished(Host host) {
         completionSignaled.set(true);
+        RemoteClientRegistry.get().forget(lockId);
         cancelHeartbeatTask();
         releaseBestEffort(host);
     }
 
     /** Aborts an in-flight session (step stopped): cancel timers, best-effort release, fail the context. */
     public void stop(Host host, Throwable cause) {
+        RemoteClientRegistry.get().forget(lockId);
         cancelPollTaskAndRetries();
         cancelHeartbeatTask();
         // Unified remote lock cleanup: release if held (no-op when nothing acquired yet).
@@ -531,7 +541,14 @@ public final class RemoteLockSession implements Serializable {
             Run<?, ?> run = host.context().get(Run.class);
             String authorizationHeader = RemoteCredentials.basicAuthHeader(remote, run);
             RemoteApiClient client = new RemoteApiClient();
-            String displayTarget = lockId; // best-effort description post-restart
+            // Before the registry existed there was nothing to describe a resumed lock with, so the
+            // lock id stood in for the request. requestDescription survives the restart with the session.
+            String displayTarget = requestDescription != null ? requestDescription : lockId;
+            Run<?, ?> resumedBuild = host.context().get(Run.class);
+            RemoteClientRegistry.get().queued(lockId, serverId, displayTarget, resumedBuild);
+            if (bodyStarted) {
+                RemoteClientRegistry.get().acquired(lockId, null);
+            }
             // Restart is not a poll failure: start the post-restart retry budget fresh so a
             // long pre-restart QUEUED period does not shrink it.
             consecutivePollFailures = 0;

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteLockSession.java
@@ -13,6 +13,7 @@ import hudson.model.TaskListener;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -67,6 +68,12 @@ public final class RemoteLockSession implements Serializable {
     private final AtomicBoolean completionSignaled = new AtomicBoolean(false);
 
     private transient volatile ScheduledFuture<?> pollTask;
+    /** Set while the remote answers 503 ACQUIRES_PAUSED and we are waiting for it to reopen. */
+    private volatile boolean acquirePaused;
+    /** Wall-clock deadline for the acquire retries, or 0 when the request waits forever. */
+    private volatile long acquireDeadlineMillis;
+
+    private transient volatile ScheduledFuture<?> acquireRetryTask;
     private transient volatile ScheduledFuture<?> heartbeatTask;
 
     private volatile String serverId;
@@ -120,30 +127,25 @@ public final class RemoteLockSession implements Serializable {
                 logger);
         context.get(FlowNode.class).addAction(new PauseAction("Lock"));
 
+        // Use configured clientId (or root URL as fallback) to identify this Jenkins to the remote server.
+        String clientId = lrm.getEffectiveClientId();
+        this.acquireDeadlineMillis = acquireDeadline(lockRequest);
         try {
-            // Use configured clientId (or root URL as fallback) to identify this Jenkins to the remote server.
-            String clientId = lrm.getEffectiveClientId();
-            String acquiredLockId = client.enqueueAcquire(
-                    remote,
-                    authorizationHeader,
-                    lockRequest,
-                    RemoteClientDefaults.DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
-                    clientId);
-            this.serverId = remote.getServerId();
-            this.lockId = acquiredLockId;
-            LockableResourcesManager.printLogs(
-                    "Remote acquire enqueued (serverId="
-                            + remote.getServerId()
-                            + ", serverUrl="
-                            + remote.getUrl()
-                            + ", lockId="
-                            + acquiredLockId
-                            + ")",
-                    Level.FINE,
-                    LOGGER,
-                    logger);
-            startPolling(host, remote, authorizationHeader, client, run, displayTarget);
+            enqueueAcquire(host, remote, authorizationHeader, client, run, displayTarget, lockRequest, clientId);
         } catch (RemoteApiException ex) {
+            if (ex.getHttpStatus() == 503) {
+                // The server is paused for maintenance, not broken. Failing the build here is exactly what
+                // the switch exists to avoid, so keep asking until this request's own allocation timeout.
+                acquirePaused = true;
+                logger.println("Remote server is not accepting new acquire requests right now (serverId="
+                        + remote.getServerId()
+                        + ", serverUrl="
+                        + remote.getUrl()
+                        + "); waiting for it to resume.");
+                scheduleAcquireRetry(
+                        host, remote, authorizationHeader, client, run, displayTarget, lockRequest, clientId);
+                return false;
+            }
             logger.println("Remote lock request failed (serverId="
                     + remote.getServerId()
                     + ", serverUrl="
@@ -153,6 +155,116 @@ public final class RemoteLockSession implements Serializable {
             finishFailure(host, ex);
         }
         return false;
+    }
+
+    /** Sends the acquire request and, on acceptance, starts polling for its outcome. */
+    private void enqueueAcquire(
+            Host host,
+            RemoteConnection remote,
+            String authorizationHeader,
+            RemoteApiClient client,
+            Run<?, ?> run,
+            String displayTarget,
+            RemoteLockRequest lockRequest,
+            String clientId)
+            throws RemoteApiException {
+        String acquiredLockId = client.enqueueAcquire(
+                remote,
+                authorizationHeader,
+                lockRequest,
+                RemoteClientDefaults.DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+                clientId);
+        this.serverId = remote.getServerId();
+        this.lockId = acquiredLockId;
+        this.acquirePaused = false;
+        LOGGER.log(Level.FINE, "Remote acquire enqueued: serverId={0}, serverUrl={1}, lockId={2}", new Object[] {
+            remote.getServerId(), remote.getUrl(), acquiredLockId
+        });
+        startPolling(host, remote, authorizationHeader, client, run, displayTarget);
+    }
+
+    /** Deadline for the acquire retries, mirroring the allocation timeout the request carries. */
+    private static long acquireDeadline(RemoteLockRequest lockRequest) {
+        long timeout = lockRequest.getTimeoutForAllocateResource();
+        if (timeout <= 0) {
+            return 0; // wait forever, like a local lock() without a timeout
+        }
+        try {
+            TimeUnit unit = TimeUnit.valueOf(lockRequest.getTimeoutUnit().toUpperCase(Locale.ENGLISH));
+            return System.currentTimeMillis() + unit.toMillis(timeout);
+        } catch (IllegalArgumentException e) {
+            return 0;
+        }
+    }
+
+    private void scheduleAcquireRetry(
+            Host host,
+            RemoteConnection remote,
+            String authorizationHeader,
+            RemoteApiClient client,
+            Run<?, ?> run,
+            String displayTarget,
+            RemoteLockRequest lockRequest,
+            String clientId) {
+        cancelAcquireRetryTask();
+        acquireRetryTask = jenkins.util.Timer.get()
+                .scheduleWithFixedDelay(
+                        () -> retryAcquire(
+                                host, remote, authorizationHeader, client, run, displayTarget, lockRequest, clientId),
+                        RemoteClientDefaults.DEFAULT_POLL_INTERVAL_SECONDS,
+                        RemoteClientDefaults.DEFAULT_POLL_INTERVAL_SECONDS,
+                        TimeUnit.SECONDS);
+    }
+
+    @SuppressFBWarnings(
+            value = "REC_CATCH_EXCEPTION",
+            justification = "The retry loop must not propagate anything to the executor.")
+    private void retryAcquire(
+            Host host,
+            RemoteConnection remote,
+            String authorizationHeader,
+            RemoteApiClient client,
+            Run<?, ?> run,
+            String displayTarget,
+            RemoteLockRequest lockRequest,
+            String clientId) {
+        if (completionSignaled.get()) {
+            cancelAcquireRetryTask();
+            return;
+        }
+        try {
+            enqueueAcquire(host, remote, authorizationHeader, client, run, displayTarget, lockRequest, clientId);
+            cancelAcquireRetryTask();
+        } catch (RemoteApiException ex) {
+            if (ex.getHttpStatus() == 503) {
+                if (acquireDeadlineMillis > 0 && System.currentTimeMillis() >= acquireDeadlineMillis) {
+                    cancelAcquireRetryTask();
+                    finishFailure(
+                            host,
+                            new AbortException("Remote acquire timed out while the server was not accepting new "
+                                    + "acquire requests (serverId=" + serverId(remote) + ", state=FAILED, "
+                                    + "errorCode=ACQUIRES_PAUSED)"));
+                }
+                return; // still paused and still within the budget - keep waiting
+            }
+            cancelAcquireRetryTask();
+            finishFailure(host, ex);
+        } catch (Exception ex) {
+            cancelAcquireRetryTask();
+            finishFailure(host, ex);
+        }
+    }
+
+    private String serverId(RemoteConnection remote) {
+        return serverId != null ? serverId : remote.getServerId();
+    }
+
+    private void cancelAcquireRetryTask() {
+        ScheduledFuture<?> task = acquireRetryTask;
+        if (task != null) {
+            task.cancel(false);
+            acquireRetryTask = null;
+        }
     }
 
     private void startPolling(
@@ -347,7 +459,7 @@ public final class RemoteLockSession implements Serializable {
         if (!completionSignaled.compareAndSet(false, true)) {
             return;
         }
-        cancelPollTask();
+        cancelPollTaskAndRetries();
         cancelHeartbeatTask();
         // Fail-closed: do not attempt release on communication/state failures.
         // Remote side should reclaim via heartbeat timeout.
@@ -363,7 +475,7 @@ public final class RemoteLockSession implements Serializable {
 
     /** Aborts an in-flight session (step stopped): cancel timers, best-effort release, fail the context. */
     public void stop(Host host, Throwable cause) {
-        cancelPollTask();
+        cancelPollTaskAndRetries();
         cancelHeartbeatTask();
         // Unified remote lock cleanup: release if held (no-op when nothing acquired yet).
         releaseBestEffort(host);
@@ -377,6 +489,19 @@ public final class RemoteLockSession implements Serializable {
             justification = "Resume is best-effort; any failure resuming the poll loop fails the step closed.")
     public void onResume(Host host) {
         if (lockId == null || lockId.isEmpty()) {
+            if (acquirePaused) {
+                // We were still waiting for a paused server, so no lock exists anywhere: fail closed
+                // rather than leave the step waiting for a retry loop that did not survive the restart.
+                LOGGER.log(Level.WARNING, "Jenkins restarted while waiting for a paused remote server: {0}", serverId);
+                try {
+                    host.context()
+                            .onFailure(new AbortException("Jenkins restarted while waiting for the remote server to "
+                                    + "accept new acquire requests (serverId=" + serverId + ")"));
+                } catch (Exception ex) {
+                    LOGGER.log(Level.FINE, "Best-effort: could not signal the resume failure", ex);
+                }
+                return;
+            }
             // Nothing was enqueued before the restart - nothing to resume.
             return;
         }
@@ -423,6 +548,11 @@ public final class RemoteLockSession implements Serializable {
                 LOGGER.log(Level.FINE, "Best-effort: could not signal resume failure to the step context", signalEx);
             }
         }
+    }
+
+    private void cancelPollTaskAndRetries() {
+        cancelPollTask();
+        cancelAcquireRetryTask();
     }
 
     private void cancelPollTask() {

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
@@ -89,6 +89,19 @@ public final class RemoteResolver {
     }
 
     /** A resource is exposed to remote clients iff it carries at least one configured exposeLabel (OR). */
+    /** Exposed resources, in declaration order, for the discovery endpoint. */
+    @NonNull
+    public List<LockableResource> exposedResources() {
+        Set<String> exposeLabels = lrm.getExposeLabels();
+        List<LockableResource> exposed = new ArrayList<>();
+        for (LockableResource r : lrm.getResources()) {
+            if (isExposed(r, exposeLabels)) {
+                exposed.add(r);
+            }
+        }
+        return exposed;
+    }
+
     private static boolean isExposed(@NonNull LockableResource r, @NonNull Set<String> exposeLabels) {
         return !exposeLabels.isEmpty() && !Collections.disjoint(r.getLabelsAsList(), exposeLabels);
     }

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.jenkins.plugins.lockableresources.LockStepExecution;
+import org.jenkins.plugins.lockableresources.LockStepResource;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourceProperty;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
@@ -103,6 +104,41 @@ public final class RemoteResolver {
             }
         }
         return false;
+    }
+
+    /**
+     * Runs the canonical {@code lock()} parameter validation over a remote request, exactly as
+     * {@link LockStep#validate} does for a local step: no target while empty values are disallowed,
+     * {@code resource} and {@code label} together, {@code priority} combined with
+     * {@code inversePrecedence}, and an unknown {@code resourceSelectStrategy}. Each {@code extra}
+     * entry is validated as well.
+     *
+     * <p>Keeping this on the canonical validator is what makes the bridge transparent: the rules stay
+     * in one place, and a request the local DSL would reject is rejected here with the same message.
+     *
+     * @throws IllegalArgumentException if the request is not a valid {@code lock()} request; the caller
+     *     maps it to HTTP 400.
+     */
+    @Restricted(NoExternalUse.class)
+    public static void validateAsLocalStep(@NonNull RemoteLockRequest req, boolean allowEmptyOrNullValues) {
+        List<LockStepResource> extra = new ArrayList<>();
+        List<RemoteLockRequest.ExtraResource> requested = req.getExtra();
+        if (requested != null) {
+            for (RemoteLockRequest.ExtraResource e : requested) {
+                LockStepResource resource = new LockStepResource(e.getResource());
+                resource.setLabel(e.getLabel());
+                resource.setQuantity(e.getQuantity());
+                extra.add(resource);
+            }
+        }
+        LockStepResource.validate(
+                req.getResource(),
+                req.getLabel(),
+                req.getResourceSelectStrategy(),
+                extra,
+                req.getPriority(),
+                req.isInversePrecedence(),
+                allowEmptyOrNullValues);
     }
 
     /**

--- a/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/remote/RemoteResolver.java
@@ -121,8 +121,9 @@ public final class RemoteResolver {
 
     /**
      * Runs the canonical {@code lock()} parameter validation over a remote request, exactly as
-     * {@link LockStep#validate} does for a local step: no target while empty values are disallowed,
-     * {@code resource} and {@code label} together, {@code priority} combined with
+     * {@link org.jenkins.plugins.lockableresources.LockStep#validate} does for a local step: no
+     * target while empty values are disallowed, {@code resource} and {@code label} together,
+     * {@code priority} combined with
      * {@code inversePrecedence}, and an unknown {@code resourceSelectStrategy}. Each {@code extra}
      * entry is validated as well.
      *

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.jelly
@@ -36,6 +36,9 @@
       <f:entry field="exposeLabel" title="${%remote.server.exposeLabel.title}" help="/descriptor/org.jenkins.plugins.lockableresources.LockableResourcesManager/help/exposeLabel">
         <f:textbox value="${instance.exposeLabel}" clazz="setting-input"/>
       </f:entry>
+      <f:entry field="acceptNewAcquires" title="${%remote.server.acceptNewAcquires.title}" help="/descriptor/org.jenkins.plugins.lockableresources.LockableResourcesManager/help/acceptNewAcquires">
+        <f:checkbox default="true"/>
+      </f:entry>
     </f:section>
 
     <f:section title="${%remote.client.section.title}">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/config.properties
@@ -32,6 +32,7 @@ field.add=Add Lockable Resource
 remote.server.section.title=Remote Lockable Resources (Server)
 remote.server.remoteApiEnabled.title=Enable remote API
 remote.server.exposeLabel.title=Expose label(s) (space-separated)
+remote.server.acceptNewAcquires.title=Accept new acquire requests
 remote.client.section.title=Remote Lockable Resources (Client)
 remote.clientId.title=Client ID (optional)
 remote.forcedServerId.title=Forced server ID (delegated mode, optional)

--- a/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/help-acceptNewAcquires.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/LockableResourcesManager/help-acceptNewAcquires.html
@@ -1,0 +1,17 @@
+<div>
+  <p>
+    Maintenance switch for the remote lock API. Leave it on for normal operation.
+  </p>
+  <p>
+    While it is off, this controller answers <code>POST /lockable-resources/remote/v1/acquire</code>
+    with <code>503</code> and the error code <code>ACQUIRES_PAUSED</code>, so no new remote lock is
+    handed out. Everything else keeps working: leases already held can send heartbeats and release
+    normally, status can still be polled, and requests already waiting in the queue keep their place
+    and are still promoted as resources free up.
+  </p>
+  <p>
+    Client controllers do not fail their builds when they see this. They keep retrying until their
+    own allocation timeout expires, so you can drain this controller for maintenance without
+    disturbing the pipelines waiting on it.
+  </p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/Messages.properties
@@ -85,6 +85,8 @@ RequiredResourcesProperty.displayName=Required Lockable Resources
 # warnings (build-parameter references)
 warning.forcedServerIdNotConfigured=forcedServerId ''{0}'' does not match any configured remote connection. \
   Delegated mode will fail until a remote with this serverId is added.
+warning.forcedServerIdDisabled=forcedServerId ''{0}'' refers to a remote connection that is currently disabled. \
+  Every lock() on this controller would fail until it is enabled again.
 warning.resourceNameContainsVariable=Resource name contains build parameter references. \
   Validation will occur at build time.
 warning.labelContainsVariable=Label contains build parameter references. \

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/config.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/config.jelly
@@ -6,6 +6,9 @@
   <f:entry field="url" title="${%remote.connection.url.title}" help="/descriptorByName/org.jenkins.plugins.lockableresources.RemoteConnection/help/url">
     <f:textbox checkMethod="post"/>
   </f:entry>
+  <f:entry field="enabled" title="${%remote.connection.enabled.title}" help="/descriptorByName/org.jenkins.plugins.lockableresources.RemoteConnection/help/enabled">
+    <f:checkbox default="true"/>
+  </f:entry>
   <f:entry field="credentialsId" title="${%remote.connection.credentialsId.title}" help="/descriptorByName/org.jenkins.plugins.lockableresources.RemoteConnection/help/credentialsId">
     <f:select/>
   </f:entry>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/config.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/config.properties
@@ -1,3 +1,4 @@
 remote.connection.serverId.title=Server ID
 remote.connection.url.title=Remote Jenkins URL
 remote.connection.credentialsId.title=Credentials ID (optional)
+remote.connection.enabled.title=Enabled

--- a/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/help-enabled.html
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/RemoteConnection/help-enabled.html
@@ -1,0 +1,19 @@
+<div>
+  <p>
+    Whether this controller may use this connection. Leave it on for normal operation.
+  </p>
+  <p>
+    Turning it off keeps the entry - its URL and its credentials binding - but stops this controller
+    from requesting new locks through it. A <code>lock(..., serverId: '...')</code> naming a disabled
+    connection fails the step rather than falling back to a local resource of the same name: locking
+    something other than what was asked for is worse than failing.
+  </p>
+  <p>
+    Locks already held are not affected. Heartbeats and releases continue, so nothing is stranded on
+    the other side; only new requests are refused.
+  </p>
+  <p>
+    This is the client-side counterpart of the server-side "Accept new acquire requests" switch: that
+    one stops lending resources out, this one stops asking for them.
+  </p>
+</div>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
@@ -133,6 +133,15 @@
                   data-edit-resource-on-fail="${%edit.resource.on.fail}"
       />
 
+      <j:if test="${it.remoteAcquiresPaused}">
+        <div class="lr-paused-banner jenkins-!-margin-bottom-2">
+          <l:icon src="symbol-pause-circle-outline plugin-ionicons-api" />
+          <span>
+            <strong>${%paused.banner.title}</strong>
+            ${%paused.banner.detail}
+          </span>
+        </div>
+      </j:if>
       <j:if test="${it.delegatedMode}">
         <div class="lr-delegated-badge jenkins-!-margin-bottom-2">
           <l:icon src="symbol-git-network-outline plugin-ionicons-api" />

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
@@ -133,6 +133,17 @@
                   data-edit-resource-on-fail="${%edit.resource.on.fail}"
       />
 
+      <j:if test="${it.delegatedMode}">
+        <div class="lr-delegated-badge jenkins-!-margin-bottom-2">
+          <l:icon src="symbol-git-network-outline plugin-ionicons-api" />
+          <span>
+            <strong>${%delegated.badge.title}</strong>
+            ${%delegated.badge.routedTo(it.forcedServerId, it.forcedServerUrl)}
+            <br/>
+            <span class="jenkins-!-color-secondary">${%delegated.badge.localNote}</span>
+          </span>
+        </div>
+      </j:if>
       <j:choose>
         <j:when test="${it.resources.size() == 0 and !it.remoteConfigured}">
           <l:notice title="${%resources.not_configured}" icon="symbol-lock-closed">

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.jelly
@@ -17,16 +17,20 @@
       <link rel="stylesheet" href="${resURL}/plugin/lockable-resources/css/style.css"/>
       <div id="lr-page-data" data-current-user="${it.userName}" style="display:none;"></div>
       <l:app-bar title="${%header.resources}">
-        <j:if test="${it.resources.size() > 0}">
+        <j:if test="${it.resources.size() > 0 or it.remoteConfigured}">
           <div class="app-build-tabs lr-tab-bar" role="tablist">
-            <a class="jenkins-button lr-tab-button lr-tab-button--active"
-              role="tab" aria-selected="true" data-lr-tab="overview">${%tab.overview}</a>
+            <a class="jenkins-button lr-tab-button ${it.resources.size() > 0 ? 'lr-tab-button--active' : ''}"
+              role="tab" aria-selected="${it.resources.size() > 0}" data-lr-tab="overview">${%tab.overview}</a>
             <a class="jenkins-button jenkins-button--tertiary lr-tab-button"
               role="tab" aria-selected="false" data-lr-tab="resources">${%tab.resources}</a>
             <a class="jenkins-button jenkins-button--tertiary lr-tab-button"
               role="tab" aria-selected="false" data-lr-tab="labels">${%tab.labels}</a>
             <a class="jenkins-button jenkins-button--tertiary lr-tab-button"
               role="tab" aria-selected="false" data-lr-tab="queue">${%tab.queue}</a>
+            <j:if test="${it.remoteConfigured}">
+              <a class="jenkins-button jenkins-button--tertiary lr-tab-button ${it.resources.size() == 0 ? 'lr-tab-button--active' : ''}"
+                role="tab" aria-selected="${it.resources.size() == 0}" data-lr-tab="remote">${%tab.remote}</a>
+            </j:if>
           </div>
         </j:if>
         <l:hasPermission permission="${it.CONFIGURE}">
@@ -130,7 +134,7 @@
       />
 
       <j:choose>
-        <j:when test="${it.resources.size() == 0}">
+        <j:when test="${it.resources.size() == 0 and !it.remoteConfigured}">
           <l:notice title="${%resources.not_configured}" icon="symbol-lock-closed">
             <l:hasPermission permission="${it.CONFIGURE}">
               <p>${%resources.empty.hint}</p>
@@ -140,7 +144,7 @@
         <j:otherwise>
         <div class="lr-tabs">
           <!-- Tab panes -->
-          <div class="lr-tab-pane lr-tab-pane--active" id="lr-tab-overview" role="tabpanel">
+          <div class="lr-tab-pane ${it.resources.size() > 0 ? 'lr-tab-pane--active' : ''}" id="lr-tab-overview" role="tabpanel">
             <j:set var="summary" value="${it.summary}" />
             <div class="lr-overview-grid">
               <!-- Quick Actions card (top, full width) -->
@@ -373,6 +377,11 @@
             </div>
             <st:include page="tableQueue/table"/>
           </div>
+          <j:if test="${it.remoteConfigured}">
+            <div class="lr-tab-pane ${it.resources.size() == 0 ? 'lr-tab-pane--active' : ''}" id="lr-tab-remote" role="tabpanel">
+              <st:include page="tableRemote/table"/>
+            </div>
+          </j:if>
         </div>
         </j:otherwise>
       </j:choose>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
@@ -120,3 +120,6 @@ filter.search=Search...
 filter.queue.type=Type
 filter.queue.request=Resource(s)
 filter.queue.requestedBy=Requested By
+delegated.badge.title=Delegated mode.
+delegated.badge.routedTo=Every lock() on this controller is routed to serverId "{0}" ({1}).
+delegated.badge.localNote=The resources below are still defined here and remain lockable by other controllers; they are just not used to resolve this controller''s own lock() calls.

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
@@ -26,6 +26,7 @@ header.resources=Lockable Resources
 tab.overview=Overview
 tab.resources=Resources
 tab.labels=Labels
+tab.remote=Remote
 tab.queue=Queue
 
 # overview

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/_content.properties
@@ -123,3 +123,5 @@ filter.queue.requestedBy=Requested By
 delegated.badge.title=Delegated mode.
 delegated.badge.routedTo=Every lock() on this controller is routed to serverId "{0}" ({1}).
 delegated.badge.localNote=The resources below are still defined here and remain lockable by other controllers; they are just not used to resolve this controller''s own lock() calls.
+paused.banner.title=New remote acquire requests are paused.
+paused.banner.detail=Client controllers are waiting rather than failing, and locks already held here keep working. Turn "Accept new acquire requests" back on in Manage Jenkins > System when maintenance is over.

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.jelly
@@ -1,0 +1,74 @@
+<?jelly escape-by-default='true'?>
+<!--
+  The MIT License
+
+  See the "LICENSE.txt" file for full copyright and license information.
+-->
+<j:jelly
+  xmlns:j="jelly:core"
+  xmlns:l="/lib/layout"
+  xmlns:st="jelly:stapler">
+
+  <j:set var="remoteLocks" value="${it.remoteLocks}" />
+
+  <div class="lr-remote-note jenkins-!-margin-bottom-2">
+    <l:icon src="symbol-information-circle-outline plugin-ionicons-api" />
+    <span>${%remote.cachedViewNote}</span>
+  </div>
+
+  <j:choose>
+    <j:when test="${remoteLocks.size() == 0}">
+      <p class="jenkins-!-color-secondary">${%remote.none}</p>
+    </j:when>
+    <j:otherwise>
+      <div class="table-responsive">
+        <table class="jenkins-table sortable" id="lockable-resources-remote">
+          <thead>
+            <tr>
+              <th>${%remote.table.column.server}</th>
+              <th>${%remote.table.column.request}</th>
+              <th>${%remote.table.column.status}</th>
+              <th>${%remote.table.column.resources}</th>
+              <th>${%remote.table.column.requestedBy}</th>
+              <th>${%remote.table.column.since}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <j:forEach var="entry" items="${remoteLocks}">
+              <tr>
+                <td>
+                  <strong>${entry.serverId}</strong>
+                  <j:if test="${it.isServerDisabled(entry.serverId)}">
+                    <br/><span class="jenkins-!-color-secondary">${%remote.server.disabled}</span>
+                  </j:if>
+                </td>
+                <td>${entry.request}</td>
+                <td class="jenkins-!-${entry.acquired ? 'warning' : 'success'}-color">
+                  <j:choose>
+                    <j:when test="${entry.acquired}"><strong>${%remote.status.acquired}</strong></j:when>
+                    <j:otherwise><strong>${%remote.status.queued}</strong></j:otherwise>
+                  </j:choose>
+                </td>
+                <td>
+                  <j:forEach var="name" items="${entry.resourceNames}" varStatus="loop">
+                    <j:if test="${!loop.first}">, </j:if>${name}
+                  </j:forEach>
+                </td>
+                <td>
+                  <j:choose>
+                    <j:when test="${entry.buildUrl != ''}">
+                      <a href="${rootURL}/${entry.buildUrl}">${entry.buildName}</a>
+                    </j:when>
+                    <j:when test="${entry.buildName != ''}">${entry.buildName}</j:when>
+                    <j:otherwise><span class="jenkins-!-color-secondary">${%remote.requestedBy.unknown}</span></j:otherwise>
+                  </j:choose>
+                </td>
+                <td>${it.getElapsedSince(entry.since)}</td>
+              </tr>
+            </j:forEach>
+          </tbody>
+        </table>
+      </div>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.jelly
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.jelly
@@ -10,6 +10,64 @@
   xmlns:st="jelly:stapler">
 
   <j:set var="remoteLocks" value="${it.remoteLocks}" />
+  <j:set var="catalog" value="${it.delegatedCatalog}" />
+
+  <j:if test="${it.delegatedMode}">
+    <h2 class="jenkins-!-margin-top-2">${%remote.catalog.heading(it.forcedServerId)}</h2>
+    <j:choose>
+      <j:when test="${catalog == null}">
+        <p class="jenkins-!-color-secondary">${%remote.catalog.notFetched}</p>
+      </j:when>
+      <j:otherwise>
+        <p class="jenkins-!-color-secondary">
+          ${%remote.catalog.age(it.getElapsedSince(catalog.fetchedAt))}
+          <j:if test="${catalog.error != null}"> &#8212; ${%remote.catalog.stale(catalog.error)}</j:if>
+          <j:if test="${!catalog.acceptNewAcquires}"> &#8212; <strong>${%remote.catalog.paused}</strong></j:if>
+        </p>
+        <div class="table-responsive">
+          <table class="jenkins-table sortable" id="lockable-resources-remote-catalog">
+            <thead>
+              <tr>
+                <th>${%remote.catalog.column.resource}</th>
+                <th>${%remote.catalog.column.status}</th>
+                <th>${%remote.catalog.column.heldBy}</th>
+                <th>${%remote.catalog.column.labels}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <j:forEach var="r" items="${catalog.resources}">
+                <tr>
+                  <td>
+                    <strong>${r.name}</strong>
+                    <j:if test="${r.description != ''}">
+                      <div class="jenkins-!-color-secondary">${r.description}</div>
+                    </j:if>
+                  </td>
+                  <td>${r.state}</td>
+                  <td>
+                    <j:choose>
+                      <j:when test="${r.heldByClientId != ''}">${%remote.catalog.heldBy.client(r.heldByClientId)}</j:when>
+                      <j:when test="${r.heldByKind == 'LOCAL_BUILD'}">${%remote.catalog.heldBy.localBuild}</j:when>
+                      <j:when test="${r.heldByKind == 'ADMIN'}">${%remote.catalog.heldBy.admin}</j:when>
+                      <j:otherwise/>
+                    </j:choose>
+                    <j:if test="${r.since > 0}">
+                      <span class="jenkins-!-color-secondary">&#160;(${it.getElapsedSince(r.since)})</span>
+                    </j:if>
+                  </td>
+                  <td>
+                    <j:forEach var="l" items="${r.labels}" varStatus="loop"><j:if test="${!loop.first}">, </j:if>${l}</j:forEach>
+                  </td>
+                </tr>
+              </j:forEach>
+            </tbody>
+          </table>
+        </div>
+      </j:otherwise>
+    </j:choose>
+
+    <h2 class="jenkins-!-margin-top-2">${%remote.heading.ownLocks}</h2>
+  </j:if>
 
   <div class="lr-remote-note jenkins-!-margin-bottom-2">
     <l:icon src="symbol-information-circle-outline plugin-ionicons-api" />

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.properties
@@ -1,0 +1,18 @@
+# The MIT License
+#
+# See the "LICENSE.txt" file for full copyright and license information.
+
+remote.cachedViewNote=This is what this controller last observed. The remote server is the source of truth for its own resources.
+remote.none=This controller does not hold or wait for any remote lock right now.
+
+remote.table.column.server=Server
+remote.table.column.request=Request
+remote.table.column.status=Status
+remote.table.column.resources=Resources
+remote.table.column.requestedBy=Requested By
+remote.table.column.since=Since
+
+remote.status.acquired=ACQUIRED
+remote.status.queued=QUEUED
+remote.requestedBy.unknown=(build unavailable)
+remote.server.disabled=(disabled - no new locks are requested here)

--- a/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.properties
+++ b/src/main/resources/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootAction/tableRemote/table.properties
@@ -16,3 +16,17 @@ remote.status.acquired=ACQUIRED
 remote.status.queued=QUEUED
 remote.requestedBy.unknown=(build unavailable)
 remote.server.disabled=(disabled - no new locks are requested here)
+
+remote.catalog.heading=Resources published by "{0}"
+remote.catalog.notFetched=Not fetched yet. Reload in a moment.
+remote.catalog.age=As this controller saw it {0} ago.
+remote.catalog.stale=refresh failed ({0}), showing the last successful fetch
+remote.catalog.paused=This server is not accepting new acquire requests right now.
+remote.catalog.column.resource=Resource
+remote.catalog.column.status=Status
+remote.catalog.column.heldBy=Held By
+remote.catalog.column.labels=Labels
+remote.catalog.heldBy.client=remote client: {0}
+remote.catalog.heldBy.localBuild=a build on that server
+remote.catalog.heldBy.admin=reserved by an administrator
+remote.heading.ownLocks=Locks this controller holds or waits for

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -764,6 +764,24 @@ span.lr-static-label {
   color: var(--primary);
 }
 
+/* Maintenance — this server is not accepting new remote acquires */
+.lr-paused-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--orange);
+  border-radius: var(--form-input-border-radius, 6px);
+  background: var(--card-background);
+}
+
+.lr-paused-banner svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--orange);
+}
+
 @media (max-width: 768px) {
   .lr-tab-bar {
     position: static;

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -746,6 +746,24 @@ span.lr-static-label {
   flex-shrink: 0;
 }
 
+/* Delegated mode — where this controller's lock() calls actually go */
+.lr-delegated-badge {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--jenkins-border--subtle);
+  border-radius: var(--form-input-border-radius, 6px);
+  background: var(--card-background);
+}
+
+.lr-delegated-badge svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
 @media (max-width: 768px) {
   .lr-tab-bar {
     position: static;

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -730,6 +730,22 @@ span.lr-static-label {
 /* ====================================================================
    Responsive — mobile & narrow viewports
    ==================================================================== */
+/* Remote tab — the note that this table is a client-side view, not the server's own state.
+   Jenkins symbols carry an intrinsic 512px size, so an unsized container renders them full width. */
+.lr-remote-note {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-color-secondary);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.lr-remote-note svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 @media (max-width: 768px) {
   .lr-tab-bar {
     position: static;

--- a/src/main/webapp/js/lockable-resources.js
+++ b/src/main/webapp/js/lockable-resources.js
@@ -1428,7 +1428,9 @@ function initColumnVisibility(config) {
 
     // Action
     html += "<td>";
-    if (hasQueuePermission) {
+    // Reordering works on the local queue only: changeQueueOrder looks the id up among the queued
+    // contexts, so offering the button on a remote row can only ever fail.
+    if (hasQueuePermission && item.type !== "remote") {
       html += "<button data-queue-item-id=\"" + escapeHtml(item.id) + "\" class=\"jenkins-button jenkins-button--tertiary jenkins-!-success-color lockable-resources-change-queue-order\" title=\"Change Position\" tooltip=\"Change Position\" aria-label=\"Change Position\">" + queueOrderIconHtml + "</button>";
     }
     html += "</td>";

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.lockableresources;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -112,6 +113,7 @@ class ConfigurationAsCodeTest {
         LockableResourcesManager LRM = LockableResourcesManager.get();
         assertTrue(LRM.isRemoteApiEnabled());
         assertEquals("remote-enabled", LRM.getExposeLabel());
+        assertFalse(LRM.isAcceptNewAcquires());
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ConfigurationAsCodeTest.java
@@ -125,6 +125,8 @@ class ConfigurationAsCodeTest {
         List<RemoteConnection> remotes = LRM.getRemotes();
         assertEquals(2, remotes.size());
         assertEquals("server-a", remotes.get(0).getServerId());
+        assertTrue(remotes.get(0).isEnabled(), "omitting enabled keeps the connection usable");
+        assertFalse(remotes.get(1).isEnabled(), "enabled: false round-trips");
         assertEquals("http://jenkins-server-a:8080/jenkins", remotes.get(0).getUrl());
         assertEquals("server-a-token", remotes.get(0).getCredentialsId());
         assertEquals("server-b", remotes.get(1).getServerId());

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
@@ -145,6 +145,38 @@ class LockStepRemoteTest extends LockStepTestBase {
     }
 
     @Test
+    void acquireWaitsWhileTheRemoteIsPausedForMaintenance(JenkinsRule j) throws Exception {
+        // 503 means "come back later", not "give up": failing the build here would defeat the purpose of
+        // the server-side maintenance switch.
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.pauseNextAcquires(2);
+        remote.start();
+        try {
+            LockableResourcesManager manager = LockableResourcesManager.get();
+            manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+
+            WorkflowJob job = j.createProject(WorkflowJob.class, "remote-lock-paused");
+            job.setDefinition(new CpsFlowDefinition("""
+                    lock(resource: 'paused-resource', serverId: 'server-a') {
+                        semaphore 'paused-body'
+                    }
+                    """, true));
+
+            WorkflowRun run = job.scheduleBuild2(0).waitForStart();
+            j.waitForMessage("not accepting new acquire requests right now", run);
+
+            // The retries eventually get through and the body runs.
+            SemaphoreStep.waitForStart("paused-body/1", run);
+            assertTrue(remote.acquireRequests.get() >= 3, "expected retries, saw " + remote.acquireRequests.get());
+
+            SemaphoreStep.success("paused-body/1", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(run));
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
     void lockWithoutServerIdKeepsUsingLocalFlow(JenkinsRule j) throws Exception {
         RemoteServerFixture remote = new RemoteServerFixture();
         remote.start();
@@ -497,6 +529,7 @@ class LockStepRemoteTest extends LockStepTestBase {
         private final AtomicReference<String> lastAcquireBody = new AtomicReference<>();
         private final AtomicReference<String> lastAcquireRawBody = new AtomicReference<>();
         private final AtomicReference<String> lastAuthorizationHeader = new AtomicReference<>();
+        private final AtomicInteger pausedAcquires = new AtomicInteger();
         private int acquireResponseStatus = 202;
         private String acquireResponseBody = "{\"lockId\":\"lock-1\"}";
         private String acquireStatusResponse = "{\"lockId\":\"lock-1\",\"state\":\"ACQUIRED\"}";
@@ -505,6 +538,11 @@ class LockStepRemoteTest extends LockStepTestBase {
         private void setAcquireResponse(int status, String body) {
             this.acquireResponseStatus = status;
             this.acquireResponseBody = body;
+        }
+
+        /** Answers the next {@code n} acquire calls with the maintenance switch's 503. */
+        private void pauseNextAcquires(int n) {
+            pausedAcquires.set(n);
         }
 
         private void setAcquireStatusResponse(String acquireStatusResponse) {
@@ -537,6 +575,13 @@ class LockStepRemoteTest extends LockStepTestBase {
             public void handle(HttpExchange exchange) throws IOException {
                 acquireRequests.incrementAndGet();
                 lastAuthorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                if (pausedAcquires.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+                    sendJson(
+                            exchange,
+                            503,
+                            "{\"errorCode\":\"ACQUIRES_PAUSED\",\"message\":\"not accepting new acquires\"}");
+                    return;
+                }
                 String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
                 lastAcquireRawBody.set(body);
                 String resource = extractResource(body);

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
@@ -7,17 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import org.jenkins.plugins.lockableresources.remote.RemoteServerFixture;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -520,138 +513,6 @@ class LockStepRemoteTest extends LockStepTestBase {
                 .add(new UsernamePasswordCredentialsImpl(
                         CredentialsScope.GLOBAL, credentialsId, "remote lock test credential", username, password));
         SystemCredentialsProvider.getInstance().save();
-    }
-
-    private static final class RemoteServerFixture {
-        private final AtomicInteger acquireRequests = new AtomicInteger();
-        private final AtomicInteger statusRequests = new AtomicInteger();
-        private final AtomicInteger releaseRequests = new AtomicInteger();
-        private final AtomicReference<String> lastAcquireBody = new AtomicReference<>();
-        private final AtomicReference<String> lastAcquireRawBody = new AtomicReference<>();
-        private final AtomicReference<String> lastAuthorizationHeader = new AtomicReference<>();
-        private final AtomicInteger pausedAcquires = new AtomicInteger();
-        private int acquireResponseStatus = 202;
-        private String acquireResponseBody = "{\"lockId\":\"lock-1\"}";
-        private String acquireStatusResponse = "{\"lockId\":\"lock-1\",\"state\":\"ACQUIRED\"}";
-        private HttpServer server;
-
-        private void setAcquireResponse(int status, String body) {
-            this.acquireResponseStatus = status;
-            this.acquireResponseBody = body;
-        }
-
-        /** Answers the next {@code n} acquire calls with the maintenance switch's 503. */
-        private void pauseNextAcquires(int n) {
-            pausedAcquires.set(n);
-        }
-
-        private void setAcquireStatusResponse(String acquireStatusResponse) {
-            this.acquireStatusResponse = acquireStatusResponse;
-        }
-
-        private void start() throws IOException {
-            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-            server.createContext("/lockable-resources/remote/v1/acquire", new AcquireHandler());
-            server.createContext("/lockable-resources/remote/v1/acquire/lock-1", new AcquireStatusHandler());
-            server.createContext(
-                    "/lockable-resources/remote/v1/lease/lock-1/release", new NoContentHandler(releaseRequests));
-            server.createContext(
-                    "/lockable-resources/remote/v1/lease/lock-1/heartbeat", new NoContentHandler(new AtomicInteger()));
-            server.start();
-        }
-
-        private void stop() {
-            if (server != null) {
-                server.stop(0);
-            }
-        }
-
-        private String baseUrl() {
-            return "http://127.0.0.1:" + server.getAddress().getPort();
-        }
-
-        private final class AcquireHandler implements HttpHandler {
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                acquireRequests.incrementAndGet();
-                lastAuthorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
-                if (pausedAcquires.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
-                    sendJson(
-                            exchange,
-                            503,
-                            "{\"errorCode\":\"ACQUIRES_PAUSED\",\"message\":\"not accepting new acquires\"}");
-                    return;
-                }
-                String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
-                lastAcquireRawBody.set(body);
-                String resource = extractResource(body);
-                lastAcquireBody.set(resource);
-                // Auto-generate lockEnvVars in status response when variable is specified
-                String variable = extractVariable(body);
-                if (variable != null && resource != null && acquireStatusResponse.contains("\"state\":\"ACQUIRED\"")) {
-                    acquireStatusResponse = "{\"lockId\":\"lock-1\",\"state\":\"ACQUIRED\","
-                            + "\"lockEnvVars\":{"
-                            + "\"" + variable + "\":\"" + resource + "\","
-                            + "\"" + variable + "0\":\"" + resource + "\""
-                            + "}}";
-                }
-                sendJson(exchange, acquireResponseStatus, acquireResponseBody);
-            }
-        }
-
-        private final class AcquireStatusHandler implements HttpHandler {
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                statusRequests.incrementAndGet();
-                sendJson(exchange, 200, acquireStatusResponse);
-            }
-        }
-
-        private static final class NoContentHandler implements HttpHandler {
-            private final AtomicInteger counter;
-
-            private NoContentHandler(AtomicInteger counter) {
-                this.counter = counter;
-            }
-
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                counter.incrementAndGet();
-                exchange.sendResponseHeaders(204, -1);
-                exchange.close();
-            }
-        }
-
-        private static String extractResource(String json) {
-            String marker = "\"resource\":\"";
-            int start = json.indexOf(marker);
-            if (start < 0) {
-                return null;
-            }
-            int valueStart = start + marker.length();
-            int valueEnd = json.indexOf('"', valueStart);
-            return valueEnd >= 0 ? json.substring(valueStart, valueEnd) : null;
-        }
-
-        private static String extractVariable(String json) {
-            String marker = "\"variable\":\"";
-            int start = json.indexOf(marker);
-            if (start < 0) {
-                return null;
-            }
-            int valueStart = start + marker.length();
-            int valueEnd = json.indexOf('"', valueStart);
-            return valueEnd >= 0 ? json.substring(valueStart, valueEnd) : null;
-        }
-
-        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
-            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().add("Content-Type", "application/json");
-            exchange.sendResponseHeaders(status, bytes.length);
-            try (OutputStream outputStream = exchange.getResponseBody()) {
-                outputStream.write(bytes);
-            }
-        }
     }
 
     private static int findUnusedPort() throws IOException {

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepRemoteTest.java
@@ -114,6 +114,37 @@ class LockStepRemoteTest extends LockStepTestBase {
     }
 
     @Test
+    void remoteMetadataEnvVarsAreSetEvenWithoutLockEnvVars(JenkinsRule j) throws Exception {
+        // The bridge metadata used to be gated on a non-empty lockEnvVars, so a server that returned
+        // none (nothing to name, or an older server) left X_SERVER_ID / X_LOCK_ID unset.
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.setAcquireStatusResponse("{\"lockId\":\"lock-1\",\"state\":\"ACQUIRED\"}");
+        remote.start();
+        try {
+            LockableResourcesManager manager = LockableResourcesManager.get();
+            manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+
+            WorkflowJob job = j.createProject(WorkflowJob.class, "remote-lock-no-envvars");
+            job.setDefinition(new CpsFlowDefinition("""
+                    lock(resource: 'plc-a', serverId: 'server-a', variable: 'PLC') {
+                        echo "server=${env.PLC_SERVER_ID} lockId=${env.PLC_LOCK_ID}"
+                        semaphore 'no-envvars-body'
+                    }
+                    """, true));
+
+            WorkflowRun run = job.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("no-envvars-body/1", run);
+
+            j.assertLogContains("server=server-a lockId=lock-1", run);
+
+            SemaphoreStep.success("no-envvars-body/1", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(run));
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
     void lockWithoutServerIdKeepsUsingLocalFlow(JenkinsRule j) throws Exception {
         RemoteServerFixture remote = new RemoteServerFixture();
         remote.start();

--- a/src/test/java/org/jenkins/plugins/lockableresources/RemoteConnectionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/RemoteConnectionTest.java
@@ -6,10 +6,15 @@
 package org.jenkins.plugins.lockableresources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import hudson.AbortException;
 import hudson.util.FormValidation;
+import java.util.List;
+import org.jenkins.plugins.lockableresources.remote.RemoteLockRouting;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -130,5 +135,57 @@ class RemoteConnectionTest {
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());
         assertNotEquals(a, c);
+    }
+
+    @Test
+    void enabledDefaultsToTrueAndSurvivesConfigurationWithoutIt() {
+        // Existing configuration - JCasC yaml or config.xml written before this field existed - carries
+        // only the three connection fields, so the default has to come from the field itself.
+        RemoteConnection remote = new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "");
+        assertTrue(remote.isEnabled());
+
+        remote.setEnabled(false);
+        assertFalse(remote.isEnabled());
+    }
+
+    @Test
+    @WithJenkins
+    void disabledConnectionFailsTheStepInsteadOfFallingBackLocally(JenkinsRule j) throws Exception {
+        // Falling back to a local resource of the same name is exactly the accident delegated mode was
+        // made strict to avoid, so a disabled connection has to fail instead.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        RemoteConnection disabled = new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "");
+        disabled.setEnabled(false);
+        manager.setRemotes(List.of(disabled));
+
+        AbortException thrown =
+                assertThrows(AbortException.class, () -> RemoteLockRouting.findConnection(manager, "server-a"));
+        assertTrue(thrown.getMessage().contains("disabled"), thrown.getMessage());
+    }
+
+    @Test
+    @WithJenkins
+    void enabledConnectionResolvesNormally(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemotes(List.of(new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "")));
+
+        assertEquals(
+                "http://jenkins-b:8080/jenkins",
+                RemoteLockRouting.findConnection(manager, "server-a").getUrl());
+    }
+
+    @Test
+    @WithJenkins
+    void forcedServerIdWarnsWhenItsTargetIsDisabled(JenkinsRule j) {
+        // Delegated mode routes every lock() there, so a disabled target fails all of them silently
+        // until someone reads a build log.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        RemoteConnection disabled = new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "");
+        disabled.setEnabled(false);
+        manager.setRemotes(List.of(disabled));
+
+        FormValidation validation = manager.doCheckForcedServerId("server-a");
+        assertEquals(FormValidation.Kind.WARNING, validation.kind);
+        assertTrue(validation.getMessage().contains("disabled"), validation.getMessage());
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/RemoteLockRestartTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/RemoteLockRestartTest.java
@@ -1,0 +1,167 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.jenkins.plugins.lockableresources.remote.RemoteServerFixture;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
+
+/**
+ * What happens to a remote lock when the client controller restarts underneath it.
+ *
+ * <p>A remote lock is held on another controller, which knows nothing about this one going down. The
+ * two sides can therefore disagree in a way a local lock never can: the server goes on holding a
+ * resource for a build that no longer exists. Everything here is about not leaving it that way.
+ *
+ * <p>The fixture lives outside the sessions and is restarted on its own port, because the resumed
+ * controller has to find the remote at the address its configuration already records - a fixture on
+ * a new port would only prove that a client cannot reach a server that moved.
+ */
+class RemoteLockRestartTest extends LockStepTestBase {
+
+    @RegisterExtension
+    private final JenkinsSessionExtension sessions = new JenkinsSessionExtension();
+
+    @Test
+    void aQueuedRequestKeepsWaitingAcrossARestart() throws Throwable {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            // Enough queued polls that the request is still waiting when the controller goes down.
+            remote.queueFor(1000);
+
+            sessions.then(j -> {
+                LockableResourcesManager manager = LockableResourcesManager.get();
+                manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+                manager.setClientId("client-jenkins-a");
+
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "queued-across-restart");
+                p.setDefinition(new CpsFlowDefinition("""
+                        lock(resource: 'remote-resource', serverId: 'server-a') {
+                            echo 'BODY_RAN'
+                        }
+                        echo 'AFTER_LOCK'
+                        """, true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                j.waitForMessage("Trying to acquire", b);
+            });
+
+            remote.restartOnSamePort();
+
+            sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("queued-across-restart", WorkflowJob.class);
+                WorkflowRun b = p.getBuildByNumber(1);
+
+                // Stop queueing, so the next poll hands the resource over. The body running is the
+                // proof that the step resumed polling at all: nothing else would ever ask again, and
+                // the build would sit here until the test timed out.
+                remote.queueFor(0);
+
+                j.waitForCompletion(b);
+                j.assertBuildStatusSuccess(b);
+                j.assertLogContains("BODY_RAN", b);
+                assertEquals(1, remote.releaseRequests.get(), "released once, after the resumed body finished");
+            });
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aHeldLockIsReleasedWhenTheBodyDiesWithTheController() throws Throwable {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            sessions.then(j -> {
+                LockableResourcesManager manager = LockableResourcesManager.get();
+                manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+                manager.setClientId("client-jenkins-a");
+
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "held-across-restart");
+                p.setDefinition(new CpsFlowDefinition("""
+                        lock(resource: 'remote-resource', serverId: 'server-a') {
+                            semaphore 'inside-remote-lock'
+                        }
+                        echo 'AFTER_LOCK'
+                        """, true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("inside-remote-lock/1", b);
+            });
+
+            remote.restartOnSamePort();
+            int releasesBefore = remote.releaseRequests.get();
+
+            sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("held-across-restart", WorkflowJob.class);
+                WorkflowRun b = p.getBuildByNumber(1);
+
+                // The body cannot survive the restart, so the lock it was holding has to go back. If it
+                // did not, the server would hold that resource for a build that no longer exists, and
+                // only an administrator could get it back.
+                j.waitForCompletion(b);
+                j.assertBuildStatus(hudson.model.Result.FAILURE, b);
+                j.assertLogContains("Jenkins restarted during remote lock body execution", b);
+                j.assertLogNotContains("AFTER_LOCK", b);
+                assertTrue(
+                        remote.releaseRequests.get() > releasesBefore,
+                        "the remote lock was released on the way down, not left held");
+            });
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void waitingOnAPausedServerDoesNotSurviveARestart() throws Throwable {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            // The server is in maintenance, so the client is sitting in its retry loop with no lock
+            // anywhere - not on this side, and not on the server's.
+            remote.pauseNextAcquires(1000);
+
+            sessions.then(j -> {
+                LockableResourcesManager manager = LockableResourcesManager.get();
+                manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+                manager.setClientId("client-jenkins-a");
+
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "paused-across-restart");
+                p.setDefinition(new CpsFlowDefinition("""
+                        lock(resource: 'remote-resource', serverId: 'server-a') {
+                            echo 'BODY_RAN'
+                        }
+                        """, true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                j.waitForMessage("not accepting new acquire requests", b);
+            });
+
+            remote.restartOnSamePort();
+
+            sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("paused-across-restart", WorkflowJob.class);
+                WorkflowRun b = p.getBuildByNumber(1);
+
+                // The retry loop did not survive the restart. Failing is the honest outcome: waiting
+                // forever for a retry that will never happen would be worse than saying so.
+                j.waitForCompletion(b);
+                j.assertBuildStatus(hudson.model.Result.FAILURE, b);
+                j.assertLogNotContains("BODY_RAN", b);
+                j.assertLogContains("Jenkins restarted while waiting for the remote server", b);
+            });
+        } finally {
+            remote.stop();
+        }
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/RemoteLockSessionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/RemoteLockSessionTest.java
@@ -1,0 +1,221 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.jenkins.plugins.lockableresources.remote.RemoteServerFixture;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * What the client does with the answers a server gives it over time.
+ *
+ * <p>{@link LockStepRemoteTest} covers the happy path: ask, be told it is yours, run the body. This
+ * covers the rest of the state machine - waiting and then being promoted, being told no, being told
+ * about a lock the server no longer knows, and losing contact with the server for a while.
+ *
+ * <p>Every one of these ends up somewhere a build can see, which is what the assertions look at: the
+ * build result, and whether the body ran. A remote lock that fails has to fail closed, and one that
+ * is skipped has to leave the build running - the difference between the two is the whole point.
+ */
+@WithJenkins
+class RemoteLockSessionTest extends LockStepTestBase {
+
+    private static final String LOCK_BODY = """
+            lock(resource: 'remote-resource', serverId: 'server-a') {
+                echo 'BODY_RAN'
+            }
+            echo 'AFTER_LOCK'
+            """;
+
+    private static RemoteServerFixture startFixture(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemotes(List.of(new RemoteConnection("server-a", remote.baseUrl(), "")));
+        manager.setClientId("client-jenkins-a");
+        return remote;
+    }
+
+    private static WorkflowRun run(JenkinsRule j, String name, String script) throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class, name);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        return job.scheduleBuild2(0).waitForStart();
+    }
+
+    @Test
+    void queuedRequestRunsTheBodyOncePromoted(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // Three polls report QUEUED before the server hands the resource over. The body must not
+            // start until it does - a client that ran on QUEUED would be running unlocked.
+            remote.queueFor(3);
+
+            WorkflowRun run = run(j, "queued-then-acquired", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatusSuccess(run);
+            j.assertLogContains("BODY_RAN", run);
+            assertTrue(remote.statusRequests.get() >= 4, "polled while queued, then once more to be promoted");
+            assertEquals(1, remote.releaseRequests.get(), "released on the way out");
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void terminalFailureFailsTheBuildWithoutRunningTheBody(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // What a server reports when the request waited out its allocate timeout.
+            remote.terminal("FAILED", "LOCK_WAIT_TIMEOUT");
+
+            WorkflowRun run = run(j, "terminal-failed", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatus(hudson.model.Result.FAILURE, run);
+            j.assertLogNotContains("BODY_RAN", run);
+            j.assertLogContains("LOCK_WAIT_TIMEOUT", run);
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void skippedRequestLeavesTheBuildRunning(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // skipIfLocked: the body is skipped, the build carries on. Failing here would turn an
+            // intentional skip into a broken build.
+            remote.terminal("SKIPPED", "ALREADY_LOCKED");
+
+            WorkflowRun run = run(j, "terminal-skipped", """
+                    lock(resource: 'remote-resource', serverId: 'server-a', skipIfLocked: true) {
+                        echo 'BODY_RAN'
+                    }
+                    echo 'AFTER_LOCK'
+                    """);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatusSuccess(run);
+            j.assertLogNotContains("BODY_RAN", run);
+            j.assertLogContains("AFTER_LOCK", run);
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aLockTheServerNoLongerKnowsIsReportedAsMissingNotAsATimeout(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // 404 means the record is genuinely gone - the server restarted, or the record outlived
+            // its TTL. Calling that a timeout would send the reader looking for contention that never
+            // happened, which is the mislabelling A3 was about.
+            remote.failAllPolls(404, "{\"errorCode\":\"LOCK_NOT_FOUND\",\"message\":\"Lock not found\"}");
+
+            WorkflowRun run = run(j, "record-gone", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatus(hudson.model.Result.FAILURE, run);
+            j.assertLogNotContains("BODY_RAN", run);
+            j.assertLogContains("server may have restarted", run);
+            j.assertLogNotContains("LOCK_WAIT_TIMEOUT", run);
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aStaleLeaseIsReportedAsMissingToo(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            remote.failAllPolls(410, "{\"errorCode\":\"LOCK_STALE\",\"message\":\"Lock is STALE\"}");
+
+            WorkflowRun run = run(j, "record-stale", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatus(hudson.model.Result.FAILURE, run);
+            j.assertLogNotContains("BODY_RAN", run);
+            j.assertLogContains("server may have restarted", run);
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aBriefLossOfContactIsRiddenOut(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // A handful of failed polls is a blip, not an answer. The client has to keep asking:
+            // giving up here would fail builds over a server that was busy for ten seconds.
+            remote.failNextPolls(3, 500, "{\"errorCode\":\"BOOM\",\"message\":\"transient\"}");
+
+            WorkflowRun run = run(j, "transient-poll-failure", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatusSuccess(run);
+            j.assertLogContains("BODY_RAN", run);
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aServerThatNeverComesBackEndsTheBuildFailClosed(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // The other side of the previous test: past the client's tolerance, it has to stop. This
+            // is the only threshold at which the client gives up on its own, and it takes about a
+            // minute of real time to reach - the poll interval and the failure count are both fixed.
+            remote.failAllPolls(500, "{\"errorCode\":\"BOOM\",\"message\":\"gone for good\"}");
+
+            WorkflowRun run = run(j, "permanent-poll-failure", LOCK_BODY);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatus(hudson.model.Result.FAILURE, run);
+            j.assertLogNotContains("BODY_RAN", run);
+            assertTrue(
+                    remote.statusRequests.get() >= 20,
+                    "gave up only after the full run of failures, not on the first one: "
+                            + remote.statusRequests.get());
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aFailingHeartbeatDoesNotInterruptTheBody(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = startFixture(j);
+        try {
+            // A heartbeat renews a lease; losing one is not losing the lock. The server holds it until
+            // STALE, so aborting the build here would throw away work the build still owns.
+            remote.setHeartbeatResponse(410, "{\"errorCode\":\"LOCK_STALE\",\"message\":\"Lock is STALE\"}");
+
+            WorkflowRun run = run(j, "heartbeat-failure", """
+                    lock(resource: 'remote-resource', serverId: 'server-a') {
+                        echo 'BODY_RAN'
+                        sleep 12
+                        echo 'BODY_FINISHED'
+                    }
+                    """);
+            j.waitForCompletion(run);
+
+            j.assertBuildStatusSuccess(run);
+            j.assertLogContains("BODY_FINISHED", run);
+            assertTrue(remote.heartbeatRequests.get() >= 1, "the heartbeat was attempted and refused");
+        } finally {
+            remote.stop();
+        }
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/ResourceAuditLogTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/ResourceAuditLogTest.java
@@ -1,0 +1,183 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
+import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * The audit log has to be worth trusting, because an oracle is going to be built on it.
+ *
+ * <p>Reconstructing mutual exclusion from the clients cannot work: a client timestamps its own call
+ * to release, and that call returns after the server has already freed the resource and possibly
+ * handed it to the next waiter. Two clients' logs can therefore appear to overlap on a resource that
+ * was never held twice, and nothing in those logs distinguishes that from a real double-grant.
+ *
+ * <p>These lines are written where the state changes, under the lock that guards it, so their order
+ * is the order the resource really changed hands. What is checked here is exactly that: the release
+ * of one holder is recorded before the acquisition of the next, and each line names who it was.
+ */
+@WithJenkins
+class ResourceAuditLogTest {
+
+    private static final class Capture implements AutoCloseable {
+        private final Logger logger = Logger.getLogger("org.jenkins.plugins.lockableresources.audit");
+        private final List<String> lines = new ArrayList<>();
+        private final Level previous = logger.getLevel();
+        private final Handler handler;
+
+        Capture() {
+            handler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    synchronized (lines) {
+                        lines.add(record.getMessage());
+                    }
+                }
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void close() {}
+            };
+            handler.setLevel(Level.FINE);
+            logger.setLevel(Level.FINE);
+            logger.addHandler(handler);
+        }
+
+        List<String> lines() {
+            synchronized (lines) {
+                return new ArrayList<>(lines);
+            }
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(handler);
+            logger.setLevel(previous);
+        }
+    }
+
+    private static RemoteLockRequest req(String resource) {
+        return new RemoteLockRequest(resource, null, 0, null, false, "SEQUENTIAL", false, null, 0, 0, "MINUTES", null);
+    }
+
+    /** Fields of an LRA line: epochMs, kind, event, resource, holder. */
+    private static String[] parse(String line) {
+        assertTrue(line.startsWith("LRA|"), "unexpected audit line: " + line);
+        String[] parts = line.split("\\|", -1);
+        assertEquals(6, parts.length, "unexpected audit line shape: " + line);
+        return parts;
+    }
+
+    @Test
+    void aHandoverIsRecordedInTheOrderItHappened(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        try (Capture audit = new Capture()) {
+            var first = RemoteLockManager.get().enqueue(req("board-1"), "client-a");
+            var second = RemoteLockManager.get().enqueue(req("board-1"), "client-b");
+            // The second one has to wait: that is what makes this a handover rather than two grants.
+            assertEquals("QUEUED", second.getState().name());
+
+            RemoteLockManager.get().release(first.getLockId());
+            assertEquals("ACQUIRED", second.getState().name());
+            RemoteLockManager.get().release(second.getLockId());
+
+            List<String> board1 = new ArrayList<>();
+            for (String line : audit.lines()) {
+                String[] f = parse(line);
+                if ("board-1".equals(f[4])) {
+                    board1.add(f[3] + " " + f[5]); // event + holder
+                }
+            }
+
+            // Four transitions, in this order, each naming the holder it belonged to. The release of
+            // the first appears before the acquisition of the second - which is the fact a client-side
+            // reconstruction cannot establish.
+            assertEquals(
+                    List.of(
+                            "ACQUIRED " + first.getLockId(),
+                            "RELEASED " + first.getLockId(),
+                            "ACQUIRED " + second.getLockId(),
+                            "RELEASED " + second.getLockId()),
+                    board1);
+        }
+    }
+
+    @Test
+    void everyLineCarriesWhoHeldItAndHow(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        try (Capture audit = new Capture()) {
+            var record = RemoteLockManager.get().enqueue(req("board-1"), "client-a");
+            RemoteLockManager.get().release(record.getLockId());
+
+            List<String> lines = audit.lines();
+            assertTrue(lines.size() >= 2, "an acquire and a release were recorded: " + lines);
+            for (String line : lines) {
+                String[] f = parse(line);
+                assertTrue(Long.parseLong(f[1]) > 0, "a timestamp to order by");
+                assertEquals("REMOTE", f[2], "a remote hold says so, to keep it apart from a local one");
+                assertTrue("ACQUIRED".equals(f[3]) || "RELEASED".equals(f[3]), "the transition itself: " + f[3]);
+                assertEquals(record.getLockId(), f[5], "the holder, so client and server can be joined up");
+            }
+        }
+    }
+
+    @Test
+    void nothingIsWrittenWhenTheLoggerIsOff(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        Logger logger = Logger.getLogger("org.jenkins.plugins.lockableresources.audit");
+        Level previous = logger.getLevel();
+        List<String> lines = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                lines.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.setLevel(Level.INFO); // the default: auditing is opt-in
+        logger.addHandler(handler);
+        try {
+            var record = RemoteLockManager.get().enqueue(req("board-1"), "client-a");
+            RemoteLockManager.get().release(record.getLockId());
+            assertTrue(lines.isEmpty(), "ordinary use does not pay for the audit trail");
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previous);
+        }
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -21,6 +21,8 @@ import org.htmlunit.html.HtmlPage;
 import org.jenkins.plugins.lockableresources.LockStepTestBase;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+import org.jenkins.plugins.lockableresources.RemoteConnection;
+import org.jenkins.plugins.lockableresources.remote.RemoteClientRegistry;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockManager;
 import org.jenkins.plugins.lockableresources.remote.RemoteLockRequest;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -543,6 +545,43 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
     private static RemoteLockRequest remoteRequest(String resource, int priority) {
         return new RemoteLockRequest(
                 resource, null, 0, null, false, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
+    void testRemoteTabShowsWhatThisControllerHoldsRemotely() throws Exception {
+        // The client side of the page: these resources belong to another controller, so they cannot
+        // appear in the Resources tab, and until now they appeared nowhere at all.
+        LockableResourcesManager.get()
+                .setRemotes(java.util.List.of(new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "")));
+        RemoteClientRegistry.get().queued("lock-1", "server-a", "plc-01", null);
+        RemoteClientRegistry.get().acquired("lock-1", java.util.List.of("plc-01"));
+        RemoteClientRegistry.get().queued("lock-2", "server-a", "label:plc", null);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(this.ADMIN);
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+        String page = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+
+        assertTrue(page.contains("data-lr-tab=\"remote\""), "the Remote tab is offered");
+        assertTrue(page.contains("plc-01"), "a held remote lock is listed");
+        assertTrue(page.contains("label:plc"), "a waiting remote request is listed");
+        assertTrue(page.contains("source of truth"), "the view says it is a cached view");
+
+        RemoteClientRegistry.get().forget("lock-1");
+        RemoteClientRegistry.get().forget("lock-2");
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
+    void testRemoteTabIsHiddenWhenNoRemoteRelationIsConfigured() throws Exception {
+        // Nothing remote configured: the tab would only be an empty promise.
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(this.ADMIN);
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+        String page = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+
+        assertFalse(page.contains("data-lr-tab=\"remote\""));
     }
 
     // ---------------------------------------------------------------------------

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -486,6 +486,67 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
 
     // ---------------------------------------------------------------------------
     @Test
+    void testQueueMergesRemoteEntriesByPriority() throws Exception {
+        // The queue used to be rendered as "all local entries, then all remote ones", which contradicts
+        // promotion: proceedNextContext compares the heads by priority and only favours local on a tie.
+        LockableResourcesManager.get().setRemoteApiEnabled(true);
+        LockableResourcesManager.get().setExposeLabel("remote-ok");
+        LockableResourcesManager.get().createResourceWithLabel("merge-res", "remote-ok");
+
+        LockableResourcesRootAction action = new LockableResourcesRootAction();
+
+        // Hold the resource so everything that follows has to wait.
+        WorkflowJob holder = j.jenkins.createProject(WorkflowJob.class, "merge-holder");
+        holder.setDefinition(new CpsFlowDefinition("""
+                lock('merge-res') {
+                    semaphore 'merge-hold'
+                }
+                """, true));
+        WorkflowRun holderRun = holder.scheduleBuild2(0).waitForStart();
+        org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.waitForStart("merge-hold/1", holderRun);
+
+        // A local waiter at the default priority.
+        WorkflowJob waiter = j.jenkins.createProject(WorkflowJob.class, "merge-waiter");
+        waiter.setDefinition(new CpsFlowDefinition("""
+                lock('merge-res') {
+                    echo('local waiter')
+                }
+                """, true));
+        WorkflowRun waiterRun = waiter.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("[Resource: merge-res] is not free, waiting for execution ...", waiterRun);
+
+        // A remote waiter that outranks it, and one that ties with it.
+        String highId = RemoteLockManager.get()
+                .enqueue(remoteRequest("merge-res", 10), "client-high")
+                .getLockId();
+        String tieId = RemoteLockManager.get()
+                .enqueue(remoteRequest("merge-res", 0), "client-tie")
+                .getLockId();
+
+        List<LockableResourcesRootAction.Queue.QueueStruct> queueItems =
+                action.getQueue().getAll();
+        assertEquals(3, queueItems.size(), "queue size");
+
+        assertEquals(highId, queueItems.get(0).getId(), "the higher priority remote entry comes first");
+        assertFalse(queueItems.get(1).isRemote(), "on a tie the local entry keeps its place");
+        assertEquals(tieId, queueItems.get(2).getId(), "the tying remote entry follows the local one");
+
+        // Drain everything before leaving: the remote entries have no client to release them, so the
+        // local waiter would never be promoted and both builds would still be running at teardown.
+        RemoteLockManager.get().release(highId);
+        RemoteLockManager.get().release(tieId);
+        org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.success("merge-hold/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(holderRun));
+        j.assertBuildStatusSuccess(j.waitForCompletion(waiterRun));
+    }
+
+    private static RemoteLockRequest remoteRequest(String resource, int priority) {
+        return new RemoteLockRequest(
+                resource, null, 0, null, false, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
     void testGetAllLabels() {
         when(req.getMethod()).thenReturn("POST");
         LockableResourcesRootAction action = new LockableResourcesRootAction();

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -622,6 +622,35 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
 
     // ---------------------------------------------------------------------------
     @Test
+    void testPausedBannerAppearsOnlyWhileServingAndPaused() throws Exception {
+        // The switch is easy to leave on by accident, and its effect is invisible from this side -
+        // clients wait quietly rather than failing - so the page has to say it out loud.
+        this.createResource("served-1");
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setAcceptNewAcquires(false);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(this.ADMIN);
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+        String paused = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+        assertTrue(paused.contains("acquire requests are paused"), "the banner explains the pause");
+
+        manager.setAcceptNewAcquires(true);
+        String running = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+        assertFalse(running.contains("acquire requests are paused"));
+
+        // Not serving at all: pausing acquires means nothing, so neither should the banner.
+        manager.setAcceptNewAcquires(false);
+        manager.setRemoteApiEnabled(false);
+        String notServing = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+        assertFalse(notServing.contains("acquire requests are paused"));
+
+        manager.setAcceptNewAcquires(true);
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
     void testGetAllLabels() {
         when(req.getMethod()).thenReturn("POST");
         LockableResourcesRootAction action = new LockableResourcesRootAction();

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/LockableResourcesRootActionTest.java
@@ -586,6 +586,42 @@ class LockableResourcesRootActionTest extends LockStepTestBase {
 
     // ---------------------------------------------------------------------------
     @Test
+    void testDelegatedModeShowsABadgeAndKeepsLocalResourcesVisible() throws Exception {
+        // Roles are per relation: a controller that delegates its own lock() calls can still be the
+        // server other controllers lock against, so its resources must stay on the page.
+        this.createResource("local-1");
+        LockableResourcesManager.get()
+                .setRemotes(java.util.List.of(new RemoteConnection("server-a", "http://jenkins-b:8080/jenkins", "")));
+        LockableResourcesManager.get().setForcedServerId("server-a");
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(this.ADMIN);
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+        String page = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+
+        assertTrue(page.contains("Delegated mode"), "the badge explains the changed resolution");
+        assertTrue(page.contains("server-a"), "the badge names the target");
+        assertTrue(page.contains("local-1"), "local resources are not hidden");
+        assertTrue(
+                page.contains("remain lockable by other controllers"), "and the page says why they are still listed");
+
+        LockableResourcesManager.get().setForcedServerId("");
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
+    void testNoDelegatedBadgeWithoutForcedServerId() throws Exception {
+        this.createResource("local-2");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login(this.ADMIN);
+        wc.getOptions().setThrowExceptionOnScriptError(false);
+        String page = wc.goTo("lockable-resources").getWebResponse().getContentAsString();
+
+        assertFalse(page.contains("Delegated mode"));
+    }
+
+    // ---------------------------------------------------------------------------
+    @Test
     void testGetAllLabels() {
         when(req.getMethod()).thenReturn("POST");
         LockableResourcesRootAction action = new LockableResourcesRootAction();

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
@@ -83,8 +83,51 @@ class RemoteApiV1ActionTest {
     @Test
     void acquireReturns400WhenBothResourceAndLabelAreAbsent(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().setRemoteApiEnabled(true);
+        LockableResourcesManager.get().setAllowEmptyOrNullValues(false);
 
-        assertJsonError(invokeAcquire(new RemoteApiV1Action(), "{\"lockRequest\":{}}"), 400, "MISSING_TARGET");
+        assertJsonError(invokeAcquire(new RemoteApiV1Action(), "{\"lockRequest\":{}}"), 400, "INVALID_REQUEST");
+    }
+
+    @Test
+    void acquireAcceptsAnEmptyRequestWhenEmptyValuesAreAllowed(JenkinsRule j) throws Exception {
+        // The boundary used to reject a target-less request unconditionally, while a local lock() honours
+        // allowEmptyOrNullValues - so the same call behaved differently over the bridge.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setAllowEmptyOrNullValues(true);
+
+        ResponseCapture result = invokeAcquire(new RemoteApiV1Action(), "{\"lockRequest\":{}}");
+        assertEquals(202, result.status.get());
+    }
+
+    @Test
+    void acquireRejectsResourceAndLabelTogether(JenkinsRule j) throws Exception {
+        // Canonical lock() refuses this combination; the bridge used to accept it (M1E-2).
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        assertJsonError(
+                invokeAcquire(new RemoteApiV1Action(), "{\"lockRequest\":{\"resource\":\"board-1\",\"label\":\"hw\"}}"),
+                400,
+                "INVALID_REQUEST");
+    }
+
+    @Test
+    void acquireRejectsPriorityCombinedWithInversePrecedence(JenkinsRule j) throws Exception {
+        // Canonical lock() refuses this combination too; the bridge used to accept it silently.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        assertJsonError(
+                invokeAcquire(
+                        new RemoteApiV1Action(),
+                        "{\"lockRequest\":{\"resource\":\"board-1\",\"priority\":5,\"inversePrecedence\":true}}"),
+                400,
+                "INVALID_REQUEST");
     }
 
     @Test
@@ -168,7 +211,7 @@ class RemoteApiV1ActionTest {
                         new RemoteApiV1Action(),
                         "{\"lockRequest\":{\"resource\":\"board-1\",\"resourceSelectStrategy\":\"BOGUS\"}}"),
                 400,
-                "INVALID_SELECT_STRATEGY");
+                "INVALID_REQUEST");
     }
 
     @Test
@@ -268,7 +311,7 @@ class RemoteApiV1ActionTest {
         // A null selector is no selector. json-lib hands back the string "null" for a JSON null, so
         // this used to go looking for a resource actually named "null" and report it missing - an
         // answer that sends the caller hunting for the wrong problem.
-        assertJsonError(invokeAcquire(action, "{\"lockRequest\":{\"resource\":null}}"), 400, "MISSING_TARGET");
+        assertJsonError(invokeAcquire(action, "{\"lockRequest\":{\"resource\":null}}"), 400, "INVALID_REQUEST");
 
         // Same for variable: an unset one must not export an environment variable called "null".
         manager.createResourceWithLabel("board-6", "hw");

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
@@ -324,6 +324,38 @@ class RemoteApiV1ActionTest {
     }
 
     @Test
+    void pausedServerRefusesNewAcquiresButKeepsLeasesWorking(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+        manager.createResourceWithLabel("board-2", "hw");
+
+        ResponseCapture acquired = invokeAcquire(new RemoteApiV1Action(), jsonBody("resource", "board-1"));
+        assertEquals(202, acquired.status.get());
+        String lockId =
+                net.sf.json.JSONObject.fromObject(acquired.body.toString()).getString("lockId");
+
+        manager.setAcceptNewAcquires(false);
+
+        // New acquires are refused with a "come back later", not an error the client should give up on.
+        assertJsonError(
+                invokeAcquire(new RemoteApiV1Action(), jsonBody("resource", "board-2")), 503, "ACQUIRES_PAUSED");
+
+        // Everything the lease in flight needs keeps working.
+        assertEquals(200, invokeAcquireStatus(lockId).status.get());
+        assertEquals(204, invokeHeartbeat(lockId).status.get());
+        assertEquals(204, invokeRelease(lockId).status.get());
+
+        manager.setAcceptNewAcquires(true);
+        assertEquals(
+                202,
+                invokeAcquire(new RemoteApiV1Action(), jsonBody("resource", "board-2"))
+                        .status
+                        .get());
+    }
+
+    @Test
     void acquireWithOversizedBodyReturns413(JenkinsRule j) throws Exception {
         LockableResourcesManager manager = LockableResourcesManager.get();
         manager.setRemoteApiEnabled(true);

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
@@ -172,6 +172,115 @@ class RemoteApiV1ActionTest {
     }
 
     @Test
+    void acquireRejectsFieldValuesItCannotInterpret(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+        RemoteApiV1Action action = new RemoteApiV1Action();
+
+        // A quantity that is not a number used to read as 0, and 0 on a label means "every match" -
+        // so a typo asked for the whole pool instead of the one machine that was meant.
+        assertJsonError(
+                invokeAcquire(action, "{\"lockRequest\":{\"label\":\"hw\",\"quantity\":\"abc\"}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+        assertJsonError(
+                invokeAcquire(action, "{\"lockRequest\":{\"label\":\"hw\",\"quantity\":true}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+        assertJsonError(
+                invokeAcquire(action, "{\"lockRequest\":{\"resource\":\"board-1\",\"priority\":\"high\"}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+
+        // A timeout that cannot be read used to disable the deadline rather than be refused, which
+        // turned a bounded wait into an unbounded one with nothing to see from the caller's side.
+        assertJsonError(
+                invokeAcquire(
+                        action, "{\"lockRequest\":{\"resource\":\"board-1\",\"timeoutForAllocateResource\":\"soon\"}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+        // MINUTE for MINUTES: the local step rejects this in setTimeoutUnit, and now so does the wire.
+        assertJsonError(
+                invokeAcquire(
+                        action,
+                        "{\"lockRequest\":{\"resource\":\"board-1\",\"timeoutForAllocateResource\":5,\"timeoutUnit\":\"MINUTE\"}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+
+        // The same rule inside an extra entry, which is parsed separately.
+        assertJsonError(
+                invokeAcquire(
+                        action,
+                        "{\"lockRequest\":{\"resource\":\"board-1\",\"extra\":[{\"label\":\"hw\",\"quantity\":\"all\"}]}}"),
+                400,
+                "INVALID_FIELD_VALUE");
+    }
+
+    @Test
+    void acquireStillAcceptsTheLooseFormsClientsActuallySend(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+        manager.createResourceWithLabel("board-2", "hw");
+        RemoteApiV1Action action = new RemoteApiV1Action();
+
+        // Strict parsing must not mean brittle parsing. json-lib reads a numeric string as a number
+        // and clients in the wild send one, so "1" has to keep working.
+        ResponseCapture numericString =
+                invokeAcquire(action, "{\"lockRequest\":{\"label\":\"hw\",\"quantity\":\"1\"}}");
+        assertEquals(202, numericString.status());
+        assertEquals("ACQUIRED", numericString.json().getString("state"));
+
+        // An explicit null is how serialisers spell "not set"; refusing it would break callers over
+        // nothing. It means the same as leaving the field out.
+        ResponseCapture explicitNulls = invokeAcquire(
+                action,
+                "{\"lockRequest\":{\"resource\":\"board-2\",\"quantity\":null,\"priority\":null,"
+                        + "\"timeoutForAllocateResource\":null,\"timeoutUnit\":null}}");
+        assertEquals(202, explicitNulls.status());
+        assertEquals("ACQUIRED", explicitNulls.json().getString("state"));
+
+        // A blank unit falls back to the default, as LockStep#setTimeoutUnit does; lower case is
+        // accepted and normalised, again matching the local step.
+        manager.createResourceWithLabel("board-3", "hw");
+        ResponseCapture blankUnit = invokeAcquire(
+                action,
+                "{\"lockRequest\":{\"resource\":\"board-3\",\"timeoutForAllocateResource\":5,\"timeoutUnit\":\"  \"}}");
+        assertEquals(202, blankUnit.status());
+
+        manager.createResourceWithLabel("board-4", "hw");
+        ResponseCapture lowerCaseUnit = invokeAcquire(
+                action,
+                "{\"lockRequest\":{\"resource\":\"board-4\",\"timeoutForAllocateResource\":5,\"timeoutUnit\":\"seconds\"}}");
+        assertEquals(202, lowerCaseUnit.status());
+
+        // Zero and negative keep their existing meanings. Both are expressible through a local
+        // lock() and mean "no limit" there, so this endpoint is not the place to start refusing them.
+        manager.createResourceWithLabel("board-5", "hw");
+        ResponseCapture negative = invokeAcquire(
+                action,
+                "{\"lockRequest\":{\"resource\":\"board-5\",\"quantity\":-1,\"timeoutForAllocateResource\":-5}}");
+        assertEquals(202, negative.status());
+
+        // A null selector is no selector. json-lib hands back the string "null" for a JSON null, so
+        // this used to go looking for a resource actually named "null" and report it missing - an
+        // answer that sends the caller hunting for the wrong problem.
+        assertJsonError(invokeAcquire(action, "{\"lockRequest\":{\"resource\":null}}"), 400, "MISSING_TARGET");
+
+        // Same for variable: an unset one must not export an environment variable called "null".
+        manager.createResourceWithLabel("board-6", "hw");
+        ResponseCapture nullVariable =
+                invokeAcquire(action, "{\"lockRequest\":{\"resource\":\"board-6\",\"variable\":null}}");
+        assertEquals(202, nullVariable.status());
+        JSONObject status =
+                invokeAcquireStatus(nullVariable.json().getString("lockId")).json();
+        assertFalse(status.containsKey("lockEnvVars"), "no variable was asked for, so none is exported");
+    }
+
+    @Test
     void acquireWithOversizedBodyReturns413(JenkinsRule j) throws Exception {
         LockableResourcesManager manager = LockableResourcesManager.get();
         manager.setRemoteApiEnabled(true);

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
@@ -557,6 +557,15 @@ class RemoteApiV1ActionTest {
         assertNotNull(doIndex.getAnnotation(GET.class));
     }
 
+    @Test
+    void resourcesEndpointIsExplicitlyGetAnnotated() throws Exception {
+        // Without a verb annotation Stapler routes any method here, which the Jenkins security scan
+        // reports as a CSRF risk. The endpoint is read-only, so GET is the honest restriction.
+        Method doIndex = RemoteApiV1Action.ResourcesResource.class.getDeclaredMethod(
+                "doIndex", StaplerRequest2.class, StaplerResponse2.class);
+        assertNotNull(doIndex.getAnnotation(GET.class));
+    }
+
     private static ResponseCapture invokeAcquire(RemoteApiV1Action action, String body) throws Exception {
         StaplerRequest2 req = mockJsonRequest(body);
         ResponseCapture response = new ResponseCapture();

--- a/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/actions/RemoteApiV1ActionTest.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.lockableresources.actions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.sf.json.JSONObject;
+import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
@@ -356,6 +358,77 @@ class RemoteApiV1ActionTest {
     }
 
     @Test
+    void resourcesListsExposedResourcesWithTheirState(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+        manager.createResourceWithLabel("board-2", "hw");
+        manager.createResourceWithLabel("internal-1", "secret");
+
+        ResponseCapture acquire = invokeAcquire(new RemoteApiV1Action(), jsonBody("resource", "board-1"));
+        assertEquals(202, acquire.status.get());
+
+        ResponseCapture result = invokeResources();
+        assertEquals(200, result.status.get());
+        net.sf.json.JSONObject payload = net.sf.json.JSONObject.fromObject(result.body.toString());
+        assertTrue(payload.getBoolean("acceptNewAcquires"));
+
+        net.sf.json.JSONArray resources = payload.getJSONArray("resources");
+        assertEquals(2, resources.size(), "only exposed resources are listed");
+
+        net.sf.json.JSONObject held = resources.getJSONObject(0);
+        assertEquals("board-1", held.getString("name"));
+        assertEquals("LOCKED", held.getString("state"));
+        assertEquals("REMOTE_CLIENT", held.getString("heldByKind"));
+
+        assertEquals("FREE", resources.getJSONObject(1).getString("state"));
+    }
+
+    @Test
+    void resourcesDoesNotLeakHolderDetails(JenkinsRule j) throws Exception {
+        // The server's admin exposed resources, not the names of the builds using them, and this list is
+        // rendered on a controller whose viewers may have no account here.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        LockableResource resource = manager.fromName("board-1");
+        resource.setNote("internal note");
+        resource.setLockReason("because of ticket 1234");
+        manager.reserve(java.util.List.of(resource), "operator-a");
+
+        String body = invokeResources().body.toString();
+        assertFalse(body.contains("internal note"), body);
+        assertFalse(body.contains("ticket 1234"), body);
+        assertFalse(body.contains("operator-a"), body);
+        assertTrue(body.contains("\"heldByKind\":\"ADMIN\""), body);
+    }
+
+    @Test
+    void resourcesReportsThePausedServerWhileStatesStayTruthful(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+        manager.setAcceptNewAcquires(false);
+
+        net.sf.json.JSONObject payload =
+                net.sf.json.JSONObject.fromObject(invokeResources().body.toString());
+        assertFalse(payload.getBoolean("acceptNewAcquires"));
+        // A free resource is still reported as free: "you cannot take it right now" is the page's job.
+        assertEquals("FREE", payload.getJSONArray("resources").getJSONObject(0).getString("state"));
+    }
+
+    @Test
+    void resourcesIsRefusedWhileTheRemoteApiIsDisabled(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().setRemoteApiEnabled(false);
+
+        assertJsonError(invokeResources(), 403, "REMOTE_API_DISABLED");
+    }
+
+    @Test
     void acquireWithOversizedBodyReturns413(JenkinsRule j) throws Exception {
         LockableResourcesManager manager = LockableResourcesManager.get();
         manager.setRemoteApiEnabled(true);
@@ -488,6 +561,12 @@ class RemoteApiV1ActionTest {
         StaplerRequest2 req = mockJsonRequest(body);
         ResponseCapture response = new ResponseCapture();
         new RemoteApiV1Action.AcquireRouter().doIndex(req, response.response());
+        return response;
+    }
+
+    private static ResponseCapture invokeResources() throws Exception {
+        ResponseCapture response = new ResponseCapture();
+        new RemoteApiV1Action.ResourcesResource().doIndex(mock(StaplerRequest2.class), response.response());
         return response;
     }
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteAcquireStatusTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteAcquireStatusTest.java
@@ -17,4 +17,20 @@ class RemoteAcquireStatusTest {
 
         assertEquals(RemoteAcquireState.UNKNOWN, status.getState());
     }
+
+    @Test
+    void aStateThisClientDoesNotRecogniseReadsAsUnknown() {
+        // Version skew: a newer server may report a state this client has never heard of. UNKNOWN is
+        // handled as a failure, so the build stops rather than carrying on against a lock whose
+        // condition nobody here can describe. Throwing instead would turn a forwards-compatible
+        // server into a broken one.
+        assertEquals(RemoteAcquireState.UNKNOWN, RemoteAcquireState.fromString("SOMETHING_NEW"));
+        assertEquals(RemoteAcquireState.UNKNOWN, RemoteAcquireState.fromString(""));
+        assertEquals(RemoteAcquireState.UNKNOWN, RemoteAcquireState.fromString(null));
+
+        // Recognised states survive the trip, whatever case and padding the wire used.
+        assertEquals(RemoteAcquireState.ACQUIRED, RemoteAcquireState.fromString("ACQUIRED"));
+        assertEquals(RemoteAcquireState.QUEUED, RemoteAcquireState.fromString("queued"));
+        assertEquals(RemoteAcquireState.FAILED, RemoteAcquireState.fromString("  Failed  "));
+    }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCacheTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCacheTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+import org.jenkins.plugins.lockableresources.RemoteConnection;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class RemoteCatalogCacheTest {
+
+    @Test
+    void doesNotContactADisabledConnection(JenkinsRule j) {
+        // Disabling a connection means this controller stops talking to it - including for display.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        RemoteConnection disabled = new RemoteConnection("server-a", "http://127.0.0.1:1/jenkins", "");
+        disabled.setEnabled(false);
+        manager.setRemotes(List.of(disabled));
+
+        assertNull(RemoteCatalogCache.get().get("server-a"));
+    }
+
+    @Test
+    void returnsNothingForAnUnknownServer(JenkinsRule j) {
+        LockableResourcesManager.get().setRemotes(List.of());
+        assertNull(RemoteCatalogCache.get().get("no-such-server"));
+    }
+
+    @Test
+    void aFailedFetchKeepsTheViewRatherThanEmptyingIt(JenkinsRule j) {
+        // A remote that is down should age the page, not blank it: display is best-effort, unlike
+        // acquiring a lock.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        RemoteConnection unreachable = new RemoteConnection("server-a", "http://127.0.0.1:1/jenkins", "");
+        manager.setRemotes(List.of(unreachable));
+
+        RemoteCatalog failed = RemoteCatalogCache.get().fetch(unreachable);
+
+        assertNotNull(failed.getError(), "the failure is recorded rather than hidden");
+        assertEquals(0, failed.getFetchedAt(), "nothing was ever fetched, so there is no age to claim");
+        assertTrue(failed.getResources().isEmpty());
+        assertTrue(failed.isStale(RemoteCatalogCache.TTL_MILLIS));
+    }
+
+    @Test
+    void invalidatingDropsEverySnapshot(JenkinsRule j) {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        RemoteConnection remote = new RemoteConnection("server-a", "http://127.0.0.1:1/jenkins", "");
+        manager.setRemotes(List.of(remote));
+        RemoteCatalogCache.get().fetch(remote);
+
+        RemoteCatalogCache.get().invalidateAll();
+
+        // Nothing cached: the next read starts a refresh and reports "not fetched yet".
+        assertNull(RemoteCatalogCache.get().get("server-a"));
+    }
+
+    @Test
+    void aSnapshotAgesOutAfterItsTtl(JenkinsRule j) {
+        RemoteCatalog fresh = new RemoteCatalog("server-a", List.of(), true, System.currentTimeMillis(), null);
+        assertFalse(fresh.isStale(RemoteCatalogCache.TTL_MILLIS));
+
+        RemoteCatalog old = new RemoteCatalog(
+                "server-a", List.of(), true, System.currentTimeMillis() - RemoteCatalogCache.TTL_MILLIS - 1, null);
+        assertTrue(old.isStale(RemoteCatalogCache.TTL_MILLIS));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCacheTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteCatalogCacheTest.java
@@ -55,6 +55,52 @@ class RemoteCatalogCacheTest {
     }
 
     @Test
+    void aFailedRefreshKeepsWhatWasLastKnown(JenkinsRule j) throws Exception {
+        // The case the fallback exists for, and the one the empty-cache test above cannot reach: a
+        // remote that answered once and then stopped. Blanking the page here would say "this server
+        // publishes nothing", which is a claim about the server rather than about the connection.
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        RemoteConnection connection = new RemoteConnection("server-a", remote.baseUrl(), "");
+        LockableResourcesManager.get().setRemotes(List.of(connection));
+        remote.setResourcesResponse(
+                200, "{\"acceptNewAcquires\":true,\"resources\":[{\"name\":\"board-1\",\"state\":\"FREE\"}]}");
+
+        RemoteCatalog good = RemoteCatalogCache.get().fetch(connection);
+        assertEquals(1, good.getResources().size());
+        assertNull(good.getError());
+        long fetchedAt = good.getFetchedAt();
+
+        remote.stop();
+        RemoteCatalog afterOutage = RemoteCatalogCache.get().fetch(connection);
+
+        assertEquals(1, afterOutage.getResources().size(), "the last known resources are still there");
+        assertEquals("board-1", afterOutage.getResources().get(0).getName());
+        assertNotNull(afterOutage.getError(), "and the page can say the view is not current");
+        assertEquals(fetchedAt, afterOutage.getFetchedAt(), "aged from the last successful fetch, not from now");
+    }
+
+    @Test
+    void aFreshSnapshotIsServedWithoutAskingAgain(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            RemoteConnection connection = new RemoteConnection("server-a", remote.baseUrl(), "");
+            LockableResourcesManager.get().setRemotes(List.of(connection));
+            RemoteCatalogCache.get().invalidateAll();
+            RemoteCatalogCache.get().fetch(connection);
+            int fetchesSoFar = remote.resourcesRequests.get();
+
+            RemoteCatalog served = RemoteCatalogCache.get().get("server-a");
+
+            assertNotNull(served, "a snapshot inside its TTL is handed straight back");
+            assertEquals(fetchesSoFar, remote.resourcesRequests.get(), "rendering did not contact the remote");
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
     void invalidatingDropsEverySnapshot(JenkinsRule j) {
         LockableResourcesManager manager = LockableResourcesManager.get();
         RemoteConnection remote = new RemoteConnection("server-a", "http://127.0.0.1:1/jenkins", "");

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteClientRegistryTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteClientRegistryTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class RemoteClientRegistryTest {
+
+    @Test
+    void tracksARequestFromQueuedToReleased(JenkinsRule j) {
+        RemoteClientRegistry registry = RemoteClientRegistry.get();
+        assertTrue(registry.isEmpty());
+
+        registry.queued("lock-1", "server-a", "plc-01", null);
+
+        List<RemoteClientRegistry.Entry> waiting = registry.getAll();
+        assertEquals(1, waiting.size());
+        assertEquals("QUEUED", waiting.get(0).getState());
+        assertEquals("server-a", waiting.get(0).getServerId());
+        assertEquals("plc-01", waiting.get(0).getRequest());
+        assertTrue(waiting.get(0).getResourceNames().isEmpty());
+        assertEquals(waiting.get(0).getEnqueuedAt(), waiting.get(0).getSince());
+
+        registry.acquired("lock-1", List.of("plc-01", "plc-02"));
+
+        RemoteClientRegistry.Entry held = registry.getAll().get(0);
+        assertEquals("ACQUIRED", held.getState());
+        assertEquals(List.of("plc-01", "plc-02"), held.getResourceNames());
+        assertEquals(held.getAcquiredAt(), held.getSince());
+
+        registry.forget("lock-1");
+        assertTrue(registry.isEmpty());
+    }
+
+    @Test
+    void listsHeldLocksBeforeWaitingOnes(JenkinsRule j) {
+        // The page answers "what do I hold, and what am I waiting for" in that order.
+        RemoteClientRegistry registry = RemoteClientRegistry.get();
+        registry.queued("waiting-1", "server-a", "plc-01", null);
+        registry.queued("held-1", "server-b", "plc-02", null);
+        registry.acquired("held-1", List.of("plc-02"));
+
+        List<RemoteClientRegistry.Entry> all = registry.getAll();
+        assertEquals(2, all.size());
+        assertEquals("held-1", all.get(0).getLockId());
+        assertEquals("waiting-1", all.get(1).getLockId());
+
+        assertEquals(1, registry.forServer("server-a").size());
+        assertEquals(1, registry.forServer("server-b").size());
+        assertTrue(registry.forServer("server-c").isEmpty());
+
+        registry.forget("waiting-1");
+        registry.forget("held-1");
+    }
+
+    @Test
+    void survivesAnEntryWhoseBuildIsGone(JenkinsRule j) {
+        // Entries outlive their builds: the page still has to render, and holding a build alive to
+        // keep a name would be worse than copying the name.
+        RemoteClientRegistry registry = RemoteClientRegistry.get();
+        registry.queued("lock-2", "server-a", "label:plc", null);
+
+        RemoteClientRegistry.Entry entry = registry.getAll().get(0);
+        assertNull(entry.getBuild());
+        assertEquals("", entry.getBuildName());
+        assertFalse(entry.isAcquired());
+
+        registry.forget("lock-2");
+    }
+
+    @Test
+    void ignoresUpdatesForUnknownLocks(JenkinsRule j) {
+        RemoteClientRegistry registry = RemoteClientRegistry.get();
+        registry.acquired("never-registered", List.of("plc-01"));
+        registry.forget("never-registered");
+        registry.forget(null);
+        assertTrue(registry.isEmpty());
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -776,6 +776,82 @@ class RemoteLockManagerTest {
     }
 
     @Test
+    void releasedRecordStaysObservableUntilItsTtl(JenkinsRule j) {
+        // A released record used to be dropped from the map at once, so the very next status poll got a
+        // 404 - indistinguishable from "the server restarted and lost the lock".
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("rel-1", "remote-ok");
+
+        RemoteLockRecord record = RemoteLockManager.get().enqueue(req("rel-1"), null);
+        assertEquals(RemoteLockState.ACQUIRED, record.getState());
+
+        RemoteLockManager.get().release(record.getLockId());
+
+        RemoteLockRecord afterRelease = RemoteLockManager.get().find(record.getLockId());
+        assertNotNull(afterRelease, "a released record must stay observable for the terminal TTL");
+        assertEquals(RemoteLockState.FAILED, afterRelease.getState());
+        assertEquals("RELEASED", afterRelease.getErrorCode());
+        assertTrue(afterRelease.getTerminalAt() > 0L, "markFailed must record terminalAt");
+        assertNull(manager.fromName("rel-1").getRemoteLockedBy(), "the resource is still freed");
+
+        // A maintenance pass right after the release must not evict it either.
+        RemoteLockManager.get().doRun();
+        assertNotNull(RemoteLockManager.get().find(record.getLockId()));
+    }
+
+    @Test
+    void releasingAQueuedRequestReportsItAsReleased(JenkinsRule j) {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("rel-2", "remote-ok");
+
+        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("rel-2"), null);
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+        RemoteLockRecord waiter = RemoteLockManager.get().enqueue(req("rel-2"), null);
+        assertEquals(RemoteLockState.QUEUED, waiter.getState());
+
+        RemoteLockManager.get().release(waiter.getLockId());
+
+        RemoteLockRecord afterRelease = RemoteLockManager.get().find(waiter.getLockId());
+        assertNotNull(afterRelease, "a released queued request must stay observable, not vanish");
+        assertEquals(RemoteLockState.FAILED, afterRelease.getState());
+        assertEquals("RELEASED", afterRelease.getErrorCode());
+
+        // It left the queue: freeing the resource must not hand it to the released request.
+        RemoteLockManager.get().release(holder.getLockId());
+        assertEquals(RemoteLockState.FAILED, afterRelease.getState());
+        assertNull(manager.fromName("rel-2").getRemoteLockedBy());
+    }
+
+    @Test
+    void releasingTwiceDoesNotFreeSomebodyElsesLock(JenkinsRule j) {
+        // Now that the record survives the first release, a repeated (or late) release must be a no-op
+        // rather than unlocking whatever holds the resource by then.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("rel-3", "remote-ok");
+
+        RemoteLockRecord first = RemoteLockManager.get().enqueue(req("rel-3"), null);
+        assertEquals(RemoteLockState.ACQUIRED, first.getState());
+        RemoteLockManager.get().release(first.getLockId());
+
+        RemoteLockRecord second = RemoteLockManager.get().enqueue(req("rel-3"), null);
+        assertEquals(RemoteLockState.ACQUIRED, second.getState());
+
+        RemoteLockManager.get().release(first.getLockId()); // repeated release of the old lock
+
+        assertEquals(RemoteLockState.ACQUIRED, second.getState());
+        assertEquals(
+                second.getLockId(),
+                manager.fromName("rel-3").getRemoteLockedBy(),
+                "the second holder must keep the resource");
+    }
+
+    @Test
     void lockCauseNamesTheRemoteHolder(JenkinsRule j) {
         // A remote lock has no build and no reservedTimestamp, so the generic branches used to render
         // "locked by null at <unknown>" - in the REST API and in the console of a locally waiting job.

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -376,6 +376,42 @@ class RemoteLockManagerTest {
     }
 
     @Test
+    void queuedRequestTimesOutOnItsOwnDeadlineWithoutOutsideHelp(JenkinsRule j) throws Exception {
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("hw");
+        manager.createResourceWithLabel("board-1", "hw");
+
+        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("board-1"), null);
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+
+        RemoteLockRecord waiter =
+                RemoteLockManager.get().enqueue(reqWithTimeout("board-1", 500L, "MILLISECONDS"), null);
+        assertEquals(RemoteLockState.QUEUED, waiter.getState());
+
+        // Deliberately no checkTimeouts() and no release: nothing here touches the queue after the
+        // request is made. The deadline has to be enforced by a wake-up the queue scheduled for
+        // itself, which is the whole point - a timeout that only fires when something else happens to
+        // run a maintenance pass is not an upper bound on the wait, and every other test in this file
+        // hides that by calling checkTimeouts() by hand.
+        long deadlineAt = System.currentTimeMillis() + 500L;
+        for (int i = 0; i < 100 && waiter.getState() == RemoteLockState.QUEUED; i++) {
+            Thread.sleep(100);
+        }
+
+        assertEquals(RemoteLockState.FAILED, waiter.getState(), "the queued request timed out on its own");
+        assertEquals("LOCK_WAIT_TIMEOUT", waiter.getErrorCode());
+        assertTrue(
+                waiter.getTerminalAt() >= deadlineAt,
+                "it timed out at its deadline, not before: terminalAt=" + waiter.getTerminalAt() + " deadline="
+                        + deadlineAt);
+
+        // The holder is still holding: nothing about this timeout depended on the resource freeing up.
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+        assertNotNull(manager.fromName("board-1").getRemoteLockedBy());
+    }
+
+    @Test
     void timedOutRecordRecordsTerminalTimestampAndSurvivesMaintenance(JenkinsRule j) throws Exception {
         LockableResourcesManager manager = LockableResourcesManager.get();
         manager.setRemoteApiEnabled(true);

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -6,6 +6,7 @@
 package org.jenkins.plugins.lockableresources.remote;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -772,5 +773,52 @@ class RemoteLockManagerTest {
         RemoteLockRecord other = RemoteLockManager.get().enqueue(req("other-1"), null);
         assertEquals(RemoteLockState.FAILED, other.getState());
         assertEquals("UNKNOWN_RESOURCE", other.getErrorCode());
+    }
+
+    @Test
+    void lockCauseNamesTheRemoteHolder(JenkinsRule j) {
+        // A remote lock has no build and no reservedTimestamp, so the generic branches used to render
+        // "locked by null at <unknown>" - in the REST API and in the console of a locally waiting job.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("cause-1", "remote-ok");
+
+        RemoteLockRecord record = RemoteLockManager.get().enqueue(req("cause-1"), "jenkins-a");
+        assertEquals(RemoteLockState.ACQUIRED, record.getState());
+
+        LockableResource resource = manager.fromName("cause-1");
+        assertNotNull(resource);
+
+        String cause = resource.getLockCause();
+        assertNotNull(cause);
+        assertTrue(cause.contains("remote client jenkins-a"), cause);
+        assertFalse(cause.contains("null"), cause);
+        assertFalse(cause.contains("<unknown>"), cause);
+
+        String detail = resource.getLockCauseDetail();
+        assertNotNull(detail);
+        assertTrue(detail.contains("remote client jenkins-a"), detail);
+        assertTrue(detail.contains(record.getLockId()), detail);
+        assertFalse(detail.contains("<unknown>"), detail);
+    }
+
+    @Test
+    void lockCauseFallsBackToTheLockIdWhenTheRecordIsGone(JenkinsRule j) {
+        // The record is transient: after a restart a still-locked resource has a lock id and nothing else.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.createResource("orphan-1");
+        LockableResource resource = manager.fromName("orphan-1");
+        assertNotNull(resource);
+        resource.setRemoteLockedBy("lost-lock-id");
+
+        String cause = resource.getLockCause();
+        assertNotNull(cause);
+        assertTrue(cause.contains("remote lockId lost-lock-id"), cause);
+        assertTrue(cause.contains("<unknown>"), cause);
+
+        String detail = resource.getLockCauseDetail();
+        assertNotNull(detail);
+        assertTrue(detail.contains("remote lockId lost-lock-id"), detail);
     }
 }

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -52,16 +52,6 @@ class RemoteLockManagerTest {
         return new RemoteLockRequest(resource, null, 0, null, true, "SEQUENTIAL", false, null, 0, 0, "MINUTES", null);
     }
 
-    private static RemoteLockRequest inverseReqWithPriority(String resource, int priority) {
-        return new RemoteLockRequest(
-                resource, null, 0, null, true, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
-    }
-
-    private static RemoteLockRequest priorityReq(String resource, int priority) {
-        return new RemoteLockRequest(
-                resource, null, 0, null, false, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
-    }
-
     private static RemoteLockRequest reqWithTimeout(String resource, long timeout, String unit) {
         return new RemoteLockRequest(resource, null, 0, null, false, "SEQUENTIAL", false, null, 0, timeout, unit, null);
     }
@@ -852,27 +842,6 @@ class RemoteLockManagerTest {
         RemoteLockManager.get().release(holder.getLockId());
         assertEquals(RemoteLockState.ACQUIRED, jumper.getState());
         assertEquals(RemoteLockState.QUEUED, first.getState());
-    }
-
-    @Test
-    void inversePrecedenceWithAPriorityKeepsTheSortedPosition(JenkinsRule j) {
-        // Local queueContext() only jumps the queue when the priority is the default, so the bridge must
-        // fall back to the ordinary priority insert in the same case.
-        LockableResourcesManager manager = LockableResourcesManager.get();
-        manager.setRemoteApiEnabled(true);
-        manager.setExposeLabel("remote-ok");
-        manager.createResourceWithLabel("inv-2", "remote-ok");
-
-        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("inv-2"), null);
-        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
-
-        RemoteLockRecord high = RemoteLockManager.get().enqueue(priorityReq("inv-2", 10), null);
-        RemoteLockRecord inverseLow = RemoteLockManager.get().enqueue(inverseReqWithPriority("inv-2", 5), null);
-
-        List<String> queued = manager.getCurrentRemoteQueueEntries().stream()
-                .map(RemoteQueueEntry::getLockId)
-                .collect(Collectors.toList());
-        assertEquals(List.of(high.getLockId(), inverseLow.getLockId()), queued, "priority still wins");
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jenkins.plugins.lockableresources.LockableResource;
 import org.jenkins.plugins.lockableresources.LockableResourcesManager;
 import org.jenkins.plugins.lockableresources.util.Constants;
@@ -45,6 +46,20 @@ class RemoteLockManagerTest {
     private static RemoteLockRequest labelReqWithVar(String label, int quantity, String variable) {
         return new RemoteLockRequest(
                 null, label, quantity, variable, false, "SEQUENTIAL", false, null, 0, 0, "MINUTES", null);
+    }
+
+    private static RemoteLockRequest inverseReq(String resource) {
+        return new RemoteLockRequest(resource, null, 0, null, true, "SEQUENTIAL", false, null, 0, 0, "MINUTES", null);
+    }
+
+    private static RemoteLockRequest inverseReqWithPriority(String resource, int priority) {
+        return new RemoteLockRequest(
+                resource, null, 0, null, true, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
+    }
+
+    private static RemoteLockRequest priorityReq(String resource, int priority) {
+        return new RemoteLockRequest(
+                resource, null, 0, null, false, "SEQUENTIAL", false, null, priority, 0, "MINUTES", null);
     }
 
     private static RemoteLockRequest reqWithTimeout(String resource, long timeout, String unit) {
@@ -809,6 +824,55 @@ class RemoteLockManagerTest {
         RemoteLockRecord other = RemoteLockManager.get().enqueue(req("other-1"), null);
         assertEquals(RemoteLockState.FAILED, other.getState());
         assertEquals("UNKNOWN_RESOURCE", other.getErrorCode());
+    }
+
+    @Test
+    void inversePrecedenceTakesTheFirstPositionInTheRemoteQueue(JenkinsRule j) {
+        // inversePrecedence is carried on the wire and kept on the request, but the remote queue only
+        // looked at priority - so the parameter that makes a local lock() jump the queue did nothing here.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("inv-1", "remote-ok");
+
+        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("inv-1"), null);
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+
+        RemoteLockRecord first = RemoteLockManager.get().enqueue(req("inv-1"), null);
+        RemoteLockRecord jumper = RemoteLockManager.get().enqueue(inverseReq("inv-1"), null);
+        assertEquals(RemoteLockState.QUEUED, first.getState());
+        assertEquals(RemoteLockState.QUEUED, jumper.getState());
+
+        List<String> queued = manager.getCurrentRemoteQueueEntries().stream()
+                .map(RemoteQueueEntry::getLockId)
+                .collect(Collectors.toList());
+        assertEquals(List.of(jumper.getLockId(), first.getLockId()), queued, "inversePrecedence goes first");
+
+        // And the order is the one that actually gets promoted, not just the one that is displayed.
+        RemoteLockManager.get().release(holder.getLockId());
+        assertEquals(RemoteLockState.ACQUIRED, jumper.getState());
+        assertEquals(RemoteLockState.QUEUED, first.getState());
+    }
+
+    @Test
+    void inversePrecedenceWithAPriorityKeepsTheSortedPosition(JenkinsRule j) {
+        // Local queueContext() only jumps the queue when the priority is the default, so the bridge must
+        // fall back to the ordinary priority insert in the same case.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("inv-2", "remote-ok");
+
+        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("inv-2"), null);
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+
+        RemoteLockRecord high = RemoteLockManager.get().enqueue(priorityReq("inv-2", 10), null);
+        RemoteLockRecord inverseLow = RemoteLockManager.get().enqueue(inverseReqWithPriority("inv-2", 5), null);
+
+        List<String> queued = manager.getCurrentRemoteQueueEntries().stream()
+                .map(RemoteQueueEntry::getLockId)
+                .collect(Collectors.toList());
+        assertEquals(List.of(high.getLockId(), inverseLow.getLockId()), queued, "priority still wins");
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockManagerTest.java
@@ -845,6 +845,26 @@ class RemoteLockManagerTest {
     }
 
     @Test
+    void pausingNewAcquiresDoesNotStopTheQueueFromDraining(JenkinsRule j) {
+        // The switch gates the REST boundary only. Requests that were already accepted keep their place
+        // and are still promoted, so an administrator can drain the server instead of stranding clients.
+        LockableResourcesManager manager = LockableResourcesManager.get();
+        manager.setRemoteApiEnabled(true);
+        manager.setExposeLabel("remote-ok");
+        manager.createResourceWithLabel("drain-1", "remote-ok");
+
+        RemoteLockRecord holder = RemoteLockManager.get().enqueue(req("drain-1"), null);
+        RemoteLockRecord waiter = RemoteLockManager.get().enqueue(req("drain-1"), null);
+        assertEquals(RemoteLockState.ACQUIRED, holder.getState());
+        assertEquals(RemoteLockState.QUEUED, waiter.getState());
+
+        manager.setAcceptNewAcquires(false);
+        RemoteLockManager.get().release(holder.getLockId());
+
+        assertEquals(RemoteLockState.ACQUIRED, waiter.getState(), "a queued request still gets promoted");
+    }
+
+    @Test
     void releasedRecordStaysObservableUntilItsTtl(JenkinsRule j) {
         // A released record used to be dropped from the map at once, so the very next status poll got a
         // 404 - indistinguishable from "the server restarted and lost the lock".

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRoutingTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteLockRoutingTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.AbortException;
+import java.util.List;
+import org.jenkins.plugins.lockableresources.LockStep;
+import org.jenkins.plugins.lockableresources.LockStepResource;
+import org.jenkins.plugins.lockableresources.LockableResourcesManager;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Deciding whether a lock is remote, and whose it is.
+ *
+ * <p>Everything else about a remote lock happens after these three answers, and getting one wrong is
+ * not a visible failure - it is a build quietly locking the wrong controller's resource, or locking
+ * locally something it was meant to take from a peer. The delegated-mode override is the sharp edge:
+ * a controller configured to delegate sends every serverId-less lock() elsewhere, and overrides a
+ * serverId the pipeline did name.
+ */
+@WithJenkins
+class RemoteLockRoutingTest {
+
+    private static LockStep step(String resource, String label, String serverId) {
+        LockStep step = new LockStep(resource);
+        step.label = label;
+        step.serverId = serverId;
+        return step;
+    }
+
+    @Test
+    void aStepIsRemoteWhenItNamesAServerOrTheControllerDelegates(JenkinsRule j) {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+        lrm.setForcedServerId("");
+
+        assertTrue(RemoteLockRouting.isRemoteRequest(step("r", null, "server-a"), lrm), "the DSL named a server");
+        assertFalse(RemoteLockRouting.isRemoteRequest(step("r", null, null), lrm), "no server anywhere: local");
+        // Blank is not a server name. Treating it as one would send an ordinary local lock over the wire.
+        assertFalse(RemoteLockRouting.isRemoteRequest(step("r", null, "   "), lrm), "blank serverId is no serverId");
+
+        lrm.setForcedServerId("server-b");
+        assertTrue(
+                RemoteLockRouting.isRemoteRequest(step("r", null, null), lrm),
+                "delegated mode makes a serverId-less lock remote");
+        lrm.setForcedServerId("   ");
+        assertFalse(RemoteLockRouting.isRemoteRequest(step("r", null, null), lrm), "blank forcedServerId is not set");
+
+        lrm.setForcedServerId("");
+    }
+
+    @Test
+    void delegationOverridesTheServerThePipelineNamed(JenkinsRule j) {
+        LockableResourcesManager lrm = LockableResourcesManager.get();
+
+        lrm.setForcedServerId("");
+        assertEquals("server-a", RemoteLockRouting.effectiveServerId(step("r", null, "server-a"), lrm, null));
+
+        // The point of delegated mode: the controller's setting wins. A pipeline that names a server
+        // still goes where the administrator says, which is why the override is logged.
+        lrm.setForcedServerId("server-b");
+        assertEquals("server-b", RemoteLockRouting.effectiveServerId(step("r", null, "server-a"), lrm, null));
+        assertEquals("server-b", RemoteLockRouting.effectiveServerId(step("r", null, null), lrm, null));
+        // Naming the same server as the forced one is agreement, not an override.
+        assertEquals("server-b", RemoteLockRouting.effectiveServerId(step("r", null, "server-b"), lrm, null));
+        // Surrounding whitespace is not a different server.
+        assertEquals("server-b", RemoteLockRouting.effectiveServerId(step("r", null, " server-b "), lrm, null));
+
+        lrm.setForcedServerId("");
+    }
+
+    @Test
+    void theDisplayTargetNamesWhateverTheStepAskedFor(JenkinsRule j) throws Exception {
+        assertEquals("board-1", RemoteLockRouting.displayTarget(step("board-1", null, "server-a")));
+        assertEquals("board-1", RemoteLockRouting.displayTarget(step("  board-1  ", null, "server-a")));
+        assertEquals("label:hw", RemoteLockRouting.displayTarget(step(null, "hw", "server-a")));
+        assertEquals("label:hw", RemoteLockRouting.displayTarget(step(null, "  hw  ", "server-a")));
+
+        // extra on its own is a legitimate request, and has to describe itself somehow.
+        LockStep extraOnly = step(null, null, "server-a");
+        extraOnly.extra = List.of(new LockStepResource("board-2"));
+        assertFalse(RemoteLockRouting.displayTarget(extraOnly).isEmpty());
+
+        // Nothing to lock is not a target. Failing here beats sending an empty request over the wire.
+        assertThrows(AbortException.class, () -> RemoteLockRouting.displayTarget(step(null, null, "server-a")));
+        assertThrows(AbortException.class, () -> RemoteLockRouting.displayTarget(step("  ", "  ", "server-a")));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteResourcesClientTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteResourcesClientTest.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.jenkins.plugins.lockableresources.RemoteConnection;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Reading another controller's catalogue.
+ *
+ * <p>This is what the client page renders remote resources from, and it is the one client call whose
+ * job is to be tolerant: a page that fails to draw because a remote was slow is worse than a page
+ * that draws slightly old information. The parsing has to survive a server that omits fields, and a
+ * server that answers with an error has to arrive as an exception the cache can catch and fall back
+ * from - not as an empty catalogue that would render as "this server has nothing".
+ */
+@WithJenkins
+class RemoteResourcesClientTest {
+
+    private static RemoteConnection connection(RemoteServerFixture remote) {
+        return new RemoteConnection("server-a", remote.baseUrl(), "");
+    }
+
+    @Test
+    void readsResourcesAndTheAcceptFlag(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            remote.setResourcesResponse(200, """
+                    {"acceptNewAcquires":false,"resources":[
+                      {"name":"board-1","labels":["hw","fast"],"description":"a board",
+                       "state":"LOCKED","heldByKind":"REMOTE_CLIENT","heldByClientId":"client-b","since":1234},
+                      {"name":"board-2","labels":[],"description":"","state":"FREE"}
+                    ]}
+                    """);
+
+            RemoteCatalog catalog = new RemoteApiClient().listResources(connection(remote), "");
+
+            assertEquals("server-a", catalog.getServerId());
+            assertEquals(2, catalog.getResources().size());
+            // The switch travels with the list on purpose: split across two calls, a page could show a
+            // resource as free while the server had stopped handing out leases.
+            assertFalse(catalog.isAcceptNewAcquires(), "the server said it is not accepting new acquires");
+
+            RemoteCatalog.Resource first = catalog.getResources().get(0);
+            assertEquals("board-1", first.getName());
+            assertEquals(List.of("hw", "fast"), first.getLabels());
+            assertEquals("a board", first.getDescription());
+            assertEquals("LOCKED", first.getState());
+            assertEquals("REMOTE_CLIENT", first.getHeldByKind());
+            assertEquals("client-b", first.getHeldByClientId());
+            assertEquals(1234L, first.getSince());
+
+            // A free resource carries no holder. Reading those absent fields must not throw.
+            RemoteCatalog.Resource second = catalog.getResources().get(1);
+            assertEquals("board-2", second.getName());
+            assertEquals("FREE", second.getState());
+            assertTrue(second.getLabels().isEmpty());
+            assertEquals(0L, second.getSince());
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void toleratesAServerThatOmitsFields(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            // No acceptNewAcquires, no labels, no state. An older server, or one that grew the field
+            // later, must not take the page down.
+            remote.setResourcesResponse(200, "{\"resources\":[{\"name\":\"board-1\"}]}");
+
+            RemoteCatalog catalog = new RemoteApiClient().listResources(connection(remote), "");
+
+            assertEquals(1, catalog.getResources().size());
+            assertEquals("board-1", catalog.getResources().get(0).getName());
+            assertTrue(catalog.getResources().get(0).getLabels().isEmpty());
+            // Absent means "yes" here: a server that never heard of the switch is not paused.
+            assertTrue(catalog.isAcceptNewAcquires());
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void anEmptyCatalogueIsNotAnError(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            remote.setResourcesResponse(200, "{\"acceptNewAcquires\":true,\"resources\":[]}");
+
+            RemoteCatalog catalog = new RemoteApiClient().listResources(connection(remote), "");
+
+            assertNotNull(catalog);
+            assertTrue(catalog.getResources().isEmpty(), "a server may legitimately publish nothing");
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aRefusedRequestIsRaisedRatherThanReadAsAnEmptyCatalogue(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        try {
+            // 403 when the remote API is switched off. Returning an empty catalogue here would render
+            // as "this server publishes nothing", which is a different and wrong statement - the cache
+            // has to be able to tell the difference and keep showing what it last knew.
+            remote.setResourcesResponse(
+                    403, "{\"errorCode\":\"REMOTE_API_DISABLED\",\"message\":\"Remote API is not enabled\"}");
+
+            RemoteApiException ex = assertThrows(
+                    RemoteApiException.class, () -> new RemoteApiClient().listResources(connection(remote), ""));
+            assertEquals(403, ex.getHttpStatus());
+        } finally {
+            remote.stop();
+        }
+    }
+
+    @Test
+    void aCatalogueFromAServerThatIsGoneIsRaisedToo(JenkinsRule j) throws Exception {
+        RemoteServerFixture remote = new RemoteServerFixture();
+        remote.start();
+        String url = remote.baseUrl();
+        remote.stop();
+
+        // Nothing is listening any more. This is the case the cache's stale fallback exists for.
+        RemoteConnection dead = new RemoteConnection("server-a", url, "");
+        assertThrows(Exception.class, () -> new RemoteApiClient().listResources(dead, ""));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteServerFixture.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/remote/RemoteServerFixture.java
@@ -1,0 +1,275 @@
+/*
+ * The MIT License
+ *
+ * See the "LICENSE.txt" file for full copyright and license information.
+ */
+package org.jenkins.plugins.lockableresources.remote;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A remote lock server that answers whatever a test needs it to answer.
+ *
+ * <p>The client half of a remote lock is the harder half to test. It is a state machine driven by
+ * what a server says over time - a request that queues and is later promoted, one that ends in a
+ * terminal state, a lease that goes stale, a server that stops answering for a while - and none of
+ * that can be provoked from the client side. A real server will not produce those states on demand
+ * either; it produces the ones its own state happens to warrant.
+ *
+ * <p>So the server is scripted instead. Tests say what the sequence of answers is, and then assert
+ * what the client did with it. The scripting is deliberately sequence-shaped rather than a set of
+ * flags: {@code queueFor(3)} means "the next three status polls report QUEUED, then it is acquired",
+ * which is the shape the interesting client paths actually respond to.
+ *
+ * <p>Fixed to a single lock id, {@code lock-1}. Nothing here needs two in flight at once, and the
+ * URL routing is much clearer for it.
+ */
+public final class RemoteServerFixture {
+
+    public static final String LOCK_ID = "lock-1";
+
+    public final AtomicInteger acquireRequests = new AtomicInteger();
+    public final AtomicInteger statusRequests = new AtomicInteger();
+    public final AtomicInteger releaseRequests = new AtomicInteger();
+    public final AtomicInteger heartbeatRequests = new AtomicInteger();
+    public final AtomicInteger resourcesRequests = new AtomicInteger();
+
+    public final AtomicReference<String> lastAcquireBody = new AtomicReference<>();
+    public final AtomicReference<String> lastAcquireRawBody = new AtomicReference<>();
+    public final AtomicReference<String> lastAuthorizationHeader = new AtomicReference<>();
+
+    private final AtomicInteger pausedAcquires = new AtomicInteger();
+    private int acquireResponseStatus = 202;
+    private String acquireResponseBody = "{\"lockId\":\"" + LOCK_ID + "\"}";
+
+    /** Polls still to be answered QUEUED before the lock is reported as acquired. */
+    private final AtomicInteger queuedPolls = new AtomicInteger();
+    /** Status polls still to be answered with {@link #statusFailureStatus}. */
+    private final AtomicInteger failingPolls = new AtomicInteger();
+
+    private int statusFailureStatus = 500;
+    private String statusFailureBody = "{\"errorCode\":\"BOOM\",\"message\":\"scripted failure\"}";
+    private String acquireStatusResponse = "{\"lockId\":\"" + LOCK_ID + "\",\"state\":\"ACQUIRED\"}";
+
+    private int heartbeatStatus = 204;
+    private String heartbeatBody = "";
+
+    private int resourcesStatus = 200;
+    private String resourcesBody = "{\"acceptNewAcquires\":true,\"resources\":[]}";
+
+    private HttpServer server;
+
+    // -----------------------------------------------------------------------
+    // Scripting
+    // -----------------------------------------------------------------------
+
+    public void setAcquireResponse(int status, String body) {
+        this.acquireResponseStatus = status;
+        this.acquireResponseBody = body;
+    }
+
+    /** Answers the next {@code n} acquire calls with the maintenance switch's 503. */
+    public void pauseNextAcquires(int n) {
+        pausedAcquires.set(n);
+    }
+
+    public void setAcquireStatusResponse(String response) {
+        this.acquireStatusResponse = response;
+    }
+
+    /**
+     * Reports QUEUED for the next {@code polls} status calls, then whatever the status response is
+     * set to - ACQUIRED unless a test says otherwise. This is the promotion path: a request that
+     * waits and then gets its resources.
+     */
+    public void queueFor(int polls) {
+        queuedPolls.set(polls);
+    }
+
+    /** Ends the request in a terminal state, the way a server reports a timeout or a skip. */
+    public void terminal(String state, String errorCode) {
+        this.acquireStatusResponse =
+                "{\"lockId\":\"" + LOCK_ID + "\",\"state\":\"" + state + "\",\"errorCode\":\"" + errorCode + "\"}";
+    }
+
+    /**
+     * Answers the next {@code n} status polls with an error, then goes back to normal. Used to walk
+     * up to - and over - the client's tolerance for consecutive poll failures.
+     */
+    public void failNextPolls(int n, int status, String body) {
+        failingPolls.set(n);
+        this.statusFailureStatus = status;
+        this.statusFailureBody = body;
+    }
+
+    /** Answers every status poll with an error, with no recovery. */
+    public void failAllPolls(int status, String body) {
+        failNextPolls(Integer.MAX_VALUE, status, body);
+    }
+
+    public void setHeartbeatResponse(int status, String body) {
+        this.heartbeatStatus = status;
+        this.heartbeatBody = body;
+    }
+
+    public void setResourcesResponse(int status, String body) {
+        this.resourcesStatus = status;
+        this.resourcesBody = body;
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    public void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/lockable-resources/remote/v1/acquire", new AcquireHandler());
+        server.createContext("/lockable-resources/remote/v1/acquire/" + LOCK_ID, new AcquireStatusHandler());
+        server.createContext("/lockable-resources/remote/v1/lease/" + LOCK_ID + "/release", new ReleaseHandler());
+        server.createContext("/lockable-resources/remote/v1/lease/" + LOCK_ID + "/heartbeat", new HeartbeatHandler());
+        server.createContext("/lockable-resources/remote/v1/resources", new ResourcesHandler());
+        server.start();
+    }
+
+    /**
+     * Starts again on the port this fixture was already using.
+     *
+     * <p>A restart test tears the controller down and brings it back, and the remote it resumes
+     * against has to still be at the address stored in its configuration - otherwise the test proves
+     * only that a client cannot reach a server that moved.
+     */
+    public void restartOnSamePort() throws IOException {
+        int port = server.getAddress().getPort();
+        server.stop(0);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+        server.createContext("/lockable-resources/remote/v1/acquire", new AcquireHandler());
+        server.createContext("/lockable-resources/remote/v1/acquire/" + LOCK_ID, new AcquireStatusHandler());
+        server.createContext("/lockable-resources/remote/v1/lease/" + LOCK_ID + "/release", new ReleaseHandler());
+        server.createContext("/lockable-resources/remote/v1/lease/" + LOCK_ID + "/heartbeat", new HeartbeatHandler());
+        server.createContext("/lockable-resources/remote/v1/resources", new ResourcesHandler());
+        server.start();
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    public String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    // -----------------------------------------------------------------------
+    // Handlers
+    // -----------------------------------------------------------------------
+
+    private final class AcquireHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            acquireRequests.incrementAndGet();
+            lastAuthorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            if (pausedAcquires.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+                sendJson(
+                        exchange,
+                        503,
+                        "{\"errorCode\":\"ACQUIRES_PAUSED\",\"message\":\"not accepting new acquires\"}");
+                return;
+            }
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            lastAcquireRawBody.set(body);
+            String resource = extractString(body, "resource");
+            lastAcquireBody.set(resource);
+            // Auto-generate lockEnvVars in the status response when a variable was asked for, so a
+            // test does not have to spell out what the server would have derived anyway.
+            String variable = extractString(body, "variable");
+            if (variable != null && resource != null && acquireStatusResponse.contains("\"state\":\"ACQUIRED\"")) {
+                acquireStatusResponse = "{\"lockId\":\"" + LOCK_ID + "\",\"state\":\"ACQUIRED\","
+                        + "\"lockEnvVars\":{"
+                        + "\"" + variable + "\":\"" + resource + "\","
+                        + "\"" + variable + "0\":\"" + resource + "\""
+                        + "}}";
+            }
+            sendJson(exchange, acquireResponseStatus, acquireResponseBody);
+        }
+    }
+
+    private final class AcquireStatusHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            statusRequests.incrementAndGet();
+            if (failingPolls.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+                sendJson(exchange, statusFailureStatus, statusFailureBody);
+                return;
+            }
+            if (queuedPolls.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+                sendJson(exchange, 200, "{\"lockId\":\"" + LOCK_ID + "\",\"state\":\"QUEUED\"}");
+                return;
+            }
+            sendJson(exchange, 200, acquireStatusResponse);
+        }
+    }
+
+    private final class ReleaseHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            releaseRequests.incrementAndGet();
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        }
+    }
+
+    private final class HeartbeatHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            heartbeatRequests.incrementAndGet();
+            if (heartbeatStatus == 204) {
+                exchange.sendResponseHeaders(204, -1);
+                exchange.close();
+                return;
+            }
+            sendJson(exchange, heartbeatStatus, heartbeatBody);
+        }
+    }
+
+    private final class ResourcesHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            resourcesRequests.incrementAndGet();
+            sendJson(exchange, resourcesStatus, resourcesBody);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Pulls a string field out of a request body. Enough for what the handlers need to echo back. */
+    private static String extractString(String json, String field) {
+        String marker = "\"" + field + "\":\"";
+        int start = json.indexOf(marker);
+        if (start < 0) {
+            return null;
+        }
+        int valueStart = start + marker.length();
+        int valueEnd = json.indexOf('"', valueStart);
+        return valueEnd >= 0 ? json.substring(valueStart, valueEnd) : null;
+    }
+
+    private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(bytes);
+        }
+    }
+}

--- a/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/casc_expected_output.yml
@@ -1,3 +1,4 @@
+acceptNewAcquires: true
 allowEmptyOrNullValues: true
 allowEphemeralResources: true
 declaredResources:

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code-remote.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code-remote.yml
@@ -18,6 +18,7 @@ unclassified:
       - serverId: "server-b"
         url: "https://jenkins-server-b.example.com/"
         credentialsId: "server-b-token"
+        enabled: false          # borrower-side switch; default is true
     # ── Resources (optional - may be defined separately) ─────────────────────
     declaredResources:
       - name: "plc-01"

--- a/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code-remote.yml
+++ b/src/test/resources/org/jenkins/plugins/lockableresources/configuration-as-code-remote.yml
@@ -7,6 +7,7 @@ unclassified:
     # ── Server-side (this Jenkins exposes resources) ──────────────────────────
     remoteApiEnabled: true
     exposeLabel: "remote-enabled"
+    acceptNewAcquires: false   # maintenance switch; default is true
     # ── Client-side (this Jenkins contacts remote servers) ────────────────────
     clientId: "jenkins-client-1"
     forcedServerId: ""


### PR DESCRIPTION
See #1025 (phase 1, M2 + M3). Follow-up to #1055.

### What does this PR do?

- [#1055](https://github.com/jenkinsci/lockable-resources-plugin/pull/1055) Code enhancements
  - Enhancements to features centered on the "Remote Lockable Resources" UI, which had not been fully implemented
  - Bug fixes related to [#1055](https://github.com/jenkinsci/lockable-resources-plugin/pull/1055)
  - No change to the transport or the phase-1 non-goals from [#1055](https://github.com/jenkinsci/lockable-resources-plugin/pull/1055): short-polling only, the `lock()` body always runs locally, fail-closed on communication failure, resources pre-declared on the remote.
- Changes
  - The lockable resources page learns about remote locks (C1-C4)
    - A **Remote** tab listing what this controller holds and waits for on other controllers, linked back to the build that asked. The tab appears only when a remote is configured.
    - In delegated mode, the target's published resources are listed beside the local ones, so a user can see what is available before writing the `lock()`. `Held By` distinguishes a remote client (named), a build local to that server, and an administrator's reservation.
    - A badge naming the server every `lock()` is routed to, and that the local resources listed underneath remain lockable by others - they are just no longer used to answer this controller's own calls.
    - A banner while new remote acquires are paused.
    - The catalogue is a cached client-side view, and says so: it keeps the last successful fetch, states how old it is, and states why when a refresh fails.
  - Operations (B3-B6)
    - **Maintenance switch.** New acquires get 503 `ACQUIRES_PAUSED` while everything already held keeps working - leases, heartbeats, releases, and requests already queued. Clients wait rather than fail, so a controller can be drained before it is taken down.
    - **Client-side disable.** Stop asking a remote for new locks without deleting its URL and credentials. Leases already held are unaffected; dropping them would strand the resource on the other side.
    - **`GET /resources`.** What this server exposes, so a client can discover names and labels instead of having them configured by hand on both sides. It deliberately omits the build name, the lock reason and the resource note.
    - **Audit trail.** An optional record at each point a resource changes hands (`org.jenkins.plugins.lockableresources.audit`, FINE, off by default).
  - Semantics (B1, B2)
    - `inversePrecedence` now reaches the remote queue; it was carried on the request and ignored.
    - Remote request validation delegates to the canonical validator instead of a second implementation, so the bridge and `lock()` refuse the same combinations.
  - Fixes (A1-A7)
    - All seven were introduced by [#1055](https://github.com/jenkinsci/lockable-resources-plugin/pull/1055) and are reachable only through the remote path - a local `lock()` cannot express the input that triggers them.
      | | |
      |---|---|
      | A1 | A resource held remotely reported no holder in the lock cause, so a waiting build could not tell who had it |
      | A2 | A released remote lock was forgotten immediately instead of at its terminal TTL, so a client polling a moment later saw a 404 |
      | A3 | A vanished lock record was reported as a timeout rather than as missing |
      | A4 | `lockEnvVars` were left unset when the server returned none, so the body ran without its variable |
      | A5 | The queue tab listed every remote entry behind every local one regardless of priority, disagreeing with the order in which they are actually promoted |
      | A6 | A queued remote request never scheduled its own wake-up, so its allocate timeout fired only when something else happened to sweep the queue |
      | A7 | The acquire endpoint coerced values it could not interpret into defaults - a non-numeric `quantity` became "all matching", an unknown `timeoutUnit` became "wait forever" |
    - A6 and A7 came out of extending the E2E suite; the other five out of reading the M2/M3 design against the code. A6 is the one to look at first: measured against a 60s deadline, the timeout fired 59s late before the fix and 0.2-0.4s late after it.
  - Documentation (D1, D2)
    - The README had no mention of remote locking at all, including the `RemoteUse` row missing from the permissions table. D2 corrects the REST reference against what the code actually does - `EXPIRED` is never returned, `STALE` was missing, `heartbeatIntervalSeconds` is validated and then ignored, and the error table predated B2.

### Testing done

Reference: [lockable-resources-remote-notes / docs/remote-lr-pull-1077](https://github.com/kohtaro-satoh/lockable-resources-remote-notes/tree/docs/remote-lr-pull-1077)

- **Unit:** `mvn verify` BUILD SUCCESS, 462 run / 0 failures / 1 skip, all gates clean. Remote-related
  coverage 78.7% line / 63.3% branch → **88.4% / 72.5%** (T1-T5; T1 turns the test remote server into
  a scriptable state machine - queued transitions, terminal states, 404/410, consecutive failures,
  restart on the same port - which is what makes the rest writable).
- **E2E:** 32/32 across function / data / time / scale axes, on a four-controller Docker harness.
- **Load:** two presets at 4×50 = 200 concurrent jobs. `stress` for contention and throughput;
  `timeout-race` puts the deadlines inside the window so the allocate-timeout path runs in bulk
  rather than a handful of times. Both: **0 mutual-exclusion violations, 0 hung builds**, every
  failure a clean `LOCK_WAIT_TIMEOUT`.

Mutual exclusion in the load runs is judged from the servers' own audit trail, not from what the
clients believed they held: a build logs its acquisition after taking the lock and its release
before giving it up, so its interval lies inside the true one and it can miss a real overlap. The
reports carry both counts and say which one the verdict came from.

The UI changes are listed with screenshots in a comment below.

### Checklist

- [x] Automated tests added or existing tests cover the change
- [x] PR title is a clear, imperative-mood changelog entry
- [x] Breaking changes or upgrade steps are documented below

### Upgrade guidelines

N/A. Everything added here is reachable only with a remote configured; the remote REST API remains
disabled by default. The audit logger is off unless its level is raised.