### PR TITLE
Document early unlock via LockableResourcesManager #164

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,17 @@ lock(
 echo 'Finish'
 ```
 
+#### Release a lock early
+
+The `lock` step keeps the resource until the block ends. To release it
+sooner (for example after one `parallel` branch fails, without
+`failFast`), call `LockableResourcesManager` from scripted Pipeline or
+the Script Console. See [Unlock a resource via LockableResourcesManager](src/doc/examples/unlock-via-lrm.md).
+
+> **Risk:** another job can take the resource while this build is still
+> running. Remaining branches that still need exclusive access will race
+> with that job.
+
 More examples are [here](src/doc/examples/readme.md).
 
 ----

--- a/src/doc/examples/readme.md
+++ b/src/doc/examples/readme.md
@@ -17,3 +17,4 @@ If you have a question, please open a [GitHub issue](https://github.com/jenkinsc
 - [Lock with allocation timeout](lock-with-timeout.md)
 - [Remote Lock REST API (curl examples)](remote-api-curl.md)
 - [Remote lock from Jenkins Pipeline (local gate + remote lock)](remote-lock-pipeline-pattern.md)
+- [Unlock a resource via LockableResourcesManager](unlock-via-lrm.md)

--- a/src/doc/examples/unlock-via-lrm.md
+++ b/src/doc/examples/unlock-via-lrm.md
@@ -1,0 +1,77 @@
+# Unlock a resource via LockableResourcesManager
+
+The `lock` step holds a resource until its block finishes. Sometimes you need
+to release it sooner — for example when one `parallel` branch fails and you
+do not want `failFast` to abort the others, but you also do not want to keep
+the lock until those branches complete.
+
+Call `LockableResourcesManager` directly. This is a scripted-pipeline /
+Script Console API, not a Pipeline step.
+
+> **Risk:** after an early unlock, another build can acquire the same
+> resource while *this* build is still running. Any remaining parallel
+> branch that still uses the resource is then racing with that other
+> build. Only do this when the remaining work no longer needs exclusive
+> access. Unlocking twice is safe: when the `lock` block later ends, the
+> step calls `unlockNames` again and skips resources this build no longer
+> holds.
+
+## Scripted pipeline
+
+```groovy
+import org.jenkins.plugins.lockableresources.LockableResourcesManager
+
+lock(resource: 'mylock', variable: 'LOCKED') {
+  parallel(
+    foo: {
+      // stuff_for_foo
+    },
+    bar: {
+      try {
+        // stuff_for_bar
+      } catch (err) {
+        def names = env.LOCKED.split(',').collect { it.trim() }.findAll { it }
+        LockableResourcesManager.get().unlockNames(names, currentBuild.rawBuild)
+        throw err
+      }
+    },
+    failFast: false
+  )
+}
+```
+
+`unlockNames` takes the resource names and the `Run` that currently holds
+them (`currentBuild.rawBuild` in a Pipeline). You can also pass the
+`LockableResource` objects:
+
+```groovy
+def lrm = LockableResourcesManager.get()
+def lr = lrm.fromName('mylock')
+if (lr != null && lr.isLocked()) {
+  lrm.unlockResources([lr], lr.getBuild())
+}
+```
+
+`lrm.unlockResources([lr])` (one argument) uses the first resource's
+build for every name in the list.
+
+## Script Console
+
+From *Manage Jenkins* → *Script Console* (or a Groovy Postbuild / shared
+library), the same manager unlocks a stuck resource:
+
+```groovy
+def lrm = org.jenkins.plugins.lockableresources.LockableResourcesManager.get()
+def lr = lrm.fromName('mylock')
+if (lr == null) {
+  println 'no such resource'
+} else if (!lr.isLocked()) {
+  println 'already free'
+} else {
+  lrm.unlockResources([lr], lr.getBuild())
+  println "unlocked ${lr.name}"
+}
+```
+
+Prefer the Lockable Resources UI **Unlock** action when you are not
+inside a running Pipeline. The API above is the programmatic equivalent.


### PR DESCRIPTION
Fixes #164

The lock step keeps the resource until the block ends. I added an example for calling LockableResourcesManager.unlockNames / unlockResources from scripted pipeline or the Script Console so a parallel branch can drop the lock without failFast.

There is a risk note: another job can take the resource while this build is still running.

### Testing done
Docs only.

### Checklist
- [ ] Automated tests added or existing tests cover the change
- [x] PR title is a clear, imperative-mood changelog entry
- [ ] Breaking changes or upgrade steps are documented below

### Upgrade guidelines

N/A
