### PR TITLE
Emit non-indexed property env var for first locked resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,17 @@ lock(resource: 'staging-server', priority: 10) {
 ```groovy
 lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
   echo env.LOCKED_RESOURCE
+  // properties of the first acquired resource are available both without an index ...
+  echo env.LOCKED_RESOURCE_PROP_ABC
+  // ... and with the numeric index (0 == first acquired resource)
   echo env.LOCKED_RESOURCE0_PROP_ABC
 }
 ```
+
+The properties of the first acquired resource are exposed both with the `0` index
+(`LOCKED_RESOURCE0_PROP_ABC`) and without it (`LOCKED_RESOURCE_PROP_ABC`). The un-indexed form is a
+convenience alias for the first acquired resource and is always present, even when multiple resources
+are locked.
 
 When multiple locks are acquired, each will be assigned to a numbered variable:
 
@@ -181,6 +189,8 @@ lock(label: 'some_resource', variable: 'LOCKED_RESOURCE', quantity: 2) {
   // first lock
   echo env.LOCKED_RESOURCE0
   echo env.LOCKED_RESOURCE0_PROP_ABC
+  // the un-indexed alias always refers to the first lock's properties
+  echo env.LOCKED_RESOURCE_PROP_ABC
 
   // second lock
   echo env.LOCKED_RESOURCE1

--- a/src/doc/examples/resource-properties.md
+++ b/src/doc/examples/resource-properties.md
@@ -32,10 +32,16 @@ parameter is specified** in the `lock()` step.
 | Variable | Value |
 |----------|-------|
 | `{variable}` | Comma-separated list of all locked resource names |
+| `{variable}_{PROPERTY_NAME}` | Value of the **first** locked resource's property — un-indexed convenience alias, always present |
 | `{variable}0` | Name of the first locked resource |
 | `{variable}0_{PROPERTY_NAME}` | Value of that resource's property |
 | `{variable}1` | Name of the second locked resource (if any) |
 | `{variable}1_{PROPERTY_NAME}` | Value of the second resource's property |
+
+The properties of the first acquired resource are exposed both with the `0` index
+(`{variable}0_{PROPERTY_NAME}`) and without it (`{variable}_{PROPERTY_NAME}`). The un-indexed form
+is a convenience alias for the first acquired resource and is always present, even when multiple
+resources are locked.
 
 ### Example: Read properties after locking by name
 
@@ -51,6 +57,9 @@ pipeline {
         echo "Resource: ${env.LOCKED0}"          // staging-server
         echo "Host: ${env.LOCKED0_HOST}"         // 192.168.1.10
         echo "Port: ${env.LOCKED0_PORT}"         // 8080
+        // un-indexed aliases — same values, refer to the first locked resource
+        echo "Host: ${env.LOCKED_HOST}"          // 192.168.1.10
+        echo "Port: ${env.LOCKED_PORT}"          // 8080
       }
     }
   }
@@ -70,6 +79,7 @@ pipeline {
       steps {
         echo "Got: ${env.GPU0}"
         echo "GPU model: ${env.GPU0_MODEL}"
+        echo "GPU model: ${env.GPU_MODEL}"   // un-indexed alias, same value
       }
     }
   }

--- a/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/LockStepExecution.java
@@ -305,7 +305,9 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Remo
      * Builds the {@code lockEnvVars} map injected for the duration of a {@code lock()} block, following
      * local semantics exactly: {@code variable="X"} with locked resources {@code r1, r2} yields
      * {@code X="r1,r2"}, {@code X0="r1"}, {@code X0_<prop>=<value>}, {@code X1="r2"}, ... Property env vars
-     * are included. Returns {@code null} when {@code variable} is null/empty.
+     * are included. The first (index {@code 0}) resource's properties are additionally exposed without the
+     * numeric index ({@code X_<prop>=<value>}) for the common single-resource lock (JENKINS-75943).
+     * Returns {@code null} when {@code variable} is null/empty.
      *
      * <p>Shared by the local flow ({@link #proceed}) and the remote bridge so the two never drift. All
      * inputs (resource names and property name/value strings) are serializable, so the remote server can
@@ -326,6 +328,11 @@ public class LockStepExecution extends AbstractStepExecutionImpl implements Remo
             variables.put(lockEnvName, lockResourceEntry.getKey());
             for (LockableResourceProperty lockProperty : lockResourceEntry.getValue()) {
                 variables.put(lockEnvName + "_" + lockProperty.getName(), lockProperty.getValue());
+                if (index == 0) {
+                    // JENKINS-75943: also expose the first resource's properties without the numeric
+                    // index, so ${variable}_<prop> resolves for the common single-resource lock.
+                    variables.put(variable + "_" + lockProperty.getName(), lockProperty.getValue());
+                }
             }
             ++index;
         }

--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockRunListener.java
@@ -87,6 +87,13 @@ public class LockRunListener extends RunListener<Run<?, ?>> {
                                 for (LockableResourceProperty lockProperty : lr.getProperties()) {
                                     String propEnvName = lockEnvName + "_" + lockProperty.getName();
                                     envsToSet.add(new StringParameterValue(propEnvName, lockProperty.getValue()));
+                                    if (index == 0) {
+                                        // JENKINS-75943: also expose the first resource's properties without
+                                        // the numeric index for the common single-resource lock.
+                                        envsToSet.add(new StringParameterValue(
+                                                resources.requiredVar + "_" + lockProperty.getName(),
+                                                lockProperty.getValue()));
+                                    }
                                 }
                                 ++index;
                             }

--- a/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/FreeStyleProjectTest.java
@@ -218,6 +218,36 @@ class FreeStyleProjectTest {
     }
 
     @Test
+    @Issue("JENKINS-75943")
+    void nonIndexedPropertyEnvVarForFirstResource(JenkinsRule j) throws Exception {
+        LockableResourcesManager.get().createResource("res-with-prop");
+        LockableResource r = LockableResourcesManager.get().fromName("res-with-prop");
+        LockableResourceProperty prop = new LockableResourceProperty();
+        prop.setName("PROP_ABC");
+        prop.setValue("the-value");
+        r.setProperties(List.of(prop));
+
+        FreeStyleProject p = j.createFreeStyleProject("freestyleProp");
+        p.addProperty(new RequiredResourcesProperty("res-with-prop", "LOCKED_RESOURCE", null, null, null));
+        p.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                listener.getLogger()
+                        .println("indexed=" + build.getEnvironment(listener).get("LOCKED_RESOURCE0_PROP_ABC"));
+                listener.getLogger()
+                        .println("nonIndexed=" + build.getEnvironment(listener).get("LOCKED_RESOURCE_PROP_ABC"));
+                return true;
+            }
+        });
+
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.SUCCESS, b);
+        j.assertLogContains("indexed=the-value", b); // existing behaviour intact
+        j.assertLogContains("nonIndexed=the-value", b); // JENKINS-75943
+    }
+
+    @Test
     void migrateToScript(JenkinsRule j) throws Exception {
         LockableResourcesManager.get().createResource("resource1");
 

--- a/src/test/java/org/jenkins/plugins/lockableresources/LockStepExecutionEnvVarsTest.java
+++ b/src/test/java/org/jenkins/plugins/lockableresources/LockStepExecutionEnvVarsTest.java
@@ -33,8 +33,36 @@ class LockStepExecutionEnvVarsTest {
         assertEquals("plc-a,plc-b", env.get("PLC"));
         assertEquals("plc-a", env.get("PLC0"));
         assertEquals("10.0.0.11", env.get("PLC0_ip"));
+        // JENKINS-75943: the un-indexed alias must resolve to the FIRST resource's property value
+        assertEquals("10.0.0.11", env.get("PLC_ip"));
         assertEquals("plc-b", env.get("PLC1"));
         assertEquals("10.0.0.12", env.get("PLC1_ip"));
+    }
+
+    @Test
+    void buildLockEnvVarsExposesFirstResourcePropertiesWithoutIndex() {
+        LockableResourceProperty ip = new LockableResourceProperty();
+        ip.setName("ip");
+        ip.setValue("10.0.0.11");
+
+        LockableResourceProperty port = new LockableResourceProperty();
+        port.setName("port");
+        port.setValue("8080");
+
+        LinkedHashMap<String, List<LockableResourceProperty>> lockedResources = new LinkedHashMap<>();
+        lockedResources.put("plc-a", List.of(ip, port));
+
+        Map<String, String> env = LockStepExecution.buildLockEnvVars("PLC", lockedResources);
+
+        // existing indexed vars are unchanged
+        assertEquals("plc-a", env.get("PLC"));
+        assertEquals("plc-a", env.get("PLC0"));
+        assertEquals("10.0.0.11", env.get("PLC0_ip"));
+        assertEquals("8080", env.get("PLC0_port"));
+
+        // JENKINS-75943: same property values are additionally exposed without the numeric index
+        assertEquals("10.0.0.11", env.get("PLC_ip"));
+        assertEquals("8080", env.get("PLC_port"));
     }
 
     @Test


### PR DESCRIPTION
### Problem

When locking a resource with `lock(label: ..., variable: 'LOCKED_RESOURCE')`, the
README documents that a non-indexed property env var (`LOCKED_RESOURCE_PROP_ABC`)
should be available. In practice, only the indexed form (`LOCKED_RESOURCE0_PROP_ABC`)
was ever emitted — the non-indexed property variable was missing entirely, even for
the common single-resource lock case.

This affected both Pipeline (`lock()` step) and Freestyle builds, since the env var
generation logic is duplicated across `LockStepExecution.buildLockEnvVars()` and
`LockRunListener.onStarted()`.

Fixes #526

### Changes

- `LockStepExecution.buildLockEnvVars()`: when building env vars for the first
  (index `0`) locked resource, additionally emit the non-indexed property var
  (`<variable>_<prop>`) alongside the existing indexed one.
- `LockRunListener.onStarted()`: same fix applied to the Freestyle/`AbstractBuild`
  code path, so behavior is consistent between Pipeline and Freestyle.
- `README.md`: documented the non-indexed alias in both the single- and
  multi-resource lock examples.
- Tests: added/extended coverage in `LockStepExecutionEnvVarsTest` (Pipeline) and
  `FreeStyleProjectTest` (Freestyle) to assert both the indexed and non-indexed
  forms are present with correct values.

### Design notes

This is intentionally **additive, not breaking** — all existing indexed variables
(`LOCKED_RESOURCE0`, `LOCKED_RESOURCE0_PROP_ABC`, `LOCKED_RESOURCE1`, ...) are
unchanged. When multiple resources are locked, the non-indexed property var is
bound to the **first** resource, consistent with how the existing non-indexed
`LOCKED_RESOURCE` (CSV of names) variable already behaves.

This approach follows the non-breaking compromise discussed by the reporter and
maintainer on the issue thread.

### How to test

```groovy
lock(label: 'some_resource', variable: 'LOCKED_RESOURCE') {
    echo env.LOCKED_RESOURCE_PROP_ABC   // now populated (previously empty)
    echo env.LOCKED_RESOURCE0_PROP_ABC  // unchanged, still populated
}
```

Or run:
```
mvn test -Dtest=LockStepExecutionEnvVarsTest,FreeStyleProjectTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KP9Eh2FVMDXiiLANSHnJG